### PR TITLE
fix core/main.c wait.h on nonlinux

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -58,11 +58,7 @@
 
 #include <stdlib.h>
 #include <sys/types.h>
-#ifdef __linux__
-#include <wait.h>
-#else
 #include <sys/wait.h>
-#endif
 #include <stdio.h>
 #include <string.h>
 #include <signal.h>


### PR DESCRIPTION
On FreeBSD there is no wait.h, but sys/wait.h. And I think it is also on other non-Linux platforms (I know about Solaris).
