### PR TITLE
constraints: don't apply fullscreen workarounds for CSD windows

### DIFF
--- a/src/core/constraints.c
+++ b/src/core/constraints.c
@@ -423,9 +423,15 @@ setup_constraint_info (ConstraintInfo      *info,
                                           xinerama_info->number);
 
   /* Workaround braindead legacy apps that don't know how to
-   * fullscreen themselves properly.
+   * fullscreen themselves properly - don't get fooled by
+   * windows which hide their titlebar when maximized or which are
+   * client decorated; that's not the same as fullscreen, even
+   * if there are no struts making the workarea smaller than
+   * the monitor.
    */
+
   if (meta_prefs_get_force_fullscreen() &&
+      window->decorated &&
       meta_rectangle_equal (new, &xinerama_info->rect) &&
       window->has_fullscreen_func &&
       !window->fullscreen)


### PR DESCRIPTION
If you maximize a CSD window on a monitor without struts, it ends up
taking the whole monitor size, but it doesn't mean that the application
wants to fullscreen.

Fixes Marco issue  #78.
Gnome Bug:
https://bugzilla.gnome.org/show_bug.cgi?id=708718
Gnome Commit:
https://git.gnome.org/browse/mutter/commit/src/core/constraints.c?id=4eeeb1557a3a0caff6ef1debd92aeb541ae1b556
