### PR TITLE
Possible keybinding to switch to previous workspace.

### DIFF
--- a/src/50-marco-global-key.xml.in
+++ b/src/50-marco-global-key.xml.in
@@ -127,5 +127,12 @@
 	schema="org.mate.Marco.general"
 	comparison="gt" />
 
+	<KeyListEntry name="switch-to-workspace-prev"
+	_description="Switch to previously selected workspace"
+	value="1"
+	key="num-workspaces"
+	schema="org.mate.Marco.general"
+	comparison="gt" />
+
 </KeyListEntries>
 

--- a/src/core/keybindings.c
+++ b/src/core/keybindings.c
@@ -2242,6 +2242,14 @@ handle_switch_to_workspace (MetaDisplay    *display,
 {
   gint which = binding->handler->data;
   MetaWorkspace *workspace;
+
+  if (which == META_MOTION_PREV)
+    {
+      workspace = screen->prev_workspace;
+      if (workspace)
+          meta_workspace_activate (workspace, event->xkey.time);
+      return;
+    }
   
   if (which < 0)
     {

--- a/src/core/screen-private.h
+++ b/src/core/screen-private.h
@@ -85,6 +85,9 @@ struct _MetaScreen
   
   MetaWorkspace *active_workspace;
 
+  /* Previous active workspace */
+  MetaWorkspace *prev_workspace;
+
   /* This window holds the focus when we don't want to focus
    * any actual clients
    */

--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -385,6 +385,9 @@ meta_workspace_activate_with_focus (MetaWorkspace *workspace,
   /* Note that old can be NULL; e.g. when starting up */
   old = workspace->screen->active_workspace;
   
+  /* Save old workspace, to be able to switch back. */
+  workspace->screen->prev_workspace = old;
+
   workspace->screen->active_workspace = workspace;
 
   set_active_space_hint (workspace->screen);

--- a/src/core/workspace.h
+++ b/src/core/workspace.h
@@ -43,7 +43,8 @@ typedef enum
   META_MOTION_UP = -1,
   META_MOTION_DOWN = -2,
   META_MOTION_LEFT = -3,
-  META_MOTION_RIGHT = -4
+  META_MOTION_RIGHT = -4,
+  META_MOTION_PREV = -5
 } MetaMotionDirection;
 
 struct _MetaWorkspace

--- a/src/include/all-keybindings.h
+++ b/src/include/all-keybindings.h
@@ -111,6 +111,9 @@ keybind (switch-to-workspace-up, handle_switch_to_workspace,
 keybind (switch-to-workspace-down, handle_switch_to_workspace,
          META_MOTION_DOWN, 0)
 
+keybind (switch-to-workspace-prev, handle_switch_to_workspace,
+         META_MOTION_PREV, 0)
+
 /***********************************/
 
 /* The ones which have inverses.  These can't be bound to any keystroke

--- a/src/marco.convert
+++ b/src/marco.convert
@@ -71,6 +71,7 @@ switch-to-workspace-left = /apps/marco/global_keybindings/switch_to_workspace_le
 switch-to-workspace-right = /apps/marco/global_keybindings/switch_to_workspace_right
 switch-to-workspace-up = /apps/marco/global_keybindings/switch_to_workspace_up
 switch-to-workspace-down = /apps/marco/global_keybindings/switch_to_workspace_down
+switch-to-workspace-prev = /apps/marco/global_keybindings/switch_to_workspace_prev
 switch-group = /apps/marco/global_keybindings/switch_group
 switch-group-backward = /apps/marco/global_keybindings/switch_group_backward
 switch-windows = /apps/marco/global_keybindings/switch_windows

--- a/src/org.mate.marco.gschema.xml
+++ b/src/org.mate.marco.gschema.xml
@@ -497,6 +497,11 @@
       <summary>Switch to workspace below the current workspace</summary>
       <description>The format looks like "&lt;Control&gt;a" or "&lt;Shift&gt;&lt;Alt&gt;F1". The parser is fairly liberal and allows lower or upper case, and also abbreviations such as "&lt;Ctl&gt;" and "&lt;Ctrl&gt;". If you set the option to the special string "disabled", then there will be no keybinding for this action.</description>
     </key>
+    <key name="switch-to-workspace-prev" type="s">
+      <default>'disabled'</default>
+      <summary>Switch to previously selected workspace</summary>
+      <description>The format looks like "&lt;Control&gt;a" or "&lt;Shift&gt;&lt;Alt&gt;F1". The parser is fairly liberal and allows lower or upper case, and also abbreviations such as "&lt;Ctl&gt;" and "&lt;Ctrl&gt;". If you set the option to the special string "disabled", then there will be no keybinding for this action.</description>
+    </key>
     <key name="switch-group" type="s">
       <default>'disabled'</default>
       <summary>Move between windows of an application, using a popup window</summary>


### PR DESCRIPTION
This is implementation of new keybinding handler. It allows to switch to previously selected workspece. It is very useful for example for fast switching between two workspaces.
