### PR TITLE
Possible fix for disappearing panels and windows

### DIFF
--- a/src/compositor/compositor-xrender.c
+++ b/src/compositor/compositor-xrender.c
@@ -1821,6 +1821,10 @@ add_win (MetaScreen *screen,
 
   if (xwindow == info->output)
     return;
+    
+  /* If already added, ignore */
+  if (find_window_for_screen (screen, xwindow) != NULL)
+    return;
 
   cw = g_new0 (MetaCompWindow, 1);
   cw->screen = screen;


### PR DESCRIPTION
This is a possible fix for issue #45, where  the panels and windows are disappearing when the default compositor is activated. I don't know if this is enough for all cases, but at least works for Libreoffice's Writer font color window.
If this is not enough, I can at least report my findings so somebody can help. 
It seems some windows exhibit strange behavior with the compositor. On some actions these windows trigger several ConfigureNotify events (don't know why), and these call restack_win. This function manipulates the windows stack positions, and seems it was pulling the root window above the panels. I noted that the misbehaving window was being added twice, one of the times above the panels, so this commit fixes that. 
It's also interesting that add_win adds all windows at the top of the stack (prepend), above all top windows, including the panels. It says in a comment that it does this so map_win easily finds the added window, but this function doesn't touch the stack, using instead a hashmap to find the window.
I assume the windows are restacked somewhere, because it seems to be working (maybe a sequence of X events does this?).
