### PR TITLE
Allow alt+tab etc while drag'n'drop is active

### DIFF
--- a/src/core/display.c
+++ b/src/core/display.c
@@ -3464,7 +3464,7 @@ meta_display_begin_grab_op (MetaDisplay *display,
   meta_display_set_grab_op_cursor (display, screen, op, FALSE, grab_xwindow,
                                    timestamp);
 
-  if (!display->grab_have_pointer)
+  if (!display->grab_have_pointer && !grab_op_is_keyboard (op))
     {
       meta_topic (META_DEBUG_WINDOW_OPS,
                   "XGrabPointer() failed\n");


### PR DESCRIPTION
This is still not fixed "upstream" (i.e. in metacity) but many distributions
ship with this patch. The patch is from Matthias Clasen (Redhat).
See https://bugzilla.gnome.org/show_bug.cgi?id=135056#c33 and
https://bugs.launchpad.net/ubuntu/+source/metacity/+bug/111939
for details.

I missed this feature since i changed from ubuntu's gnome 2 to mate,
so i googled the cause... and well, here it is. I have NOT TESTED this though!
