### PR TITLE
Repaint area of deleted shadowed windows (fixes #27)

### DIFF
--- a/src/compositor/compositor-xrender.c
+++ b/src/compositor/compositor-xrender.c
@@ -1544,6 +1544,25 @@ free_win (MetaCompWindow *cw,
   MetaDisplay *display = meta_screen_get_display (cw->screen);
   Display *xdisplay = meta_display_get_xdisplay (display);
   MetaCompScreen *info = meta_screen_get_compositor_data (cw->screen);
+  XRectangle r;
+  XserverRegion region;
+
+  /*
+   * If we are deleting a window with a compositor shadow,
+   * trigger a repaint of the area it was covering.
+   * This fixes an issue where the shadow beneath a
+   * (GTK3) tooltip was not being erased after the tooltip
+   * disappeared.
+   */
+  if (cw->shadow) {
+          r.x = cw->attrs.x + cw->shadow_dx;
+          r.y = cw->attrs.y + cw->shadow_dy;
+          r.width = cw->attrs.width + cw->shadow_width;
+          r.height = cw->attrs.height + cw->shadow_height;
+          region = XFixesCreateRegion (xdisplay, &r, 1);
+          add_damage(cw->screen, region);
+  }
+  
 
 #ifdef HAVE_NAME_WINDOW_PIXMAP
   if (have_name_window_pixmap (display))


### PR DESCRIPTION
Hi, this is a fix for the bug where the network manager applet tooltip's shadow didn't disappear after the tooltip disappear.

The bug also happened for pretty much any tooltip from any GTK3 application, e.g. brasero

The fix code is checking if a window with a shadow has just been deleted, and if so, it is repainting the area of the screen that was occupied by the window.

Best regards :)

