### PR TITLE
Remove all trailing whitespaces in the code tree

### DIFF
--- a/src/compositor/compositor-xrender.c
+++ b/src/compositor/compositor-xrender.c
@@ -1821,7 +1821,7 @@ add_win (MetaScreen *screen,
 
   if (xwindow == info->output)
     return;
-    
+
   /* If already added, ignore */
   if (find_window_for_screen (screen, xwindow) != NULL)
     return;

--- a/src/compositor/compositor-xrender.h
+++ b/src/compositor/compositor-xrender.h
@@ -1,10 +1,10 @@
 /* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
 
-/* 
+/*
  * Copyright (C) 2007 Iain Holmes
  * Based on xcompmgr - (c) 2003 Keith Packard
  *          xfwm4    - (c) 2005-2007 Olivier Fourdan
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -114,7 +114,7 @@ meta_compositor_get_window_pixmap (MetaCompositor *compositor,
 #ifdef HAVE_COMPOSITE_EXTENSIONS
   if (compositor && compositor->get_window_pixmap)
     return compositor->get_window_pixmap (compositor, window);
-  else 
+  else
     return None;
 #else
   return None;
@@ -127,7 +127,7 @@ meta_compositor_set_active_window (MetaCompositor *compositor,
                                    MetaWindow     *window)
 {
 #ifdef HAVE_COMPOSITE_EXTENSIONS
-  if (compositor && compositor->set_active_window) 
+  if (compositor && compositor->set_active_window)
     compositor->set_active_window (compositor, screen, window);
 #endif
 }
@@ -136,14 +136,14 @@ meta_compositor_set_active_window (MetaCompositor *compositor,
 void meta_compositor_begin_move (MetaCompositor *compositor,
                                  MetaWindow     *window,
                                  MetaRectangle  *initial,
-                                 int             grab_x, 
+                                 int             grab_x,
                                  int             grab_y)
 {
 }
 
 void meta_compositor_update_move (MetaCompositor *compositor,
                                   MetaWindow     *window,
-                                  int             x, 
+                                  int             x,
                                   int             y)
 {
 }

--- a/src/core/async-getprop.c
+++ b/src/core/async-getprop.c
@@ -55,7 +55,7 @@ struct _ListNode
 struct _AgGetPropertyTask
 {
   ListNode node;
-  
+
   AgPerDisplayData *dd;
   Window window;
   Atom property;
@@ -77,7 +77,7 @@ struct _AgPerDisplayData
 {
   ListNode node;
   _XAsyncHandler async;
-  
+
   Display *display;
   ListNode *pending_tasks;
   ListNode *pending_tasks_tail;
@@ -96,7 +96,7 @@ append_to_list (ListNode **head,
                 ListNode  *task)
 {
   task->next = NULL;
-  
+
   if (*tail == NULL)
     {
       assert (*head == NULL);
@@ -131,10 +131,10 @@ remove_from_list (ListNode **head,
 
           if (node == *tail)
             *tail = prev;
-          
+
           break;
         }
-      
+
       prev = node;
       node = node->next;
     }
@@ -152,7 +152,7 @@ move_to_completed (AgPerDisplayData  *dd,
   remove_from_list (&dd->pending_tasks,
                     &dd->pending_tasks_tail,
                     &task->node);
-  
+
   append_to_list (&dd->completed_tasks,
                   &dd->completed_tasks_tail,
                   &task->node);
@@ -187,18 +187,18 @@ find_pending_by_request_sequence (AgPerDisplayData *dd,
    * I'm not sure this is 100% guaranteed, if it is,
    * it would be a big speedup.
    */
-  
+
   node = dd->pending_tasks;
   while (node != NULL)
     {
       AgGetPropertyTask *task = (AgGetPropertyTask*) node;
-      
+
       if (task->request_seq == request_seq)
         return task;
-      
+
       node = node->next;
     }
-  
+
   return NULL;
 }
 
@@ -216,12 +216,12 @@ async_get_property_handler (Display *dpy,
   int bytes_read;
 
   dd = (AgPerDisplayData*) data;
-  
+
 #if 0
   printf ("%s: seeing request seq %ld buflen %d\n", __FUNCTION__,
           dpy->last_request_read, len);
 #endif
-  
+
   task = find_pending_by_request_sequence (dd, dpy->last_request_read);
 
   if (task == NULL)
@@ -231,7 +231,7 @@ async_get_property_handler (Display *dpy,
 
   task->have_reply = True;
   move_to_completed (dd, task);
-  
+
   /* read bytes so far */
   bytes_read = SIZEOF (xReply);
 
@@ -240,7 +240,7 @@ async_get_property_handler (Display *dpy,
       xError errbuf;
 
       task->error = rep->error.errorCode;
-      
+
 #ifdef DEBUG_SPEW
       printf ("%s: error code = %d (ignoring error, eating %d bytes, generic.length = %ld)\n",
               __FUNCTION__, task->error, (SIZEOF (xError) - bytes_read),
@@ -263,7 +263,7 @@ async_get_property_handler (Display *dpy,
       _XGetAsyncReply (dpy, (char *)&errbuf, rep, buf, len,
                        (SIZEOF (xError) - bytes_read) >> 2, /* in 32-bit words */
                        False); /* really seems like it should be True */
-      
+
       return True;
     }
 
@@ -368,7 +368,7 @@ async_get_property_handler (Display *dpy,
                   char *netdata;
                   char *lptr;
                   char *end_lptr;
-                  
+
                   /* Store the 32-bit values in the end of the array */
                   netdata = task->data + nbytes / 2;
 
@@ -377,7 +377,7 @@ async_get_property_handler (Display *dpy,
                                   netbytes);
 
                   /* Now move the 32-bit values to the front */
-                  
+
                   lptr = task->data;
                   end_lptr = task->data + nbytes;
                   while (lptr != end_lptr)
@@ -411,7 +411,7 @@ async_get_property_handler (Display *dpy,
 #if 0
             xError error;
 #endif
-            
+
             task->error = BadImplementation;
 
 #if 0
@@ -468,21 +468,21 @@ get_display_data (Display *display,
 {
   ListNode *node;
   AgPerDisplayData *dd;
-  
+
   node = display_datas;
   while (node != NULL)
     {
       dd = (AgPerDisplayData*) node;
-      
+
       if (dd->display == display)
         return dd;
-      
+
       node = node->next;
     }
 
   if (!create)
     return NULL;
-  
+
   dd = Xcalloc (1, sizeof (AgPerDisplayData));
   if (dd == NULL)
     return NULL;
@@ -496,7 +496,7 @@ get_display_data (Display *display,
   append_to_list (&display_datas,
                   &display_datas_tail,
                   &dd->node);
-  
+
   return dd;
 }
 
@@ -524,8 +524,8 @@ ag_task_create (Display *dpy,
 {
   AgGetPropertyTask *task;
   xGetPropertyReq *req;
-  AgPerDisplayData *dd;  
-  
+  AgPerDisplayData *dd;
+
   /* Fire up our request */
   LockDisplay (dpy);
 
@@ -535,7 +535,7 @@ ag_task_create (Display *dpy,
       UnlockDisplay (dpy);
       return NULL;
     }
-  
+
   GetReq (GetProperty, req);
   req->window = window;
   req->property = property;
@@ -561,7 +561,7 @@ ag_task_create (Display *dpy,
                   &dd->pending_tasks_tail,
                   &task->node);
   dd->n_tasks_pending += 1;
-  
+
   UnlockDisplay (dpy);
 
   SyncHandle ();
@@ -593,13 +593,13 @@ ag_task_get_reply_and_free (AgGetPropertyTask  *task,
   *prop = NULL;
 
   dpy = task->dd->display; /* Xlib macros require a variable named "dpy" */
-  
+
   if (task->error != Success)
     {
       Status s = task->error;
 
       free_task (task);
-      
+
       return s;
     }
 
@@ -620,7 +620,7 @@ ag_task_get_reply_and_free (AgGetPropertyTask  *task,
   SyncHandle ();
 
   free_task (task);
-  
+
   return Success;
 }
 
@@ -657,7 +657,7 @@ ag_get_next_completed_task (Display *display)
 
   if (dd == NULL)
     return NULL;
-  
+
 #ifdef DEBUG_SPEW
   printf ("%d pending %d completed\n",
           dd->n_tasks_pending,

--- a/src/core/async-getprop.h
+++ b/src/core/async-getprop.h
@@ -4,16 +4,16 @@
 
 /*
  * Copyright (C) 2002 Havoc Pennington
- * 
+ *
  * Permission to use, copy, modify, distribute, and sell this software
  * and its documentation for any purpose is hereby granted without
  * fee, provided that the above copyright notice appear in all copies
  * and that both that copyright notice and this permission notice
  * appear in supporting documentation.
- * 
+ *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND

--- a/src/core/atomnames.h
+++ b/src/core/atomnames.h
@@ -1,12 +1,12 @@
 /* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2002, 2003, 2004 Red Hat, Inc.
  * Copyright (C) 2003, 2004 Rob Adams
  * Copyright (C) 2004-2006 Elijah Newren
  * Copyright (C) 2008 Thomas Thurman
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -16,7 +16,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -54,7 +54,7 @@ item(WM_WINDOW_ROLE)
 item(UTF8_STRING)
 item(WM_ICON_SIZE)
 item(_KWM_WIN_ICON)
-item(_MARCO_RESTART_MESSAGE)    
+item(_MARCO_RESTART_MESSAGE)
 item(_MARCO_RELOAD_THEME_MESSAGE)
 item(_MARCO_SET_KEYBINDINGS_MESSAGE)
 item(_MARCO_TOGGLE_VERBOSE)

--- a/src/core/constraints.c
+++ b/src/core/constraints.c
@@ -43,7 +43,7 @@
  //      "constrain_whatever".
  //   3) Add your function to the all_constraints and all_constraint_names
  //      arrays (the latter of which is for debugging purposes)
- // 
+ //
  // An example constraint function, constrain_whatever:
  //
  // /* constrain_whatever does the following:
@@ -249,7 +249,7 @@ do_all_constraints (MetaWindow         *window,
           /* Log how the constraint modified the position */
           meta_topic (META_DEBUG_GEOMETRY,
                       "info->current is %d,%d +%d,%d after %s\n",
-                      info->current.x, info->current.y, 
+                      info->current.x, info->current.y,
                       info->current.width, info->current.height,
                       constraint->name);
         }
@@ -291,8 +291,8 @@ meta_window_constrain (MetaWindow          *window,
               new->x,  new->y,  new->width,  new->height);
 
   setup_constraint_info (&info,
-                         window, 
-                         orig_fgeom, 
+                         window,
+                         orig_fgeom,
                          flags,
                          resize_gravity,
                          orig,
@@ -305,7 +305,7 @@ meta_window_constrain (MetaWindow          *window,
     /* Individually enforce all the high-enough priority constraints */
     do_all_constraints (window, &info, priority, !check_only);
 
-    /* Check if all high-enough priority constraints are simultaneously 
+    /* Check if all high-enough priority constraints are simultaneously
      * satisfied
      */
     satisfied = do_all_constraints (window, &info, priority, check_only);
@@ -422,10 +422,10 @@ setup_constraint_info (ConstraintInfo      *info,
     }
 
   cur_workspace = window->screen->active_workspace;
-  info->usable_screen_region   = 
+  info->usable_screen_region   =
     meta_workspace_get_onscreen_region (cur_workspace);
-  info->usable_xinerama_region = 
-    meta_workspace_get_onxinerama_region (cur_workspace, 
+  info->usable_xinerama_region =
+    meta_workspace_get_onxinerama_region (cur_workspace,
                                           xinerama_info->number);
 
   /* Workaround braindead legacy apps that don't know how to
@@ -465,7 +465,7 @@ setup_constraint_info (ConstraintInfo      *info,
               "  work_area_xinerama: %d,%d +%d,%d\n"
               "  entire_xinerama   : %d,%d +%d,%d\n",
               info->orig.x, info->orig.y, info->orig.width, info->orig.height,
-              info->current.x, info->current.y, 
+              info->current.x, info->current.y,
                 info->current.width, info->current.height,
               info->fgeom->left_width, info->fgeom->right_width,
                 info->fgeom->top_height, info->fgeom->bottom_height,
@@ -480,7 +480,7 @@ setup_constraint_info (ConstraintInfo      *info,
                 (info->fixed_directions == FIXED_DIRECTION_Y) ? "Y fixed" :
                 "Freakin' Invalid Stupid",
               info->work_area_xinerama.x, info->work_area_xinerama.y,
-                info->work_area_xinerama.width, 
+                info->work_area_xinerama.width,
                 info->work_area_xinerama.height,
               info->entire_xinerama.x, info->entire_xinerama.y,
                 info->entire_xinerama.width, info->entire_xinerama.height);
@@ -523,8 +523,8 @@ place_window_if_needed(MetaWindow     *window,
                                               xinerama_info->number,
                                               &info->work_area_xinerama);
       cur_workspace = window->screen->active_workspace;
-      info->usable_xinerama_region = 
-        meta_workspace_get_onxinerama_region (cur_workspace, 
+      info->usable_xinerama_region =
+        meta_workspace_get_onxinerama_region (cur_workspace,
                                               xinerama_info->number);
 
 
@@ -561,7 +561,7 @@ place_window_if_needed(MetaWindow     *window,
 
           if (window->maximize_horizontally_after_placement ||
               window->maximize_vertically_after_placement)
-            meta_window_maximize_internal (window,   
+            meta_window_maximize_internal (window,
                 (window->maximize_horizontally_after_placement ?
                  META_MAXIMIZE_HORIZONTAL : 0 ) |
                 (window->maximize_vertically_after_placement ?
@@ -653,7 +653,7 @@ update_onscreen_requirements (MetaWindow     *window,
   if (old ^ window->require_on_single_xinerama)
     meta_topic (META_DEBUG_GEOMETRY,
                 "require_on_single_xinerama for %s toggled to %s\n",
-                window->desc, 
+                window->desc,
                 window->require_on_single_xinerama ? "TRUE" : "FALSE");
 
   /* Update whether we want future constraint runs to require the
@@ -914,7 +914,7 @@ constrain_size_increments (MetaWindow         *window,
     return TRUE;
 
   /* Determine whether constraint applies; exit if it doesn't */
-  if (META_WINDOW_MAXIMIZED (window) || window->fullscreen || 
+  if (META_WINDOW_MAXIMIZED (window) || window->fullscreen ||
       META_WINDOW_TILED (window) || info->action_type == ACTION_MOVE)
     return TRUE;
 
@@ -931,7 +931,7 @@ constrain_size_increments (MetaWindow         *window,
   if (window->maximized_vertically)
     extra_height *= 0;
   /* constraint is satisfied iff there is no extra height or width */
-  constraint_already_satisfied = 
+  constraint_already_satisfied =
     (extra_height == 0 && extra_width == 0);
 
   if (check_only || constraint_already_satisfied)
@@ -957,10 +957,10 @@ constrain_size_increments (MetaWindow         *window,
     start_rect = &info->current;
   else
     start_rect = &info->orig;
-    
+
   /* Resize to the new size */
   meta_rectangle_resize_with_gravity (start_rect,
-                                      &info->current, 
+                                      &info->current,
                                       info->resize_gravity,
                                       new_width,
                                       new_height);
@@ -1005,7 +1005,7 @@ constrain_size_limits (MetaWindow         *window,
   /*** Enforce constraint ***/
   new_width  = CLAMP (info->current.width,  min_size.width,  max_size.width);
   new_height = CLAMP (info->current.height, min_size.height, max_size.height);
-  
+
   /* Figure out what original rect to pass to meta_rectangle_resize_with_gravity
    * See bug 448183
    */
@@ -1013,9 +1013,9 @@ constrain_size_limits (MetaWindow         *window,
     start_rect = &info->current;
   else
     start_rect = &info->orig;
-  
+
   meta_rectangle_resize_with_gravity (start_rect,
-                                      &info->current, 
+                                      &info->current,
                                       info->resize_gravity,
                                       new_width,
                                       new_height);
@@ -1045,7 +1045,7 @@ constrain_aspect_ratio (MetaWindow         *window,
          (double)window->size_hints.max_aspect.y;
   constraints_are_inconsistent = minr > maxr;
   if (constraints_are_inconsistent ||
-      META_WINDOW_MAXIMIZED (window) || window->fullscreen || 
+      META_WINDOW_MAXIMIZED (window) || window->fullscreen ||
       META_WINDOW_TILED (window) || info->action_type == ACTION_MOVE)
     return TRUE;
 
@@ -1084,7 +1084,7 @@ constrain_aspect_ratio (MetaWindow         *window,
       fudge = 1;
       break;
     }
-  constraint_already_satisfied = 
+  constraint_already_satisfied =
     info->current.width - (info->current.height * minr ) > -minr*fudge &&
     info->current.width - (info->current.height * maxr ) <  maxr*fudge;
   if (check_only || constraint_already_satisfied)
@@ -1148,7 +1148,7 @@ constrain_aspect_ratio (MetaWindow         *window,
     start_rect = &info->orig;
 
   meta_rectangle_resize_with_gravity (start_rect,
-                                      &info->current, 
+                                      &info->current,
                                       info->resize_gravity,
                                       new_width,
                                       new_height);
@@ -1197,7 +1197,7 @@ do_screen_and_xinerama_relative_constraints (
     exit_early = TRUE;
 
   /* Determine whether constraint is already satisfied; exit if it is */
-  constraint_satisfied = 
+  constraint_satisfied =
     meta_rectangle_contained_in_region (region_spanning_rectangles,
                                         &info->current);
   if (exit_early || constraint_satisfied || check_only)
@@ -1240,7 +1240,7 @@ constrain_to_single_xinerama (MetaWindow         *window,
     return TRUE;
 
   /* Exit early if we know the constraint won't apply--note that this constraint
-   * is only meant for normal windows (e.g. we don't want docks to be shoved 
+   * is only meant for normal windows (e.g. we don't want docks to be shoved
    * "onscreen" by their own strut) and we can't apply it to frameless windows
    * or else users will be unable to move windows such as XMMS across xineramas.
    */
@@ -1253,7 +1253,7 @@ constrain_to_single_xinerama (MetaWindow         *window,
     return TRUE;
 
   /* Have a helper function handle the constraint for us */
-  return do_screen_and_xinerama_relative_constraints (window, 
+  return do_screen_and_xinerama_relative_constraints (window,
                                                  info->usable_xinerama_region,
                                                  info,
                                                  check_only);
@@ -1269,18 +1269,18 @@ constrain_fully_onscreen (MetaWindow         *window,
     return TRUE;
 
   /* Exit early if we know the constraint won't apply--note that this constraint
-   * is only meant for normal windows (e.g. we don't want docks to be shoved 
+   * is only meant for normal windows (e.g. we don't want docks to be shoved
    * "onscreen" by their own strut).
    */
   if (window->type == META_WINDOW_DESKTOP ||
       window->type == META_WINDOW_DOCK    ||
       window->fullscreen                  ||
-      !window->require_fully_onscreen     || 
+      !window->require_fully_onscreen     ||
       info->is_user_action)
     return TRUE;
 
   /* Have a helper function handle the constraint for us */
-  return do_screen_and_xinerama_relative_constraints (window, 
+  return do_screen_and_xinerama_relative_constraints (window,
                                                  info->usable_screen_region,
                                                  info,
                                                  check_only);
@@ -1308,7 +1308,7 @@ constrain_titlebar_visible (MetaWindow         *window,
     info->is_user_action && !window->display->grab_frame_action;
 
   /* Exit early if we know the constraint won't apply--note that this constraint
-   * is only meant for normal windows (e.g. we don't want docks to be shoved 
+   * is only meant for normal windows (e.g. we don't want docks to be shoved
    * "onscreen" by their own strut).
    */
   if (window->type == META_WINDOW_DESKTOP ||
@@ -1350,13 +1350,13 @@ constrain_titlebar_visible (MetaWindow         *window,
    */
   meta_rectangle_expand_region_conditionally (info->usable_screen_region,
                                               horiz_amount_offscreen,
-                                              horiz_amount_offscreen, 
+                                              horiz_amount_offscreen,
                                               0, /* Don't let titlebar off */
                                               bottom_amount,
                                               horiz_amount_onscreen,
                                               vert_amount_onscreen);
   retval =
-    do_screen_and_xinerama_relative_constraints (window, 
+    do_screen_and_xinerama_relative_constraints (window,
                                                  info->usable_screen_region,
                                                  info,
                                                  check_only);
@@ -1386,7 +1386,7 @@ constrain_partially_onscreen (MetaWindow         *window,
     return TRUE;
 
   /* Exit early if we know the constraint won't apply--note that this constraint
-   * is only meant for normal windows (e.g. we don't want docks to be shoved 
+   * is only meant for normal windows (e.g. we don't want docks to be shoved
    * "onscreen" by their own strut).
    */
   if (window->type == META_WINDOW_DESKTOP ||
@@ -1425,13 +1425,13 @@ constrain_partially_onscreen (MetaWindow         *window,
    */
   meta_rectangle_expand_region_conditionally (info->usable_screen_region,
                                               horiz_amount_offscreen,
-                                              horiz_amount_offscreen, 
+                                              horiz_amount_offscreen,
                                               top_amount,
                                               bottom_amount,
                                               horiz_amount_onscreen,
                                               vert_amount_onscreen);
   retval =
-    do_screen_and_xinerama_relative_constraints (window, 
+    do_screen_and_xinerama_relative_constraints (window,
                                                  info->usable_screen_region,
                                                  info,
                                                  check_only);

--- a/src/core/constraints.h
+++ b/src/core/constraints.h
@@ -2,10 +2,10 @@
 
 /* Marco size/position constraints */
 
-/* 
+/*
  * Copyright (C) 2002 Red Hat, Inc.
  * Copyright (C) 2005 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -15,7 +15,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA

--- a/src/core/core.c
+++ b/src/core/core.c
@@ -2,11 +2,11 @@
 
 /* Marco interface used by GTK+ UI to talk to core */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2003 Rob Adams
  * Copyright (C) 2004-2006 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -16,7 +16,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -47,7 +47,7 @@ get_window (Display *xdisplay,
 {
   MetaDisplay *display;
   MetaWindow *window;
-  
+
   display = meta_display_for_x_display (xdisplay);
   window = meta_display_lookup_x_window (display, frame_xwindow);
 
@@ -93,14 +93,14 @@ meta_core_get (Display *xdisplay,
   }
 
   while (request != META_CORE_GET_END) {
-    
+
     gpointer answer = va_arg (args, gpointer);
 
     switch (request) {
       case META_CORE_WINDOW_HAS_FRAME:
         *((gboolean*)answer) = window != NULL && window->frame != NULL;
         if (!*((gboolean*)answer)) return; /* see above */
-        break; 
+        break;
       case META_CORE_GET_CLIENT_WIDTH:
         *((gint*)answer) = window->rect.width;
         break;
@@ -115,7 +115,7 @@ meta_core_get (Display *xdisplay,
         break;
       case META_CORE_GET_FRAME_FLAGS:
         *((MetaFrameFlags*)answer) = meta_frame_get_flags (window->frame);
-        break; 
+        break;
       case META_CORE_GET_FRAME_TYPE:
           {
           MetaFrameType base_type = META_FRAME_TYPE_LAST;
@@ -155,19 +155,19 @@ meta_core_get (Display *xdisplay,
           if (base_type == META_FRAME_TYPE_LAST)
             {
               /* can't add border if undecorated */
-              *((MetaFrameType*)answer) = META_FRAME_TYPE_LAST; 
+              *((MetaFrameType*)answer) = META_FRAME_TYPE_LAST;
             }
           else if (window->border_only)
             {
               /* override base frame type */
-              *((MetaFrameType*)answer) = META_FRAME_TYPE_BORDER; 
+              *((MetaFrameType*)answer) = META_FRAME_TYPE_BORDER;
             }
           else
             {
               *((MetaFrameType*)answer) = base_type;
             }
 
-          break; 
+          break;
           }
       case META_CORE_GET_MINI_ICON:
         *((GdkPixbuf**)answer) = window->mini_icon;
@@ -208,7 +208,7 @@ meta_core_get (Display *xdisplay,
     }
 
     request = va_arg (args, MetaCoreGetType);
-  } 
+  }
 
   va_end (args);
 }
@@ -250,7 +250,7 @@ meta_core_user_raise (Display *xdisplay,
                       Window   frame_xwindow)
 {
   MetaWindow *window = get_window (xdisplay, frame_xwindow);
-  
+
   meta_window_raise (window);
 }
 
@@ -260,7 +260,7 @@ meta_core_user_lower_and_unfocus (Display *xdisplay,
                                   guint32  timestamp)
 {
   MetaWindow *window = get_window (xdisplay, frame_xwindow);
-  
+
   meta_window_lower (window);
 
   if (meta_prefs_get_focus_mode () == META_FOCUS_MODE_CLICK &&
@@ -271,21 +271,21 @@ meta_core_user_lower_and_unfocus (Display *xdisplay,
        * (Borrowed from window.c.)
        */
       if (window->screen->active_workspace &&
-          meta_window_located_on_workspace (window, 
+          meta_window_located_on_workspace (window,
                                             window->screen->active_workspace))
         {
           GList* link;
-          link = g_list_find (window->screen->active_workspace->mru_list, 
+          link = g_list_find (window->screen->active_workspace->mru_list,
                               window);
           g_assert (link);
 
-          window->screen->active_workspace->mru_list = 
+          window->screen->active_workspace->mru_list =
             g_list_remove_link (window->screen->active_workspace->mru_list,
                                 link);
           g_list_free (link);
 
-          window->screen->active_workspace->mru_list = 
-            g_list_append (window->screen->active_workspace->mru_list, 
+          window->screen->active_workspace->mru_list =
+            g_list_append (window->screen->active_workspace->mru_list,
                            window);
         }
     }
@@ -332,7 +332,7 @@ meta_core_user_focus (Display *xdisplay,
                       guint32  timestamp)
 {
   MetaWindow *window = get_window (xdisplay, frame_xwindow);
-  
+
   meta_window_focus (window, timestamp);
 }
 
@@ -354,7 +354,7 @@ meta_core_maximize (Display *xdisplay,
   if (meta_prefs_get_raise_on_click ())
     meta_window_raise (window);
 
-  meta_window_maximize (window, 
+  meta_window_maximize (window,
                         META_MAXIMIZE_HORIZONTAL | META_MAXIMIZE_VERTICAL);
 }
 
@@ -368,7 +368,7 @@ meta_core_toggle_maximize_vertically (Display *xdisplay,
     meta_window_raise (window);
 
   if (META_WINDOW_MAXIMIZED_VERTICALLY (window))
-    meta_window_unmaximize (window, 
+    meta_window_unmaximize (window,
                             META_MAXIMIZE_VERTICAL);
   else
     meta_window_maximize (window,
@@ -385,7 +385,7 @@ meta_core_toggle_maximize_horizontally (Display *xdisplay,
     meta_window_raise (window);
 
   if (META_WINDOW_MAXIMIZED_HORIZONTALLY (window))
-    meta_window_unmaximize (window, 
+    meta_window_unmaximize (window,
                             META_MAXIMIZE_HORIZONTAL);
   else
     meta_window_maximize (window,
@@ -402,7 +402,7 @@ meta_core_toggle_maximize (Display *xdisplay,
     meta_window_raise (window);
 
   if (META_WINDOW_MAXIMIZED (window))
-    meta_window_unmaximize (window, 
+    meta_window_unmaximize (window,
                             META_MAXIMIZE_HORIZONTAL | META_MAXIMIZE_VERTICAL);
   else
     meta_window_maximize (window,
@@ -428,7 +428,7 @@ meta_core_delete (Display *xdisplay,
                   guint32  timestamp)
 {
   MetaWindow *window = get_window (xdisplay, frame_xwindow);
-     
+
   meta_window_delete (window, timestamp);
 }
 
@@ -448,7 +448,7 @@ meta_core_shade (Display *xdisplay,
                  guint32  timestamp)
 {
   MetaWindow *window = get_window (xdisplay, frame_xwindow);
-  
+
   meta_window_shade (window, timestamp);
 }
 
@@ -529,7 +529,7 @@ meta_core_show_window_menu (Display *xdisplay,
                             guint32  timestamp)
 {
   MetaWindow *window = get_window (xdisplay, frame_xwindow);
-  
+
   if (meta_prefs_get_raise_on_click ())
     meta_window_raise (window);
   meta_window_focus (window, timestamp);
@@ -546,7 +546,7 @@ meta_core_get_menu_accelerator (MetaMenuOp           menu_op,
   const char *name;
 
   name = NULL;
-  
+
   switch (menu_op)
     {
     case META_MENU_OP_NONE:
@@ -587,25 +587,25 @@ meta_core_get_menu_accelerator (MetaMenuOp           menu_op,
           break;
         case 3:
           name = "move-to-workspace-3";
-          break; 
+          break;
         case 4:
           name = "move-to-workspace-4";
-          break; 
+          break;
         case 5:
           name = "move-to-workspace-5";
-          break; 
+          break;
         case 6:
           name = "move-to-workspace-6";
-          break; 
+          break;
         case 7:
           name = "move-to-workspace-7";
-          break; 
+          break;
         case 8:
           name = "move-to-workspace-8";
-          break; 
+          break;
         case 9:
           name = "move-to-workspace-9";
-          break; 
+          break;
         case 10:
           name = "move-to-workspace-10";
           break;
@@ -682,12 +682,12 @@ meta_core_begin_grab_op (Display    *xdisplay,
   MetaWindow *window = get_window (xdisplay, frame_xwindow);
   MetaDisplay *display;
   MetaScreen *screen;
-  
+
   display = meta_display_for_x_display (xdisplay);
   screen = meta_display_screen_for_xwindow (display, frame_xwindow);
 
   g_assert (screen != NULL);
-  
+
   return meta_display_begin_grab_op (display, screen, window,
                                      op, pointer_already_grabbed,
                                      frame_action,
@@ -700,7 +700,7 @@ meta_core_end_grab_op (Display *xdisplay,
                        guint32  timestamp)
 {
   MetaDisplay *display;
-  
+
   display = meta_display_for_x_display (xdisplay);
 
   meta_display_end_grab_op (display, timestamp);
@@ -710,7 +710,7 @@ MetaGrabOp
 meta_core_get_grab_op (Display *xdisplay)
 {
   MetaDisplay *display;
-  
+
   display = meta_display_for_x_display (xdisplay);
 
   return display->grab_op;
@@ -720,15 +720,15 @@ Window
 meta_core_get_grab_frame (Display *xdisplay)
 {
   MetaDisplay *display;
-  
+
   display = meta_display_for_x_display (xdisplay);
 
   g_assert (display != NULL);
-  g_assert (display->grab_op == META_GRAB_OP_NONE || 
+  g_assert (display->grab_op == META_GRAB_OP_NONE ||
             display->grab_screen != NULL);
   g_assert (display->grab_op == META_GRAB_OP_NONE ||
             display->grab_screen->display->xdisplay == xdisplay);
-  
+
   if (display->grab_op != META_GRAB_OP_NONE &&
       display->grab_window &&
       display->grab_window->frame)
@@ -741,12 +741,12 @@ int
 meta_core_get_grab_button (Display  *xdisplay)
 {
   MetaDisplay *display;
-  
+
   display = meta_display_for_x_display (xdisplay);
 
   if (display->grab_op == META_GRAB_OP_NONE)
     return -1;
-  
+
   return display->grab_button;
 }
 
@@ -755,7 +755,7 @@ meta_core_grab_buttons  (Display *xdisplay,
                          Window   frame_xwindow)
 {
   MetaDisplay *display;
-    
+
   display = meta_display_for_x_display (xdisplay);
 
   meta_verbose ("Grabbing buttons on frame 0x%lx\n", frame_xwindow);
@@ -776,7 +776,7 @@ void
 meta_core_increment_event_serial (Display *xdisplay)
 {
   MetaDisplay *display;
-  
+
   display = meta_display_for_x_display (xdisplay);
 
   meta_display_increment_event_serial (display);

--- a/src/core/display-private.h
+++ b/src/core/display-private.h
@@ -1,11 +1,11 @@
 /* Marco X display handler */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2002 Red Hat, Inc.
  * Copyright (C) 2003 Rob Adams
  * Copyright (C) 2004-2006 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -15,7 +15,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -124,7 +124,7 @@ struct _MetaDisplay {
 	MetaScreen* active_screen;
 	GHashTable* window_ids;
 	int error_traps;
-	int (*error_trap_handler) (Display* display, XErrorEvent* error);  
+	int (*error_trap_handler) (Display* display, XErrorEvent* error);
 	int server_grab_count;
 
 	/* serials of leave/unmap events that may
@@ -133,7 +133,7 @@ struct _MetaDisplay {
 	 */
 	unsigned long ignored_serials[N_IGNORED_SERIALS];
 	Window ungrab_should_not_cause_focus_window;
-  
+
 	guint32 current_time;
 
 	/* Pings which we're waiting for a reply from */
@@ -186,12 +186,12 @@ struct _MetaDisplay {
 		int         xkb_base_event_type;
 		guint32     last_bell_time;
 	#endif
-	
+
 	#ifdef HAVE_XSYNC
 		/* alarm monitoring client's _NET_WM_SYNC_REQUEST_COUNTER */
 		XSyncAlarm  grab_sync_request_alarm;
 	#endif
-	
+
 	int       grab_resize_timeout_id;
 
 	/* Keybindings stuff */
@@ -244,26 +244,26 @@ struct _MetaDisplay {
 
 	/* Managed by compositor.c */
 	MetaCompositor* compositor;
-  
+
 	#ifdef HAVE_STARTUP_NOTIFICATION
 		SnDisplay* sn_display;
 	#endif
-	
+
 	#ifdef HAVE_XSYNC
 		int xsync_event_base;
 		int xsync_error_base;
 	#endif
-	
+
 	#ifdef HAVE_SHAPE
 		int shape_event_base;
 		int shape_error_base;
 	#endif
-	
+
 	#ifdef HAVE_RENDER
 		int render_event_base;
 		int render_error_base;
 	#endif
-	
+
 	#ifdef HAVE_COMPOSITE_EXTENSIONS
 		int composite_event_base;
 		int composite_error_base;
@@ -274,28 +274,28 @@ struct _MetaDisplay {
 		int xfixes_event_base;
 		int xfixes_error_base;
 	#endif
-	
+
 	#ifdef HAVE_XSYNC
 		unsigned int have_xsync : 1;
 		#define META_DISPLAY_HAS_XSYNC(display) ((display)->have_xsync)
 	#else
 		#define META_DISPLAY_HAS_XSYNC(display) FALSE
 	#endif
-	
+
 	#ifdef HAVE_SHAPE
 		unsigned int have_shape : 1;
 		#define META_DISPLAY_HAS_SHAPE(display) ((display)->have_shape)
 	#else
 		#define META_DISPLAY_HAS_SHAPE(display) FALSE
 	#endif
-	
+
 	#ifdef HAVE_RENDER
 		unsigned int have_render : 1;
 		#define META_DISPLAY_HAS_RENDER(display) ((display)->have_render)
 	#else
 		#define META_DISPLAY_HAS_RENDER(display) FALSE
 	#endif
-	
+
 	#ifdef HAVE_COMPOSITE_EXTENSIONS
 		unsigned int have_composite : 1;
 		unsigned int have_damage : 1;
@@ -316,7 +316,7 @@ struct _MetaDisplay {
  *   time1 < time2
  * Of course, the rest of the ugliness of this macro comes from accounting
  * for the fact that wraparound can occur and the fact that a timestamp of
- * 0 must be special-cased since it means older than anything else. 
+ * 0 must be special-cased since it means older than anything else.
  *
  * Note that this is NOT an equivalent for time1 <= time2; if that's what
  * you need then you'll need to swap the order of the arguments and negate
@@ -429,7 +429,7 @@ const char* meta_event_detail_to_string (int d);
 void meta_display_queue_retheme_all_windows (MetaDisplay *display);
 void meta_display_retheme_all (void);
 
-void meta_display_set_cursor_theme (const char *theme, 
+void meta_display_set_cursor_theme (const char *theme,
 				    int         size);
 
 void meta_display_ping_window      (MetaDisplay        *display,
@@ -494,7 +494,7 @@ gboolean meta_display_focus_sentinel_clear (MetaDisplay *display);
  * whether a window should be allowed to be focused should depend
  * on user_time events (see bug 167358, comment 15 in particular)
  */
-void meta_display_set_input_focus_window   (MetaDisplay *display, 
+void meta_display_set_input_focus_window   (MetaDisplay *display,
                                             MetaWindow  *window,
                                             gboolean     focus_frame,
                                             guint32      timestamp);
@@ -503,7 +503,7 @@ void meta_display_set_input_focus_window   (MetaDisplay *display,
  * designated no_focus_window should be focused, but is otherwise the
  * same as meta_display_set_input_focus_window
  */
-void meta_display_focus_the_no_focus_window (MetaDisplay *display, 
+void meta_display_focus_the_no_focus_window (MetaDisplay *display,
                                              MetaScreen  *screen,
                                              guint32      timestamp);
 

--- a/src/core/display.c
+++ b/src/core/display.c
@@ -1,11 +1,11 @@
 /* Marco X display handler */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2002, 2003, 2004 Red Hat, Inc.
  * Copyright (C) 2003, 2004 Rob Adams
  * Copyright (C) 2004-2006 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -15,7 +15,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -120,7 +120,7 @@
  *
  * \ingroup pings
  */
-typedef struct 
+typedef struct
 {
   MetaDisplay *display;
   Window       xwindow;
@@ -131,7 +131,7 @@ typedef struct
   guint        ping_timeout_id;
 } MetaPingData;
 
-typedef struct 
+typedef struct
 {
   MetaDisplay *display;
   Window xwindow;
@@ -208,7 +208,7 @@ remove_pending_pings_for_window (MetaDisplay *display, Window xwindow)
   GSList *dead;
 
   /* could obviously be more efficient, don't care */
-  
+
   /* build list to be removed */
   dead = NULL;
   for (tmp = display->pending_pings; tmp; tmp = tmp->next)
@@ -277,11 +277,11 @@ enable_compositor (MetaDisplay *display,
 
   if (!display->compositor)
     return;
-  
+
   for (list = display->screens; list != NULL; list = list->next)
     {
       MetaScreen *screen = list->data;
-      
+
       meta_compositor_manage_screen (screen->display->compositor,
 				     screen);
 
@@ -294,18 +294,18 @@ static void
 disable_compositor (MetaDisplay *display)
 {
   GSList *list;
-  
+
   if (!display->compositor)
     return;
-  
+
   for (list = display->screens; list != NULL; list = list->next)
     {
       MetaScreen *screen = list->data;
-      
+
       meta_compositor_unmanage_screen (screen->display->compositor,
 				       screen);
     }
-  
+
   meta_compositor_destroy (display->compositor);
   display->compositor = NULL;
 }
@@ -336,11 +336,11 @@ meta_display_open (void)
 #undef item
   };
   Atom atoms[G_N_ELEMENTS(atom_names)];
-  
+
   meta_verbose ("Opening display '%s'\n", XDisplayName (NULL));
 
   xdisplay = meta_ui_get_display ();
-  
+
   if (xdisplay == NULL)
     {
       meta_warning (_("Failed to open X Window System display '%s'\n"),
@@ -350,12 +350,12 @@ meta_display_open (void)
 
   if (meta_is_syncing ())
     XSynchronize (xdisplay, True);
-  
+
   g_assert (the_display == NULL);
   the_display = g_new (MetaDisplay, 1);
 
   the_display->closing = 0;
-  
+
   /* here we use XDisplayName which is what the user
    * probably put in, vs. DisplayString(display) which is
    * canonicalized by XOpenDisplay()
@@ -382,10 +382,10 @@ meta_display_open (void)
 #ifdef HAVE_XSYNC
   the_display->grab_sync_request_alarm = None;
 #endif
-  
+
   /* FIXME copy the checks from GDK probably */
   the_display->static_gravity_works = g_getenv ("MARCO_USE_STATIC_GRAVITY") != NULL;
-  
+
   meta_bell_init (the_display);
 
   meta_display_init_keys (the_display);
@@ -398,7 +398,7 @@ meta_display_open (void)
   XInternAtoms (the_display->xdisplay, atom_names, G_N_ELEMENTS (atom_names),
                 False, atoms);
   {
-    int i = 0;    
+    int i = 0;
 #define item(x) the_display->atom_##x = atoms[i++];
 #include "atomnames.h"
 #undef item
@@ -408,7 +408,7 @@ meta_display_open (void)
   meta_display_init_window_prop_hooks (the_display);
   the_display->group_prop_hooks = NULL;
   meta_display_init_group_prop_hooks (the_display);
-  
+
   /* Offscreen unmapped window used for _NET_SUPPORTING_WM_CHECK,
    * created in screen_new
    */
@@ -421,26 +421,26 @@ meta_display_open (void)
 
   the_display->window_with_menu = NULL;
   the_display->window_menu = NULL;
-  
+
   the_display->screens = NULL;
   the_display->active_screen = NULL;
-  
+
 #ifdef HAVE_STARTUP_NOTIFICATION
   the_display->sn_display = sn_display_new (the_display->xdisplay,
                                         sn_error_trap_push,
                                         sn_error_trap_pop);
 #endif
-  
+
   the_display->events = NULL;
 
   /* Get events */
   meta_ui_add_event_func (the_display->xdisplay,
                           event_callback,
                           the_display);
-  
+
   the_display->window_ids = g_hash_table_new (meta_unsigned_long_hash,
                                           meta_unsigned_long_equal);
-  
+
   i = 0;
   while (i < N_IGNORED_SERIALS)
     {
@@ -448,14 +448,14 @@ meta_display_open (void)
       ++i;
     }
   the_display->ungrab_should_not_cause_focus_window = None;
-  
+
   the_display->current_time = CurrentTime;
   the_display->sentinel_counter = 0;
 
   the_display->grab_resize_timeout_id = 0;
   the_display->grab_have_keyboard = FALSE;
-  
-#ifdef HAVE_XKB  
+
+#ifdef HAVE_XKB
   the_display->last_bell_time = 0;
 #endif
 
@@ -472,14 +472,14 @@ meta_display_open (void)
     int major, minor;
 
     the_display->have_xsync = FALSE;
-    
+
     the_display->xsync_error_base = 0;
     the_display->xsync_event_base = 0;
 
     /* I don't think we really have to fill these in */
     major = SYNC_MAJOR_VERSION;
     minor = SYNC_MINOR_VERSION;
-    
+
     if (!XSyncQueryExtension (the_display->xdisplay,
                               &the_display->xsync_event_base,
                               &the_display->xsync_error_base) ||
@@ -491,7 +491,7 @@ meta_display_open (void)
       }
     else
       the_display->have_xsync = TRUE;
-    
+
     meta_verbose ("Attempted to init Xsync, found version %d.%d error base %d event base %d\n",
                   major, minor,
                   the_display->xsync_error_base,
@@ -505,10 +505,10 @@ meta_display_open (void)
 #ifdef HAVE_SHAPE
   {
     the_display->have_shape = FALSE;
-    
+
     the_display->shape_error_base = 0;
     the_display->shape_event_base = 0;
-    
+
     if (!XShapeQueryExtension (the_display->xdisplay,
                                &the_display->shape_event_base,
                                &the_display->shape_error_base))
@@ -518,7 +518,7 @@ meta_display_open (void)
       }
     else
       the_display->have_shape = TRUE;
-    
+
     meta_verbose ("Attempted to init Shape, found error base %d event base %d\n",
                   the_display->shape_error_base,
                   the_display->shape_event_base);
@@ -530,10 +530,10 @@ meta_display_open (void)
 #ifdef HAVE_RENDER
   {
     the_display->have_render = FALSE;
-    
+
     the_display->render_error_base = 0;
     the_display->render_event_base = 0;
-    
+
     if (!XRenderQueryExtension (the_display->xdisplay,
                                 &the_display->render_event_base,
                                 &the_display->render_error_base))
@@ -543,7 +543,7 @@ meta_display_open (void)
       }
     else
       the_display->have_render = TRUE;
-    
+
     meta_verbose ("Attempted to init Render, found error base %d event base %d\n",
                   the_display->render_error_base,
                   the_display->render_event_base);
@@ -565,7 +565,7 @@ meta_display_open (void)
       {
         the_display->composite_error_base = 0;
         the_display->composite_event_base = 0;
-      } 
+      }
     else
       {
         the_display->composite_major_version = 0;
@@ -585,7 +585,7 @@ meta_display_open (void)
 
     meta_verbose ("Attempted to init Composite, found error base %d event base %d "
                   "extn ver %d %d\n",
-                  the_display->composite_error_base, 
+                  the_display->composite_error_base,
                   the_display->composite_event_base,
                   the_display->composite_major_version,
                   the_display->composite_minor_version);
@@ -601,12 +601,12 @@ meta_display_open (void)
       {
         the_display->damage_error_base = 0;
         the_display->damage_event_base = 0;
-      } 
+      }
     else
       the_display->have_damage = TRUE;
 
     meta_verbose ("Attempted to init Damage, found error base %d event base %d\n",
-                  the_display->damage_error_base, 
+                  the_display->damage_error_base,
                   the_display->damage_event_base);
 
     the_display->have_xfixes = FALSE;
@@ -620,18 +620,18 @@ meta_display_open (void)
       {
         the_display->xfixes_error_base = 0;
         the_display->xfixes_event_base = 0;
-      } 
+      }
     else
       the_display->have_xfixes = TRUE;
 
     meta_verbose ("Attempted to init XFixes, found error base %d event base %d\n",
-                  the_display->xfixes_error_base, 
+                  the_display->xfixes_error_base,
                   the_display->xfixes_event_base);
   }
 #else /* HAVE_COMPOSITE_EXTENSIONS */
   meta_verbose ("Not compiled with Composite support\n");
 #endif /* !HAVE_COMPOSITE_EXTENSIONS */
-      
+
 #ifdef HAVE_XCURSOR
   {
     XcursorSetTheme (the_display->xdisplay, meta_prefs_get_cursor_theme ());
@@ -663,7 +663,7 @@ meta_display_open (void)
                                     the_display->leader_window,
                                     the_display->atom__NET_WM_NAME,
                                     "Marco");
-    
+
     meta_prop_set_utf8_string_hint (the_display,
                                     the_display->leader_window,
                                     the_display->atom__MARCO_VERSION,
@@ -702,9 +702,9 @@ meta_display_open (void)
   the_display->last_focus_time = timestamp;
   the_display->last_user_time = timestamp;
   the_display->compositor = NULL;
-  
+
   screens = NULL;
-  
+
   i = 0;
   while (i < ScreenCount (xdisplay))
     {
@@ -716,9 +716,9 @@ meta_display_open (void)
         screens = g_slist_prepend (screens, screen);
       ++i;
     }
-  
+
   the_display->screens = screens;
-  
+
   if (screens == NULL)
     {
       /* This would typically happen because all the screens already
@@ -728,20 +728,20 @@ meta_display_open (void)
       return FALSE;
     }
 
-  /* We don't composite the windows here because they will be composited 
-     faster with the call to meta_screen_manage_all_windows further down 
+  /* We don't composite the windows here because they will be composited
+     faster with the call to meta_screen_manage_all_windows further down
      the code */
   if (meta_prefs_get_compositing_manager ())
     enable_compositor (the_display, FALSE);
-   
+
   meta_display_grab (the_display);
-  
+
   /* Now manage all existing windows */
   tmp = the_display->screens;
   while (tmp != NULL)
     {
       MetaScreen *screen = tmp->data;
-	
+
       meta_screen_manage_all_windows (screen);
 
       tmp = tmp->next;
@@ -784,8 +784,8 @@ meta_display_open (void)
 
     meta_error_trap_pop (the_display, FALSE);
   }
-  
-  meta_display_ungrab (the_display);  
+
+  meta_display_ungrab (the_display);
 
   /* Done opening new display */
   the_display->display_opening = FALSE;
@@ -819,7 +819,7 @@ meta_display_list_windows (MetaDisplay *display)
   GSList *winlist;
   GSList *tmp;
   GSList *prev;
-  
+
   winlist = NULL;
   g_hash_table_foreach (display->window_ids,
                         listify_func,
@@ -837,7 +837,7 @@ meta_display_list_windows (MetaDisplay *display)
       GSList *next;
 
       next = tmp->next;
-      
+
       if (next &&
           next->data == tmp->data)
         {
@@ -848,7 +848,7 @@ meta_display_list_windows (MetaDisplay *display)
 
           if (tmp == winlist)
             winlist = next;
-          
+
           g_slist_free_1 (tmp);
 
           /* leave prev unchanged */
@@ -857,7 +857,7 @@ meta_display_list_windows (MetaDisplay *display)
         {
           prev = tmp;
         }
-      
+
       tmp = next;
     }
 
@@ -884,17 +884,17 @@ meta_display_close (MetaDisplay *display,
   display->closing += 1;
 
   meta_prefs_remove_listener (prefs_changed_callback, display);
-  
+
   meta_display_remove_autoraise_callback (display);
 
   if (display->grab_old_window_stacking)
     g_list_free (display->grab_old_window_stacking);
-  
+
   /* Stop caring about events */
   meta_ui_remove_event_func (display->xdisplay,
                              event_callback,
                              display);
-  
+
   /* Free all screens */
   tmp = display->screens;
   while (tmp != NULL)
@@ -914,7 +914,7 @@ meta_display_close (MetaDisplay *display,
       display->sn_display = NULL;
     }
 #endif
-  
+
   /* Must be after all calls to meta_window_free() since they
    * unregister windows
    */
@@ -927,14 +927,14 @@ meta_display_close (MetaDisplay *display,
 
   meta_display_free_window_prop_hooks (display);
   meta_display_free_group_prop_hooks (display);
-  
+
   g_free (display->name);
 
   meta_display_shutdown_keys (display);
 
   if (display->compositor)
     meta_compositor_destroy (display->compositor);
-  
+
   g_free (display);
   the_display = NULL;
 
@@ -967,7 +967,7 @@ meta_display_screen_for_xwindow (MetaDisplay *display,
 {
   XWindowAttributes attr;
   int result;
-  
+
   meta_error_trap_push (display);
   attr.screen = NULL;
   result = XGetWindowAttributes (display->xdisplay, xwindow, &attr);
@@ -979,7 +979,7 @@ meta_display_screen_for_xwindow (MetaDisplay *display,
    */
   if (result == 0 || attr.screen == NULL)
     return NULL;
-  
+
   return meta_display_screen_for_x_screen (display, attr.screen);
 }
 
@@ -1021,7 +1021,7 @@ meta_display_ungrab (MetaDisplay *display)
 {
   if (display->server_grab_count == 0)
     meta_bug ("Ungrabbed non-grabbed server\n");
-  
+
   display->server_grab_count -= 1;
   if (display->server_grab_count == 0)
     {
@@ -1055,7 +1055,7 @@ meta_display_for_x_display (Display *xdisplay)
 
   meta_warning ("Could not find display for X display %p, probably going to crash\n",
                 xdisplay);
-  
+
   return NULL;
 }
 
@@ -1082,8 +1082,8 @@ grab_op_is_mouse_only (MetaGrabOp op)
     {
     case META_GRAB_OP_MOVING:
     case META_GRAB_OP_RESIZING_SE:
-    case META_GRAB_OP_RESIZING_S:      
-    case META_GRAB_OP_RESIZING_SW:      
+    case META_GRAB_OP_RESIZING_S:
+    case META_GRAB_OP_RESIZING_SW:
     case META_GRAB_OP_RESIZING_N:
     case META_GRAB_OP_RESIZING_NE:
     case META_GRAB_OP_RESIZING_NW:
@@ -1103,8 +1103,8 @@ grab_op_is_mouse (MetaGrabOp op)
     {
     case META_GRAB_OP_MOVING:
     case META_GRAB_OP_RESIZING_SE:
-    case META_GRAB_OP_RESIZING_S:      
-    case META_GRAB_OP_RESIZING_SW:      
+    case META_GRAB_OP_RESIZING_S:
+    case META_GRAB_OP_RESIZING_SW:
     case META_GRAB_OP_RESIZING_N:
     case META_GRAB_OP_RESIZING_NE:
     case META_GRAB_OP_RESIZING_NW:
@@ -1164,8 +1164,8 @@ meta_grab_op_is_resizing (MetaGrabOp op)
   switch (op)
     {
     case META_GRAB_OP_RESIZING_SE:
-    case META_GRAB_OP_RESIZING_S:      
-    case META_GRAB_OP_RESIZING_SW:      
+    case META_GRAB_OP_RESIZING_S:
+    case META_GRAB_OP_RESIZING_SW:
     case META_GRAB_OP_RESIZING_N:
     case META_GRAB_OP_RESIZING_NE:
     case META_GRAB_OP_RESIZING_NW:
@@ -1195,7 +1195,7 @@ meta_grab_op_is_moving (MetaGrabOp op)
     case META_GRAB_OP_MOVING:
     case META_GRAB_OP_KEYBOARD_MOVING:
       return TRUE;
-      
+
     default:
       return FALSE;
     }
@@ -1213,7 +1213,7 @@ guint32
 meta_display_get_current_time_roundtrip (MetaDisplay *display)
 {
   guint32 timestamp;
-  
+
   timestamp = meta_display_get_current_time (display);
   if (timestamp == CurrentTime)
     {
@@ -1247,7 +1247,7 @@ add_ignored_serial (MetaDisplay  *display,
   /* don't add the same serial more than once */
   if (display->ignored_serials[N_IGNORED_SERIALS-1] == serial)
     return;
-  
+
   /* shift serials to the left */
   i = 0;
   while (i < (N_IGNORED_SERIALS - 1))
@@ -1290,7 +1290,7 @@ reset_ignores (MetaDisplay *display)
   display->ungrab_should_not_cause_focus_window = None;
 }
 
-static gboolean 
+static gboolean
 window_raise_with_delay_callback (void *data)
 {
   MetaWindow *window;
@@ -1298,23 +1298,23 @@ window_raise_with_delay_callback (void *data)
 
   auto_raise = data;
 
-  meta_topic (META_DEBUG_FOCUS, 
-	      "In autoraise callback for window 0x%lx\n", 
+  meta_topic (META_DEBUG_FOCUS,
+	      "In autoraise callback for window 0x%lx\n",
 	      auto_raise->xwindow);
 
   auto_raise->display->autoraise_timeout_id = 0;
   auto_raise->display->autoraise_window = NULL;
 
-  window  = meta_display_lookup_x_window (auto_raise->display, 
+  window  = meta_display_lookup_x_window (auto_raise->display,
 					  auto_raise->xwindow);
-  
-  if (window == NULL) 
+
+  if (window == NULL)
     return FALSE;
 
   /* If we aren't already on top, check whether the pointer is inside
    * the window and raise the window if so.
-   */      
-  if (meta_stack_get_top (window->screen->stack) != window) 
+   */
+  if (meta_stack_get_top (window->screen->stack) != window)
     {
       int x, y, root_x, root_y;
       Window root, child;
@@ -1329,14 +1329,14 @@ window_raise_with_delay_callback (void *data)
 				   &root_x, &root_y, &x, &y, &mask);
       meta_error_trap_pop (window->display, TRUE);
 
-      point_in_window = 
+      point_in_window =
         (window->frame && POINT_IN_RECT (root_x, root_y, window->frame->rect)) ||
         (window->frame == NULL && POINT_IN_RECT (root_x, root_y, window->rect));
       if (same_screen && point_in_window)
 	meta_window_raise (window);
       else
-	meta_topic (META_DEBUG_FOCUS, 
-		    "Pointer not inside window, not raising %s\n", 
+	meta_topic (META_DEBUG_FOCUS,
+		    "Pointer not inside window, not raising %s\n",
 		    window->desc);
     }
 
@@ -1349,19 +1349,19 @@ meta_display_queue_autoraise_callback (MetaDisplay *display,
 {
   MetaAutoRaiseData *auto_raise_data;
 
-  meta_topic (META_DEBUG_FOCUS, 
-              "Queuing an autoraise timeout for %s with delay %d\n", 
-              window->desc, 
+  meta_topic (META_DEBUG_FOCUS,
+              "Queuing an autoraise timeout for %s with delay %d\n",
+              window->desc,
               meta_prefs_get_auto_raise_delay ());
-  
+
   auto_raise_data = g_new (MetaAutoRaiseData, 1);
   auto_raise_data->display = window->display;
   auto_raise_data->xwindow = window->xwindow;
-  
+
   if (display->autoraise_timeout_id != 0)
     g_source_remove (display->autoraise_timeout_id);
 
-  display->autoraise_timeout_id = 
+  display->autoraise_timeout_id =
     g_timeout_add_full (G_PRIORITY_DEFAULT,
                         meta_prefs_get_auto_raise_delay (),
                         window_raise_with_delay_callback,
@@ -1402,7 +1402,7 @@ handle_net_restack_window (MetaDisplay* display,
         case TopIf:
         case BottomIf:
         case Opposite:
-          break;          
+          break;
         }
     }
 }
@@ -1421,7 +1421,7 @@ handle_net_restack_window (MetaDisplay* display,
  * To reduce the amount of code, the only events fields filled out
  * below are the ones that frames.c uses. If frames.c is modified to
  * use more fields, more fields need to be filled out below.
- * 
+ *
  * https://github.com/stefano-k/Mate-Desktop-Environment/commit/b0e5fb03eb21dae8f02692f11ef391bfc5ccba33
  */
 
@@ -1610,7 +1610,7 @@ static gboolean event_callback(XEvent* event, gpointer data)
   gboolean filter_out_event;
 
   display = data;
-  
+
 #ifdef WITH_VERBOSE_MODE
   if (dump_events)
     meta_spew_event (display, event);
@@ -1619,13 +1619,13 @@ static gboolean event_callback(XEvent* event, gpointer data)
 #ifdef HAVE_STARTUP_NOTIFICATION
   sn_display_process_event (display->sn_display, event);
 #endif
-  
+
   filter_out_event = FALSE;
   display->current_time = event_get_time (display, event);
   display->xinerama_cache_invalidated = TRUE;
-  
+
   modified = event_get_modified_window (display, event);
-  
+
   if (event->type == ButtonPress)
     {
       /* filter out scrollwheel */
@@ -1669,7 +1669,7 @@ static gboolean event_callback(XEvent* event, gpointer data)
       property_for_window = window;
       window = NULL;
     }
-    
+
 
   frame_was_receiver = FALSE;
   if (window &&
@@ -1686,12 +1686,12 @@ static gboolean event_callback(XEvent* event, gpointer data)
     }
 
 #ifdef HAVE_XSYNC
-  if (META_DISPLAY_HAS_XSYNC (display) && 
+  if (META_DISPLAY_HAS_XSYNC (display) &&
       event->type == (display->xsync_event_base + XSyncAlarmNotify) &&
       ((XSyncAlarmNotifyEvent*)event)->alarm == display->grab_sync_request_alarm)
     {
       filter_out_event = TRUE; /* GTK doesn't want to see this really */
-      
+
       if (display->grab_op != META_GRAB_OP_NONE &&
           display->grab_window != NULL &&
           grab_op_is_mouse (display->grab_op))
@@ -1700,11 +1700,11 @@ static gboolean event_callback(XEvent* event, gpointer data)
 #endif /* HAVE_XSYNC */
 
 #ifdef HAVE_SHAPE
-  if (META_DISPLAY_HAS_SHAPE (display) && 
+  if (META_DISPLAY_HAS_SHAPE (display) &&
       event->type == (display->shape_event_base + ShapeNotify))
     {
       filter_out_event = TRUE; /* GTK doesn't want to see this really */
-      
+
       if (window && !frame_was_receiver)
         {
           XShapeEvent *sev = (XShapeEvent*) event;
@@ -1713,7 +1713,7 @@ static gboolean event_callback(XEvent* event, gpointer data)
             {
               if (sev->shaped && !window->has_shape)
                 {
-                  window->has_shape = TRUE;                  
+                  window->has_shape = TRUE;
                   meta_topic (META_DEBUG_SHAPES,
                               "Window %s now has a shape\n",
                               window->desc);
@@ -1735,7 +1735,7 @@ static gboolean event_callback(XEvent* event, gpointer data)
               if (window->frame)
                 {
                   window->frame->need_reapply_frame_shape = TRUE;
-		  meta_warning("from event callback\n");		  
+		  meta_warning("from event callback\n");
                   meta_window_queue (window, META_QUEUE_MOVE_RESIZE);
                 }
             }
@@ -1768,7 +1768,7 @@ static gboolean event_callback(XEvent* event, gpointer data)
           sanity_check_timestamps (display, display->current_time);
         }
     }
-  
+
   switch (event->type)
     {
     case KeyPress:
@@ -1786,14 +1786,14 @@ static gboolean event_callback(XEvent* event, gpointer data)
                       "Ending grab op %u on window %s due to button press\n",
                       display->grab_op,
                       (display->grab_window ?
-                       display->grab_window->desc : 
+                       display->grab_window->desc :
                        "none"));
           if (GRAB_OP_IS_WINDOW_SWITCH (display->grab_op))
             {
               MetaScreen *screen;
-              meta_topic (META_DEBUG_WINDOW_OPS, 
+              meta_topic (META_DEBUG_WINDOW_OPS,
                           "Syncing to old stack positions.\n");
-              screen = 
+              screen =
                 meta_display_screen_for_root (display, event->xany.window);
 
               if (screen!=NULL)
@@ -1819,7 +1819,7 @@ static gboolean event_callback(XEvent* event, gpointer data)
            * button 1.  So for all such events we focus the window.
            */
           unmodified = (event->xbutton.state & grab_mask) == 0;
-          
+
           if (unmodified ||
               event->xbutton.button == 1)
             {
@@ -1829,7 +1829,7 @@ static gboolean event_callback(XEvent* event, gpointer data)
                */
               if (!frame_was_receiver)
                 {
-                  if (meta_prefs_get_raise_on_click ()) 
+                  if (meta_prefs_get_raise_on_click ())
                     meta_window_raise (window);
                   else
                     meta_topic (META_DEBUG_FOCUS,
@@ -1851,7 +1851,7 @@ static gboolean event_callback(XEvent* event, gpointer data)
                      */
                     display->allow_terminal_deactivation = TRUE;
                 }
-              
+
               /* you can move on alt-click but not on
                * the click-to-focus
                */
@@ -1892,7 +1892,7 @@ static gboolean event_callback(XEvent* event, gpointer data)
                     op = META_GRAB_OP_RESIZING_S;
                   else /* Middle region is no-op to avoid user triggering wrong action */
                     op = META_GRAB_OP_NONE;
-                  
+
                   if (op != META_GRAB_OP_NONE)
                     meta_display_begin_grab_op (display,
                                                 window->screen,
@@ -1924,7 +1924,7 @@ static gboolean event_callback(XEvent* event, gpointer data)
                * it has no modifiers and was on the client window
                */
               int mode;
-              
+
               /* When clicking a different app in click-to-focus
                * in application-based mode, and the different
                * app is not a dock or desktop, eat the focus click.
@@ -1944,7 +1944,7 @@ static gboolean event_callback(XEvent* event, gpointer data)
               meta_verbose ("Allowing events mode %s time %u\n",
                             mode == AsyncPointer ? "AsyncPointer" : "ReplayPointer",
                             (unsigned int)event->xbutton.time);
-              
+
               XAllowEvents (display->xdisplay,
                             mode, event->xbutton.time);
             }
@@ -1988,11 +1988,11 @@ static gboolean event_callback(XEvent* event, gpointer data)
        * actually appear on the right screen.
        */
       {
-        MetaScreen *new_screen = 
+        MetaScreen *new_screen =
           meta_display_screen_for_root (display, event->xcrossing.root);
 
         if (new_screen != NULL && display->active_screen != new_screen)
-          meta_workspace_focus_default_window (new_screen->active_workspace, 
+          meta_workspace_focus_default_window (new_screen->active_workspace,
                                                NULL,
                                                event->xcrossing.time);
       }
@@ -2001,7 +2001,7 @@ static gboolean event_callback(XEvent* event, gpointer data)
        * avoid races.
        */
       if (window && !serial_is_ignored (display, event->xany.serial) &&
-               event->xcrossing.mode != NotifyGrab && 
+               event->xcrossing.mode != NotifyGrab &&
                event->xcrossing.mode != NotifyUngrab &&
                event->xcrossing.detail != NotifyInferior &&
                meta_display_focus_sentinel_clear (display))
@@ -2018,7 +2018,7 @@ static gboolean event_callback(XEvent* event, gpointer data)
                               "Focusing %s due to enter notify with serial %lu "
                               "at time %lu, and setting display->mouse_mode to "
                               "TRUE.\n",
-                              window->desc, 
+                              window->desc,
                               event->xany.serial,
                               event->xcrossing.time);
 
@@ -2026,15 +2026,15 @@ static gboolean event_callback(XEvent* event, gpointer data)
 
                   /* stop ignoring stuff */
                   reset_ignores (display);
-                  
-                  if (meta_prefs_get_auto_raise ()) 
+
+                  if (meta_prefs_get_auto_raise ())
                     {
                       meta_display_queue_autoraise_callback (display, window);
                     }
                   else
                     {
                       meta_topic (META_DEBUG_FOCUS,
-                                  "Auto raise is disabled\n");		      
+                                  "Auto raise is disabled\n");
                     }
                 }
               /* In mouse focus mode, we defocus when the mouse *enters*
@@ -2054,7 +2054,7 @@ static gboolean event_callback(XEvent* event, gpointer data)
                               "Unsetting focus from %s due to mouse entering "
                               "the DESKTOP window\n",
                               display->expected_focus_window->desc);
-                  meta_display_focus_the_no_focus_window (display, 
+                  meta_display_focus_the_no_focus_window (display,
                                                           window->screen,
                                                           event->xcrossing.time);
                 }
@@ -2062,7 +2062,7 @@ static gboolean event_callback(XEvent* event, gpointer data)
             case META_FOCUS_MODE_CLICK:
               break;
             }
-          
+
           if (window->type == META_WINDOW_DOCK)
             meta_window_raise (window);
         }
@@ -2116,11 +2116,11 @@ static gboolean event_callback(XEvent* event, gpointer data)
                       event->xany.window,
                       meta_event_mode_to_string (event->xfocus.mode),
                       meta_event_detail_to_string (event->xfocus.detail));
-          
+
           if (event->type == FocusIn &&
               event->xfocus.detail == NotifyDetailNone)
             {
-              meta_topic (META_DEBUG_FOCUS, 
+              meta_topic (META_DEBUG_FOCUS,
                           "Focus got set to None, probably due to "
                           "brain-damage in the X protocol (see bug "
                           "125492).  Setting the default focus window.\n");
@@ -2155,7 +2155,7 @@ static gboolean event_callback(XEvent* event, gpointer data)
       break;
     case CreateNotify:
       break;
-      
+
     case DestroyNotify:
       if (window)
         {
@@ -2169,7 +2169,7 @@ static gboolean event_callback(XEvent* event, gpointer data)
           if (display->grab_op != META_GRAB_OP_NONE &&
               display->grab_window == window)
             meta_display_end_grab_op (display, timestamp);
-          
+
           if (frame_was_receiver)
             {
               meta_warning ("Unexpected destruction of frame 0x%lx, not sure if this should silently fail or be considered a bug\n",
@@ -2200,7 +2200,7 @@ static gboolean event_callback(XEvent* event, gpointer data)
               display->grab_window == window &&
               ((window->frame == NULL) || !window->frame->mapped))
             meta_display_end_grab_op (display, timestamp);
-      
+
           if (!frame_was_receiver)
             {
               if (window->unmaps_pending == 0)
@@ -2211,7 +2211,7 @@ static gboolean event_callback(XEvent* event, gpointer data)
 
                   meta_effect_run_close (window, NULL, NULL);
 
-                  /* Unmanage withdrawn window */		  
+                  /* Unmanage withdrawn window */
                   window->withdrawn = TRUE;
                   meta_window_free (window, timestamp);
                   window = NULL;
@@ -2242,7 +2242,7 @@ static gboolean event_callback(XEvent* event, gpointer data)
                                     FALSE);
         }
       /* if frame was receiver it's some malicious send event or something */
-      else if (!frame_was_receiver && window)        
+      else if (!frame_was_receiver && window)
         {
           meta_verbose ("MapRequest on %s mapped = %d minimized = %d\n",
                         window->desc, window->mapped, window->minimized);
@@ -2279,8 +2279,8 @@ static gboolean event_callback(XEvent* event, gpointer data)
             screen->xscreen->width   = event->xconfigure.width;
             screen->xscreen->height  = event->xconfigure.height;
 #endif
-            
-            meta_screen_resize (screen, 
+
+            meta_screen_resize (screen,
                                 event->xconfigure.width,
                                 event->xconfigure.height);
           }
@@ -2298,7 +2298,7 @@ static gboolean event_callback(XEvent* event, gpointer data)
         {
           unsigned int xwcm;
           XWindowChanges xwc;
-          
+
           xwcm = event->xconfigurerequest.value_mask &
             (CWX | CWY | CWWidth | CWHeight | CWBorderWidth);
 
@@ -2333,7 +2333,7 @@ static gboolean event_callback(XEvent* event, gpointer data)
       {
         MetaGroup *group;
         MetaScreen *screen;
-        
+
         if (window && !frame_was_receiver)
           meta_window_property_notify (window, event);
         else if (property_for_window && !frame_was_receiver)
@@ -2343,13 +2343,13 @@ static gboolean event_callback(XEvent* event, gpointer data)
                                            event->xproperty.window);
         if (group != NULL)
           meta_group_property_notify (group, event);
-        
+
         screen = NULL;
         if (window == NULL &&
             group == NULL) /* window/group != NULL means it wasn't a root window */
           screen = meta_display_screen_for_root (display,
                                                  event->xproperty.window);
-            
+
         if (screen != NULL)
           {
             if (event->xproperty.atom ==
@@ -2412,7 +2412,7 @@ static gboolean event_callback(XEvent* event, gpointer data)
 
           screen = meta_display_screen_for_root (display,
                                                  event->xclient.window);
-          
+
           if (screen)
             {
               if (event->xclient.message_type ==
@@ -2421,10 +2421,10 @@ static gboolean event_callback(XEvent* event, gpointer data)
                   int space;
                   MetaWorkspace *workspace;
                   guint32 time;
-              
+
                   space = event->xclient.data.l[0];
                   time = event->xclient.data.l[1];
-              
+
                   meta_verbose ("Request to change current workspace to %d with "
                                 "specified timestamp of %u\n",
                                 space, time);
@@ -2451,9 +2451,9 @@ static gboolean event_callback(XEvent* event, gpointer data)
                        display->atom__NET_NUMBER_OF_DESKTOPS)
                 {
                   int num_spaces;
-              
+
                   num_spaces = event->xclient.data.l[0];
-              
+
                   meta_verbose ("Request to set number of workspaces to %d\n",
                                 num_spaces);
 
@@ -2464,13 +2464,13 @@ static gboolean event_callback(XEvent* event, gpointer data)
                 {
                   gboolean showing_desktop;
                   guint32  timestamp;
-                  
+
                   showing_desktop = event->xclient.data.l[0] != 0;
                   /* FIXME: Braindead protocol doesn't have a timestamp */
                   timestamp = meta_display_get_current_time_roundtrip (display);
                   meta_verbose ("Request to %s desktop\n",
                                 showing_desktop ? "show" : "hide");
-                  
+
                   if (showing_desktop)
                     meta_screen_show_desktop (screen, timestamp);
                   else
@@ -2507,10 +2507,10 @@ static gboolean event_callback(XEvent* event, gpointer data)
                   meta_set_verbose (!meta_is_verbose ());
                 }
 	      else if (event->xclient.message_type ==
-		       display->atom_WM_PROTOCOLS) 
+		       display->atom_WM_PROTOCOLS)
 		{
                   meta_verbose ("Received WM_PROTOCOLS message\n");
-                  
+
 		  if ((Atom)event->xclient.data.l[0] == display->atom__NET_WM_PING)
                     {
                       process_pong_message (display, event);
@@ -2537,7 +2537,7 @@ static gboolean event_callback(XEvent* event, gpointer data)
         gboolean ignore_current;
 
         ignore_current = FALSE;
-        
+
         /* Check whether the next event is an identical MappingNotify
          * event.  If it is, ignore the current event, we'll update
          * when we get the next one.
@@ -2545,9 +2545,9 @@ static gboolean event_callback(XEvent* event, gpointer data)
 	if (XPending (display->xdisplay))
           {
             XEvent next_event;
-            
+
             XPeekEvent (display->xdisplay, &next_event);
-            
+
             if (next_event.type == MappingNotify &&
                 next_event.xmapping.request == event->xmapping.request)
               ignore_current = TRUE;
@@ -2564,10 +2564,10 @@ static gboolean event_callback(XEvent* event, gpointer data)
       break;
     default:
 #ifdef HAVE_XKB
-      if (event->type == display->xkb_base_event_type) 
+      if (event->type == display->xkb_base_event_type)
 	{
 	  XkbAnyEvent *xkb_ev = (XkbAnyEvent *) event;
-	  
+
 	  switch (xkb_ev->xkb_type)
 	    {
 	    case XkbBellNotify:
@@ -2588,7 +2588,7 @@ static gboolean event_callback(XEvent* event, gpointer data)
 	{
 		meta_compositor_process_event (display->compositor, event, window);
 	}
-  
+
 	/* generates event on wrong window.
   	 * https://github.com/stefano-k/Mate-Desktop-Environment/commit/b0e5fb03eb21dae8f02692f11ef391bfc5ccba33
   	 */
@@ -2633,10 +2633,10 @@ event_get_modified_window (MetaDisplay *display,
     case EnterNotify:
     case LeaveNotify:
       return event->xany.window;
-      
+
     case CreateNotify:
       return event->xcreatewindow.window;
-      
+
     case DestroyNotify:
       return event->xdestroywindow.window;
 
@@ -2651,10 +2651,10 @@ event_get_modified_window (MetaDisplay *display,
 
     case ReparentNotify:
      return event->xreparent.window;
-      
+
     case ConfigureNotify:
       return event->xconfigure.window;
-      
+
     case ConfigureRequest:
       return event->xconfigurerequest.window;
 
@@ -2672,7 +2672,7 @@ event_get_modified_window (MetaDisplay *display,
 
     default:
 #ifdef HAVE_SHAPE
-      if (META_DISPLAY_HAS_SHAPE (display) && 
+      if (META_DISPLAY_HAS_SHAPE (display) &&
           event->type == (display->shape_event_base + ShapeNotify))
         {
           XShapeEvent *sev = (XShapeEvent*) event;
@@ -2693,11 +2693,11 @@ event_get_time (MetaDisplay *display,
     case KeyPress:
     case KeyRelease:
       return event->xkey.time;
-      
+
     case ButtonPress:
     case ButtonRelease:
       return event->xbutton.time;
-      
+
     case MotionNotify:
       return event->xmotion.time;
 
@@ -2715,7 +2715,7 @@ event_get_time (MetaDisplay *display,
 
     case FocusIn:
     case FocusOut:
-    case KeymapNotify:      
+    case KeymapNotify:
     case Expose:
     case GraphicsExpose:
     case NoExpose:
@@ -2824,7 +2824,7 @@ stack_mode_to_string (int mode)
     case BottomIf:
       return "BottomIf";
     case Opposite:
-      return "Opposite";      
+      return "Opposite";
     }
 
   return "Unknown";
@@ -2838,12 +2838,12 @@ key_event_description (Display *xdisplay,
 {
   KeySym keysym;
   const char *str;
-  
-  keysym = XKeycodeToKeysym (xdisplay, event->xkey.keycode, 0);  
+
+  keysym = XKeycodeToKeysym (xdisplay, event->xkey.keycode, 0);
 
   str = XKeysymToString (keysym);
-  
-  return g_strdup_printf ("Key '%s' state 0x%x", 
+
+  return g_strdup_printf ("Key '%s' state 0x%x",
                           str ? str : "none", event->xkey.state);
 }
 #endif /* WITH_VERBOSE_MODE */
@@ -2857,7 +2857,7 @@ sync_value_to_64 (const XSyncValue *value)
 
   v = XSyncValueLow32 (*value);
   v |= (((gint64)XSyncValueHigh32 (*value)) << 32);
-  
+
   return v;
 }
 #endif /* WITH_VERBOSE_MODE */
@@ -2894,12 +2894,12 @@ meta_spew_event (MetaDisplay *display,
 
   if (!meta_is_verbose())
     return;
-  
+
   /* filter overnumerous events */
   if (event->type == Expose || event->type == MotionNotify ||
       event->type == NoExpose)
     return;
-      
+
   switch (event->type)
     {
     case KeyPress:
@@ -3083,9 +3083,9 @@ meta_spew_event (MetaDisplay *display,
       {
         char *str;
         const char *state;
-            
+
         name = "PropertyNotify";
-            
+
         meta_error_trap_push (display);
         str = XGetAtomName (display->xdisplay,
                             event->xproperty.atom);
@@ -3097,7 +3097,7 @@ meta_spew_event (MetaDisplay *display,
           state = "PropertyDelete";
         else
           state = "???";
-            
+
         extra = g_strdup_printf ("atom: %s state: %s",
                                  str ? str : "(unknown atom)",
                                  state);
@@ -3135,11 +3135,11 @@ meta_spew_event (MetaDisplay *display,
       break;
     default:
 #ifdef HAVE_XSYNC
-      if (META_DISPLAY_HAS_XSYNC (display) && 
+      if (META_DISPLAY_HAS_XSYNC (display) &&
           event->type == (display->xsync_event_base + XSyncAlarmNotify))
         {
           XSyncAlarmNotifyEvent *aevent = (XSyncAlarmNotifyEvent*) event;
-          
+
           name = "XSyncAlarmNotify";
           extra =
             g_strdup_printf ("alarm: 0x%lx"
@@ -3155,7 +3155,7 @@ meta_spew_event (MetaDisplay *display,
       else
 #endif /* HAVE_XSYNC */
 #ifdef HAVE_SHAPE
-        if (META_DISPLAY_HAS_SHAPE (display) && 
+        if (META_DISPLAY_HAS_SHAPE (display) &&
             event->type == (display->shape_event_base + ShapeNotify))
           {
             XShapeEvent *sev = (XShapeEvent*) event;
@@ -3174,7 +3174,7 @@ meta_spew_event (MetaDisplay *display,
                                sev->shaped);
           }
         else
-#endif /* HAVE_SHAPE */      
+#endif /* HAVE_SHAPE */
         {
           name = "(Unknown event)";
           extra = g_strdup_printf ("type: %d", event->xany.type);
@@ -3183,12 +3183,12 @@ meta_spew_event (MetaDisplay *display,
     }
 
   screen = meta_display_screen_for_root (display, event->xany.window);
-      
+
   if (screen)
     winname = g_strdup_printf ("root %d", screen->number);
   else
     winname = g_strdup_printf ("0x%lx", event->xany.window);
-      
+
   meta_topic (META_DEBUG_EVENTS,
               "%s on %s%s %s %sserial %lu\n", name, winname,
               extra ? ":" : "", extra ? extra : "",
@@ -3215,7 +3215,7 @@ meta_display_register_x_window (MetaDisplay *display,
                                 MetaWindow  *window)
 {
   g_return_if_fail (g_hash_table_lookup (display->window_ids, xwindowp) == NULL);
-  
+
   g_hash_table_insert (display->window_ids, xwindowp, window);
 }
 
@@ -3291,13 +3291,13 @@ meta_display_create_x_cursor (MetaDisplay *display,
     case META_CURSOR_BUSY:
       glyph = XC_watch;
       break;
-      
+
     default:
       g_assert_not_reached ();
       glyph = 0; /* silence compiler */
       break;
     }
-  
+
   xcursor = XCreateFontCursor (display->xdisplay, glyph);
 
   return xcursor;
@@ -3308,7 +3308,7 @@ xcursor_for_op (MetaDisplay *display,
                 MetaGrabOp   op)
 {
   MetaCursor cursor = META_CURSOR_DEFAULT;
-  
+
   switch (op)
     {
     case META_GRAB_OP_RESIZING_SE:
@@ -3348,7 +3348,7 @@ xcursor_for_op (MetaDisplay *display,
     case META_GRAB_OP_KEYBOARD_RESIZING_UNKNOWN:
       cursor = META_CURSOR_MOVE_OR_RESIZE_WINDOW;
       break;
-      
+
     default:
       break;
     }
@@ -3422,7 +3422,7 @@ meta_display_set_grab_op_cursor (MetaDisplay *display,
     }
 
 #undef GRAB_MASK
-  
+
   if (cursor != None)
     XFreeCursor (display->xdisplay, cursor);
 }
@@ -3441,7 +3441,7 @@ meta_display_begin_grab_op (MetaDisplay *display,
                             int          root_y)
 {
   Window grab_xwindow;
-  
+
   if (grab_op_is_mouse (op) && meta_grab_op_is_moving (op))
     {
       if (display->compositor)
@@ -3451,12 +3451,12 @@ meta_display_begin_grab_op (MetaDisplay *display,
 				      root_x, root_y);
 	}
     }
-  
+
   meta_topic (META_DEBUG_WINDOW_OPS,
               "Doing grab op %u on window %s button %d pointer already grabbed: %d pointer pos %d,%d\n",
               op, window ? window->desc : "none", button, pointer_already_grabbed,
               root_x, root_y);
-  
+
   if (display->grab_op != META_GRAB_OP_NONE)
     {
       if (window)
@@ -3491,10 +3491,10 @@ meta_display_begin_grab_op (MetaDisplay *display,
     grab_xwindow = screen->xroot;
 
   display->grab_have_pointer = FALSE;
-  
+
   if (pointer_already_grabbed)
     display->grab_have_pointer = TRUE;
-  
+
   meta_display_set_grab_op_cursor (display, screen, op, FALSE, grab_xwindow,
                                    timestamp);
 
@@ -3515,7 +3515,7 @@ meta_display_begin_grab_op (MetaDisplay *display,
       else
         display->grab_have_keyboard =
                      meta_screen_grab_all_keys (screen, timestamp);
-      
+
       if (!display->grab_have_keyboard)
         {
           meta_topic (META_DEBUG_WINDOW_OPS,
@@ -3525,7 +3525,7 @@ meta_display_begin_grab_op (MetaDisplay *display,
           return FALSE;
         }
     }
-  
+
   display->grab_op = op;
   display->grab_window = window;
   display->grab_screen = screen;
@@ -3552,7 +3552,7 @@ meta_display_begin_grab_op (MetaDisplay *display,
       g_source_remove (display->grab_resize_timeout_id);
       display->grab_resize_timeout_id = 0;
     }
-	
+
   if (display->grab_window)
     {
       meta_window_get_client_root_coords (display->grab_window,
@@ -3560,16 +3560,16 @@ meta_display_begin_grab_op (MetaDisplay *display,
       display->grab_anchor_window_pos = display->grab_initial_window_pos;
 
       display->grab_wireframe_active =
-        (meta_prefs_get_reduced_resources () && !meta_prefs_get_mate_accessibility ())  && 
+        (meta_prefs_get_reduced_resources () && !meta_prefs_get_mate_accessibility ())  &&
         (meta_grab_op_is_resizing (display->grab_op) ||
          meta_grab_op_is_moving (display->grab_op));
-      
+
       if (display->grab_wireframe_active)
         {
           meta_window_calc_showing (display->grab_window);
           meta_window_begin_wireframe (window);
         }
-      
+
 #ifdef HAVE_XSYNC
       if (!display->grab_wireframe_active &&
           meta_grab_op_is_resizing (display->grab_op) &&
@@ -3584,29 +3584,29 @@ meta_display_begin_grab_op (MetaDisplay *display,
 	   * responses to the client messages will always trigger
 	   * a PositiveTransition
 	   */
-	  
+
 	  XSyncIntToValue (&init, 0);
 	  XSyncSetCounter (display->xdisplay,
 			   display->grab_window->sync_request_counter, init);
-	  
+
 	  display->grab_window->sync_request_serial = 0;
 	  display->grab_window->sync_request_time.tv_sec = 0;
 	  display->grab_window->sync_request_time.tv_usec = 0;
-	  
+
           values.trigger.counter = display->grab_window->sync_request_counter;
           values.trigger.value_type = XSyncAbsolute;
           values.trigger.test_type = XSyncPositiveTransition;
           XSyncIntToValue (&values.trigger.wait_value,
 			   display->grab_window->sync_request_serial + 1);
-	  
+
           /* After triggering, increment test_value by this.
            * (NOT wait_value above)
            */
           XSyncIntToValue (&values.delta, 1);
-	  
+
           /* we want events (on by default anyway) */
           values.events = True;
-          
+
           display->grab_sync_request_alarm = XSyncCreateAlarm (display->xdisplay,
                                                          XSyncCACounter |
                                                          XSyncCAValueType |
@@ -3625,7 +3625,7 @@ meta_display_begin_grab_op (MetaDisplay *display,
         }
 #endif
     }
-  
+
   meta_topic (META_DEBUG_WINDOW_OPS,
               "Grab op %u on window %s successful\n",
               display->grab_op, window ? window->desc : "(null)");
@@ -3636,7 +3636,7 @@ meta_display_begin_grab_op (MetaDisplay *display,
   /* If this is a move or resize, cache the window edges for
    * resistance/snapping
    */
-  if (meta_grab_op_is_resizing (display->grab_op) || 
+  if (meta_grab_op_is_resizing (display->grab_op) ||
       meta_grab_op_is_moving (display->grab_op))
     {
       meta_topic (META_DEBUG_WINDOW_OPS,
@@ -3651,7 +3651,7 @@ meta_display_begin_grab_op (MetaDisplay *display,
       meta_topic (META_DEBUG_WINDOW_OPS,
                   "Saving old stack positions; old pointer was %p.\n",
                   display->grab_old_window_stacking);
-      display->grab_old_window_stacking = 
+      display->grab_old_window_stacking =
         meta_stack_get_positions (screen->stack);
     }
 
@@ -3699,7 +3699,7 @@ meta_display_begin_grab_op (MetaDisplay *display,
       meta_screen_ensure_tab_popup (screen,
                                     META_TAB_LIST_GROUP,
                                     META_TAB_SHOW_INSTANTLY);
-      
+
     case META_GRAB_OP_KEYBOARD_WORKSPACE_SWITCHING:
       meta_screen_ensure_workspace_popup (screen);
       break;
@@ -3712,7 +3712,7 @@ meta_display_begin_grab_op (MetaDisplay *display,
     {
       meta_window_refresh_resize_popup (display->grab_window);
     }
-  
+
   return TRUE;
 }
 
@@ -3722,13 +3722,13 @@ meta_display_end_grab_op (MetaDisplay *display,
 {
   meta_topic (META_DEBUG_WINDOW_OPS,
               "Ending grab op %u at time %u\n", display->grab_op, timestamp);
-  
+
   if (display->grab_op == META_GRAB_OP_NONE)
     return;
 
   if (display->grab_window != NULL)
     display->grab_window->shaken_loose = FALSE;
-  
+
   if (display->grab_window != NULL &&
       !meta_prefs_get_raise_on_click () &&
       (meta_grab_op_is_moving (display->grab_op) ||
@@ -3755,9 +3755,9 @@ meta_display_end_grab_op (MetaDisplay *display,
        */
       display->ungrab_should_not_cause_focus_window = display->grab_xwindow;
     }
-  
+
   /* If this was a move or resize clear out the edge cache */
-  if (meta_grab_op_is_resizing (display->grab_op) || 
+  if (meta_grab_op_is_resizing (display->grab_op) ||
       meta_grab_op_is_moving (display->grab_op))
     {
       meta_topic (META_DEBUG_WINDOW_OPS,
@@ -3798,13 +3798,13 @@ meta_display_end_grab_op (MetaDisplay *display,
 
   if (display->compositor &&
       display->grab_window &&
-      grab_op_is_mouse (display->grab_op) && 
+      grab_op_is_mouse (display->grab_op) &&
       meta_grab_op_is_moving (display->grab_op))
     {
       meta_compositor_end_move (display->compositor,
 				display->grab_window);
     }
-  
+
   if (display->grab_have_pointer)
     {
       meta_topic (META_DEBUG_WINDOW_OPS,
@@ -3830,7 +3830,7 @@ meta_display_end_grab_op (MetaDisplay *display,
       display->grab_sync_request_alarm = None;
     }
 #endif /* HAVE_XSYNC */
-  
+
   display->grab_window = NULL;
   display->grab_screen = NULL;
   display->grab_xwindow = None;
@@ -3878,9 +3878,9 @@ meta_change_button_grab (MetaDisplay *display,
                 grab ? "Grabbing" : "Ungrabbing",
                 xwindow,
                 sync, button, modmask);
-  
+
   meta_error_trap_push (display);
-  
+
   ignored_mask = 0;
   while (ignored_mask <= display->ignored_modifier_mask)
     {
@@ -3897,11 +3897,11 @@ meta_change_button_grab (MetaDisplay *display,
         meta_error_trap_push_with_return (display);
 
       /* GrabModeSync means freeze until XAllowEvents */
-      
+
       if (grab)
         XGrabButton (display->xdisplay, button, modmask | ignored_mask,
                      xwindow, False,
-                     ButtonPressMask | ButtonReleaseMask |    
+                     ButtonPressMask | ButtonReleaseMask |
                      PointerMotionMask | PointerMotionHintMask,
                      sync ? GrabModeSync : GrabModeAsync,
                      GrabModeAsync,
@@ -3913,15 +3913,15 @@ meta_change_button_grab (MetaDisplay *display,
       if (meta_is_debugging ())
         {
           int result;
-          
+
           result = meta_error_trap_pop_with_return (display, FALSE);
-          
+
           if (result != Success)
             meta_verbose ("Failed to %s button %d with mask 0x%x for window 0x%lx error code %d\n",
                           grab ? "grab" : "ungrab",
                           button, modmask | ignored_mask, xwindow, result);
         }
-      
+
       ++ignored_mask;
     }
 
@@ -3931,14 +3931,14 @@ meta_change_button_grab (MetaDisplay *display,
 void
 meta_display_grab_window_buttons (MetaDisplay *display,
                                   Window       xwindow)
-{  
+{
   /* Grab Alt + button1 for moving window.
    * Grab Alt + button2 for resizing window.
    * Grab Alt + button3 for popping up window menu.
    * Grab Alt + Shift + button1 for snap-moving window.
    */
   meta_verbose ("Grabbing window buttons for 0x%lx\n", xwindow);
-  
+
   /* FIXME If we ignored errors here instead of spewing, we could
    * put one big error trap around the loop and avoid a bunch of
    * XSync()
@@ -3953,8 +3953,8 @@ meta_display_grab_window_buttons (MetaDisplay *display,
           meta_change_button_grab (display, xwindow,
                                    TRUE,
                                    FALSE,
-                                   i, display->window_grab_modifiers);  
-          
+                                   i, display->window_grab_modifiers);
+
           /* This is for debugging, since I end up moving the Xnest
            * otherwise ;-)
            */
@@ -3987,7 +3987,7 @@ meta_display_ungrab_window_buttons  (MetaDisplay *display,
 
   if (display->window_grab_modifiers == 0)
     return;
-  
+
   debug = g_getenv ("MARCO_DEBUG_BUTTON_GRABS") != NULL;
   i = 1;
   while (i < 4)
@@ -3995,11 +3995,11 @@ meta_display_ungrab_window_buttons  (MetaDisplay *display,
       meta_change_button_grab (display, xwindow,
                                FALSE, FALSE, i,
                                display->window_grab_modifiers);
-      
+
       if (debug)
         meta_change_button_grab (display, xwindow,
                                  FALSE, FALSE, i, ControlMask);
-      
+
       ++i;
     }
 }
@@ -4027,18 +4027,18 @@ meta_display_grab_focus_window_button (MetaDisplay *display,
       return;
     }
 #endif
-  
+
   if (window->have_focus_click_grab)
     {
       meta_verbose (" (well, not grabbing since we already have the grab)\n");
       return;
     }
-  
+
   /* FIXME If we ignored errors here instead of spewing, we could
    * put one big error trap around the loop and avoid a bunch of
    * XSync()
    */
-  
+
   {
     int i = 1;
     while (i < MAX_FOCUS_BUTTON)
@@ -4047,7 +4047,7 @@ meta_display_grab_focus_window_button (MetaDisplay *display,
                                  window->xwindow,
                                  TRUE, TRUE,
                                  i, 0);
-        
+
         ++i;
       }
 
@@ -4063,14 +4063,14 @@ meta_display_ungrab_focus_window_button (MetaDisplay *display,
 
   if (!window->have_focus_click_grab)
     return;
-  
+
   {
     int i = 1;
     while (i < MAX_FOCUS_BUTTON)
       {
         meta_change_button_grab (display, window->xwindow,
                                  FALSE, FALSE, i, 0);
-        
+
         ++i;
       }
 
@@ -4090,19 +4090,19 @@ void
 meta_display_update_active_window_hint (MetaDisplay *display)
 {
   GSList *tmp;
-  
+
   gulong data[1];
 
   if (display->focus_window)
     data[0] = display->focus_window->xwindow;
   else
     data[0] = None;
-  
+
   tmp = display->screens;
   while (tmp != NULL)
     {
       MetaScreen *screen = tmp->data;
-      
+
       meta_error_trap_push (display);
       XChangeProperty (display->xdisplay, screen->xroot,
                        display->atom__NET_ACTIVE_WINDOW,
@@ -4126,15 +4126,15 @@ meta_display_queue_retheme_all_windows (MetaDisplay *display)
   while (tmp != NULL)
     {
       MetaWindow *window = tmp->data;
-      
+
       meta_window_queue (window, META_QUEUE_MOVE_RESIZE);
       if (window->frame)
         {
           window->frame->need_reapply_frame_shape = TRUE;
-          
+
           meta_frame_queue_draw (window->frame);
         }
-      
+
       tmp = tmp->next;
     }
 
@@ -4147,11 +4147,11 @@ meta_display_retheme_all (void)
   meta_display_queue_retheme_all_windows (meta_get_display ());
 }
 
-void 
-meta_display_set_cursor_theme (const char *theme, 
+void
+meta_display_set_cursor_theme (const char *theme,
 			       int         size)
 {
-#ifdef HAVE_XCURSOR     
+#ifdef HAVE_XCURSOR
   GSList *tmp;
 
   MetaDisplay *display = meta_get_display ();
@@ -4163,7 +4163,7 @@ meta_display_set_cursor_theme (const char *theme,
   while (tmp != NULL)
     {
       MetaScreen *screen = tmp->data;
-	  	  
+
       meta_screen_update_cursor (screen);
 
       tmp = tmp->next;
@@ -4244,7 +4244,7 @@ meta_display_ping_timeout (gpointer data)
   meta_topic (META_DEBUG_PING,
               "Ping %u on window %lx timed out\n",
               ping_data->timestamp, ping_data->xwindow);
-  
+
   (* ping_data->ping_timeout_func) (ping_data->display, ping_data->xwindow,
                                     ping_data->timestamp, ping_data->user_data);
 
@@ -4252,7 +4252,7 @@ meta_display_ping_timeout (gpointer data)
     g_slist_remove (ping_data->display->pending_pings,
                     ping_data);
   ping_data_free (ping_data);
-  
+
   return FALSE;
 }
 
@@ -4304,7 +4304,7 @@ meta_display_ping_window (MetaDisplay       *display,
 
       return;
     }
-  
+
   ping_data = g_new (MetaPingData, 1);
   ping_data->display = display;
   ping_data->xwindow = window->xwindow;
@@ -4315,7 +4315,7 @@ meta_display_ping_window (MetaDisplay       *display,
   ping_data->ping_timeout_id = g_timeout_add (PING_TIMEOUT_DELAY,
 					      meta_display_ping_timeout,
 					      ping_data);
-  
+
   display->pending_pings = g_slist_prepend (display->pending_pings, ping_data);
 
   meta_topic (META_DEBUG_PING,
@@ -4415,15 +4415,15 @@ process_pong_message (MetaDisplay    *display,
 
   meta_topic (META_DEBUG_PING, "Received a pong with timestamp %u\n",
               timestamp);
-  
+
   for (tmp = display->pending_pings; tmp; tmp = tmp->next)
     {
       MetaPingData *ping_data = tmp->data;
-			  
+
       if (timestamp == ping_data->timestamp)
         {
           meta_topic (META_DEBUG_PING,
-                      "Matching ping found for pong %u\n", 
+                      "Matching ping found for pong %u\n",
                       ping_data->timestamp);
 
           /* Remove the ping data from the list */
@@ -4436,13 +4436,13 @@ process_pong_message (MetaDisplay    *display,
               g_source_remove (ping_data->ping_timeout_id);
               ping_data->ping_timeout_id = 0;
             }
-          
+
           /* Call callback */
-          (* ping_data->ping_reply_func) (display, 
+          (* ping_data->ping_reply_func) (display,
                                           ping_data->xwindow,
-                                          ping_data->timestamp, 
+                                          ping_data->timestamp,
                                           ping_data->user_data);
-			      
+
           ping_data_free (ping_data);
 
           break;
@@ -4474,7 +4474,7 @@ meta_display_window_has_pending_pings (MetaDisplay *display,
     {
       MetaPingData *ping_data = tmp->data;
 
-      if (ping_data->xwindow == window->xwindow) 
+      if (ping_data->xwindow == window->xwindow)
         return TRUE;
     }
 
@@ -4499,7 +4499,7 @@ get_focussed_group (MetaDisplay *display)
 static MetaWindow*
 find_tab_forward (MetaDisplay   *display,
                   MetaTabList    type,
-                  MetaScreen    *screen, 
+                  MetaScreen    *screen,
                   MetaWorkspace *workspace,
                   GList         *start,
                   gboolean       skip_first)
@@ -4533,7 +4533,7 @@ find_tab_forward (MetaDisplay   *display,
         return window;
 
       tmp = tmp->next;
-    }  
+    }
 
   return NULL;
 }
@@ -4541,7 +4541,7 @@ find_tab_forward (MetaDisplay   *display,
 static MetaWindow*
 find_tab_backward (MetaDisplay   *display,
                    MetaTabList    type,
-                   MetaScreen    *screen, 
+                   MetaScreen    *screen,
                    MetaWorkspace *workspace,
                    GList         *start,
                    gboolean       skip_last)
@@ -4552,7 +4552,7 @@ find_tab_backward (MetaDisplay   *display,
   g_return_val_if_fail (workspace != NULL, NULL);
 
   tmp = start;
-  if (skip_last)  
+  if (skip_last)
     tmp = tmp->prev;
   while (tmp != NULL)
     {
@@ -4589,7 +4589,7 @@ meta_display_get_tab_list (MetaDisplay   *display,
   MetaWorkspace *workspace;
 
   g_return_val_if_fail (active_workspace != NULL, NULL);
-  
+
   if (type == META_TAB_LIST_NORMAL_ALL_WORKSPACES)
     {
       workspace_list = screen->workspaces;
@@ -4610,19 +4610,19 @@ meta_display_get_tab_list (MetaDisplay   *display,
   for (l = workspace_list; l != NULL; l = l->next)
     {
       GList *tmp;
-      
+
       workspace = l->data;
-      
+
       tmp = workspace->mru_list;
       while (tmp != NULL)
         {
           MetaWindow *window = tmp->data;
-          
+
           if (!window->minimized &&
               window->screen == screen &&
               IN_TAB_CHAIN (window, type))
             tab_list = g_list_prepend (tab_list, window);
-          
+
           tmp = tmp->next;
         }
     }
@@ -4696,11 +4696,11 @@ meta_display_get_tab_next (MetaDisplay   *display,
 
   if (tab_list == NULL)
     return NULL;
-  
+
   if (window != NULL)
     {
       g_assert (window->display == display);
-      
+
       if (backward)
         ret = find_tab_backward (display, type, screen, workspace,
                                  g_list_find (tab_list,
@@ -4714,7 +4714,7 @@ meta_display_get_tab_next (MetaDisplay   *display,
     }
   else
     {
-      skip = display->focus_window != NULL && 
+      skip = display->focus_window != NULL &&
              tab_list->data == display->focus_window;
       if (backward)
         ret = find_tab_backward (display, type, screen, workspace,
@@ -4737,7 +4737,7 @@ meta_display_get_tab_current (MetaDisplay   *display,
   MetaWindow *window;
 
   window = display->focus_window;
-  
+
   if (window != NULL &&
       window->screen == screen &&
       IN_TAB_CHAIN (window, type) &&
@@ -4752,7 +4752,7 @@ int
 meta_resize_gravity_from_grab_op (MetaGrabOp op)
 {
   int gravity;
-  
+
   gravity = -1;
   switch (op)
     {
@@ -4802,18 +4802,18 @@ static MetaScreen*
 find_screen_for_selection (MetaDisplay *display,
                            Window       owner,
                            Atom         selection)
-{  
-  GSList *tmp;  
-  
+{
+  GSList *tmp;
+
   tmp = display->screens;
   while (tmp != NULL)
     {
       MetaScreen *screen = tmp->data;
-      
+
       if (screen->wm_sn_selection_window == owner &&
           screen->wm_sn_atom == selection)
         return screen;
-  
+
       tmp = tmp->next;
     }
 
@@ -4855,7 +4855,7 @@ convert_property (MetaDisplay *display,
       meta_error_trap_pop_with_return (display, FALSE);
       return FALSE;
     }
-  
+
   if (meta_error_trap_pop_with_return (display, FALSE) != Success)
     return FALSE;
 
@@ -4884,20 +4884,20 @@ process_selection_request (MetaDisplay   *display,
   if (screen == NULL)
     {
       char *str;
-      
+
       meta_error_trap_push (display);
       str = XGetAtomName (display->xdisplay,
                           event->xselectionrequest.selection);
       meta_error_trap_pop (display, TRUE);
-      
+
       meta_verbose ("Selection request with selection %s window 0x%lx not a WM_Sn selection we recognize\n",
                     str ? str : "(bad atom)", event->xselectionrequest.owner);
-      
+
       meta_XFree (str);
 
       return;
     }
-  
+
   reply.type = SelectionNotify;
   reply.display = display->xdisplay;
   reply.requestor = event->xselectionrequest.requestor;
@@ -4925,9 +4925,9 @@ process_selection_request (MetaDisplay   *display,
               meta_error_trap_pop_with_return (display, TRUE);
               return;
             }
-          
+
           if (meta_error_trap_pop_with_return (display, TRUE) == Success)
-            {              
+            {
               /* FIXME: to be 100% correct, should deal with rest > 0,
                * but since we have 4 possible targets, we will hardly ever
                * meet multiple requests with a length > 8
@@ -4958,7 +4958,7 @@ process_selection_request (MetaDisplay   *display,
     {
       if (event->xselectionrequest.property == None)
         event->xselectionrequest.property = event->xselectionrequest.target;
-      
+
       if (convert_property (display, screen,
                             event->xselectionrequest.requestor,
                             event->xselectionrequest.target,
@@ -4983,25 +4983,25 @@ process_selection_clear (MetaDisplay   *display,
   screen = find_screen_for_selection (display,
                                       event->xselectionclear.window,
                                       event->xselectionclear.selection);
-  
+
 
   if (screen != NULL)
     {
       meta_verbose ("Got selection clear for screen %d on display %s\n",
                     screen->number, display->name);
-      
-      meta_display_unmanage_screen (display, 
+
+      meta_display_unmanage_screen (display,
                                     screen,
                                     event->xselectionclear.time);
 
       /* display and screen may both be invalid memory... */
-      
+
       return;
     }
 
   {
     char *str;
-            
+
     meta_error_trap_push (display);
     str = XGetAtomName (display->xdisplay,
                         event->xselectionclear.selection);
@@ -5022,9 +5022,9 @@ meta_display_unmanage_screen (MetaDisplay *display,
 
   meta_verbose ("Unmanaging screen %d on display %s\n",
                 screen->number, display->name);
-  
+
   g_return_if_fail (g_slist_find (display->screens, screen) != NULL);
-  
+
   meta_screen_free (screen, timestamp);
   display->screens = g_slist_remove (display->screens, screen);
 
@@ -5048,7 +5048,7 @@ meta_display_unmanage_windows_for_screen (MetaDisplay *display,
   while (tmp != NULL)
     {
       meta_window_free (tmp->data, timestamp);
-      
+
       tmp = tmp->next;
     }
   g_slist_free (winlist);
@@ -5078,7 +5078,7 @@ meta_display_devirtualize_modifiers (MetaDisplay        *display,
                                      unsigned int       *mask)
 {
   *mask = 0;
-  
+
   if (modifiers & META_VIRTUAL_SHIFT_MASK)
     *mask |= ShiftMask;
   if (modifiers & META_VIRTUAL_CONTROL_MASK)
@@ -5098,20 +5098,20 @@ meta_display_devirtualize_modifiers (MetaDisplay        *display,
   if (modifiers & META_VIRTUAL_MOD4_MASK)
     *mask |= Mod4Mask;
   if (modifiers & META_VIRTUAL_MOD5_MASK)
-    *mask |= Mod5Mask;  
+    *mask |= Mod5Mask;
 }
 
 static void
 update_window_grab_modifiers (MetaDisplay *display)
-     
+
 {
   MetaVirtualModifier virtual_mods;
   unsigned int mods;
-    
+
   virtual_mods = meta_prefs_get_mouse_button_mods ();
   meta_display_devirtualize_modifiers (display, virtual_mods,
                                        &mods);
-    
+
   display->window_grab_modifiers = mods;
 }
 
@@ -5120,7 +5120,7 @@ prefs_changed_callback (MetaPreference pref,
                         void          *data)
 {
   MetaDisplay *display = data;
-  
+
   /* It may not be obvious why we regrab on focus mode
    * change; it's because we handle focus clicks a
    * bit differently for the different focus modes.
@@ -5131,9 +5131,9 @@ prefs_changed_callback (MetaPreference pref,
       MetaDisplay *display = data;
       GSList *windows;
       GSList *tmp;
-      
+
       windows = meta_display_list_windows (display);
-      
+
       /* Ungrab all */
       tmp = windows;
       while (tmp != NULL)
@@ -5184,13 +5184,13 @@ meta_display_increment_focus_sentinel (MetaDisplay *display)
   unsigned long data[1];
 
   data[0] = meta_display_get_current_time (display);
-  
+
   XChangeProperty (display->xdisplay,
                    ((MetaScreen*) display->screens->data)->xroot,
                    display->atom__MARCO_SENTINEL,
                    XA_CARDINAL,
                    32, PropModeReplace, (guchar*) data, 1);
-  
+
   display->sentinel_counter += 1;
 }
 
@@ -5239,7 +5239,7 @@ sanity_check_timestamps (MetaDisplay *display,
       while (tmp != NULL)
         {
           MetaWindow *window = tmp->data;
-          
+
           if (XSERVER_TIME_IS_BEFORE (timestamp, window->net_wm_user_time))
             {
               meta_warning ("%s appears to be one of the offending windows "
@@ -5247,7 +5247,7 @@ sanity_check_timestamps (MetaDisplay *display,
                             window->desc, window->net_wm_user_time);
               window->net_wm_user_time = timestamp;
             }
-          
+
           tmp = tmp->next;
         }
 
@@ -5262,7 +5262,7 @@ timestamp_too_old (MetaDisplay *display,
 {
   /* FIXME: If Soeren's suggestion in bug 151984 is implemented, it will allow
    * us to sanity check the timestamp here and ensure it doesn't correspond to
-   * a future time (though we would want to rename to 
+   * a future time (though we would want to rename to
    * timestamp_too_old_or_in_future).
    */
 
@@ -5308,7 +5308,7 @@ timestamp_too_old (MetaDisplay *display,
 }
 
 void
-meta_display_set_input_focus_window (MetaDisplay *display, 
+meta_display_set_input_focus_window (MetaDisplay *display,
                                      MetaWindow  *window,
                                      gboolean     focus_frame,
                                      guint32      timestamp)
@@ -5332,7 +5332,7 @@ meta_display_set_input_focus_window (MetaDisplay *display,
 }
 
 void
-meta_display_focus_the_no_focus_window (MetaDisplay *display, 
+meta_display_focus_the_no_focus_window (MetaDisplay *display,
                                         MetaScreen  *screen,
                                         guint32      timestamp)
 {
@@ -5403,7 +5403,7 @@ meta_display_get_focus_window (MetaDisplay *display)
 }
 
 #ifdef HAVE_COMPOSITE_EXTENSIONS
-int 
+int
 meta_display_get_damage_event_base (MetaDisplay *display)
 {
   return display->damage_event_base;

--- a/src/core/edge-resistance.c
+++ b/src/core/edge-resistance.c
@@ -2,9 +2,9 @@
 
 /* Edge resistance for move/resize operations */
 
-/* 
+/*
  * Copyright (C) 2005, 2006 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -246,8 +246,8 @@ find_nearest_position (const GArray        *edges,
     {
       edge = g_array_index (edges, MetaEdge*, i);
       compare = horizontal ? edge->rect.x : edge->rect.y;
-  
-      edges_align = horizontal ? 
+
+      edges_align = horizontal ?
         meta_rectangle_vert_overlap (&edge->rect, new_rect) :
         meta_rectangle_horiz_overlap (&edge->rect, new_rect);
 
@@ -270,8 +270,8 @@ find_nearest_position (const GArray        *edges,
     {
       edge = g_array_index (edges, MetaEdge*, i);
       compare = horizontal ? edge->rect.x : edge->rect.y;
-  
-      edges_align = horizontal ? 
+
+      edges_align = horizontal ?
         meta_rectangle_vert_overlap (&edge->rect, new_rect) :
         meta_rectangle_horiz_overlap (&edge->rect, new_rect);
 
@@ -434,7 +434,7 @@ apply_edge_resistance (MetaWindow                *window,
               if (!resistance_data->timeout_setup &&
                   timeout_length_ms != 0)
                 {
-                  resistance_data->timeout_id = 
+                  resistance_data->timeout_id =
                     g_timeout_add (timeout_length_ms,
                                    edge_resistance_timeout,
                                    resistance_data);
@@ -535,7 +535,7 @@ apply_edge_snapping (int                  old_pos,
  * display->grab_edge_resistance_data MUST already be setup or calling this
  * function will cause a crash.
  */
-static gboolean 
+static gboolean
 apply_edge_resistance_to_each_side (MetaDisplay         *display,
                                     MetaWindow          *window,
                                     const MetaRectangle *old_outer,
@@ -655,7 +655,7 @@ apply_edge_resistance_to_each_side (MetaDisplay         *display,
     }
 
   /* Determine whether anything changed, and save the changes */
-  modified_rect = meta_rect (new_left, 
+  modified_rect = meta_rect (new_left,
                              new_top,
                              new_right - new_left,
                              new_bottom - new_top);
@@ -750,7 +750,7 @@ meta_display_cleanup_edges (MetaDisplay *display)
 }
 
 static int
-stupid_sort_requiring_extra_pointer_dereference (gconstpointer a, 
+stupid_sort_requiring_extra_pointer_dereference (gconstpointer a,
                                                  gconstpointer b)
 {
   const MetaEdge * const *a_edge = a;
@@ -775,7 +775,7 @@ cache_edges (MetaDisplay *display,
 #ifdef WITH_VERBOSE_MODE
   if (meta_is_verbose())
     {
-      int max_edges = MAX (MAX( g_list_length (window_edges), 
+      int max_edges = MAX (MAX( g_list_length (window_edges),
                                 g_list_length (xinerama_edges)),
                            g_list_length (screen_edges));
       char big_buffer[(EDGE_LENGTH+2)*max_edges];
@@ -912,13 +912,13 @@ cache_edges (MetaDisplay *display,
    * avoided this sort by sticking them into the array with some simple
    * merging of the lists).
    */
-  g_array_sort (display->grab_edge_resistance_data->left_edges, 
+  g_array_sort (display->grab_edge_resistance_data->left_edges,
                 stupid_sort_requiring_extra_pointer_dereference);
-  g_array_sort (display->grab_edge_resistance_data->right_edges, 
+  g_array_sort (display->grab_edge_resistance_data->right_edges,
                 stupid_sort_requiring_extra_pointer_dereference);
-  g_array_sort (display->grab_edge_resistance_data->top_edges, 
+  g_array_sort (display->grab_edge_resistance_data->top_edges,
                 stupid_sort_requiring_extra_pointer_dereference);
-  g_array_sort (display->grab_edge_resistance_data->bottom_edges, 
+  g_array_sort (display->grab_edge_resistance_data->bottom_edges,
                 stupid_sort_requiring_extra_pointer_dereference);
 }
 
@@ -955,7 +955,7 @@ meta_display_compute_resistance_and_snapping_edges (MetaDisplay *display)
   /*
    * 1st: Get the list of relevant windows, from bottom to top
    */
-  stacked_windows = 
+  stacked_windows =
     meta_stack_list_windows (display->grab_screen->stack,
                              display->grab_screen->active_workspace);
 
@@ -977,7 +977,7 @@ meta_display_compute_resistance_and_snapping_edges (MetaDisplay *display)
           new_rect = g_new (MetaRectangle, 1);
           meta_window_get_outer_rect (cur_window, new_rect);
           obscuring_windows = g_slist_prepend (obscuring_windows, new_rect);
-          window_stacking = 
+          window_stacking =
             g_slist_prepend (window_stacking, GINT_TO_POINTER (stack_position));
         }
 
@@ -1017,7 +1017,7 @@ meta_display_compute_resistance_and_snapping_edges (MetaDisplay *display)
            * is offscreen (we also don't care about parts of edges covered
            * by other windows or DOCKS, but that's handled below).
            */
-          meta_rectangle_intersect (&cur_rect, 
+          meta_rectangle_intersect (&cur_rect,
                                     &display->grab_screen->rect,
                                     &reduced);
 
@@ -1043,7 +1043,7 @@ meta_display_compute_resistance_and_snapping_edges (MetaDisplay *display)
           new_edge->side_type = META_SIDE_LEFT;
           new_edge->edge_type = META_EDGE_WINDOW;
           new_edges = g_list_prepend (new_edges, new_edge);
-          
+
           /* Top side of this window is resistance for the bottom edge of
            * the window being moved.
            */
@@ -1068,7 +1068,7 @@ meta_display_compute_resistance_and_snapping_edges (MetaDisplay *display)
           /* Update the remaining windows to only those at a higher
            * stacking position than this one.
            */
-          while (rem_win_stacking && 
+          while (rem_win_stacking &&
                  stack_position >= GPOINTER_TO_INT (rem_win_stacking->data))
             {
               rem_windows      = rem_windows->next;
@@ -1076,7 +1076,7 @@ meta_display_compute_resistance_and_snapping_edges (MetaDisplay *display)
             }
 
           /* Remove edge portions overlapped by rem_windows and rem_docks */
-          new_edges = 
+          new_edges =
             meta_rectangle_remove_intersections_with_boxes_from_edges (
               new_edges,
               rem_windows);
@@ -1098,7 +1098,7 @@ meta_display_compute_resistance_and_snapping_edges (MetaDisplay *display)
   /* FIXME: Shouldn't there be a helper function to make this one line of code
    * to free a list instead of four ugly ones?
    */
-  g_slist_foreach (obscuring_windows, 
+  g_slist_foreach (obscuring_windows,
                    (void (*)(gpointer,gpointer))&g_free, /* ew, for ugly */
                    NULL);
   g_slist_free (obscuring_windows);
@@ -1205,7 +1205,7 @@ meta_window_edge_resistance_for_move (MetaWindow  *window,
       else
         smaller_y_change = bottom_change;
 
-      *new_x = old_x + smaller_x_change + 
+      *new_x = old_x + smaller_x_change +
               (BOX_LEFT (*reference) - BOX_LEFT (old_outer));
       *new_y = old_y + smaller_y_change +
               (BOX_TOP (*reference) - BOX_TOP (old_outer));
@@ -1249,7 +1249,7 @@ meta_window_edge_resistance_for_resize (MetaWindow  *window,
     }
   proposed_outer_width  = old_outer.width  + (*new_width  - old_width);
   proposed_outer_height = old_outer.height + (*new_height - old_height);
-  meta_rectangle_resize_with_gravity (&old_outer, 
+  meta_rectangle_resize_with_gravity (&old_outer,
                                       &new_outer,
                                       gravity,
                                       proposed_outer_width,

--- a/src/core/edge-resistance.h
+++ b/src/core/edge-resistance.h
@@ -2,9 +2,9 @@
 
 /* Edge resistance for move/resize operations */
 
-/* 
+/*
  * Copyright (C) 2005 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA

--- a/src/core/effects.c
+++ b/src/core/effects.c
@@ -2,7 +2,7 @@
 
 /**
  * \file effects.c "Special effects" other than compositor effects.
- * 
+ *
  * Before we had a serious compositor, we supported swooping
  * rectangles for minimising and so on.  These are still supported
  * today, even when the compositor is enabled.  The file contains two
@@ -36,9 +36,9 @@
  * In svn r3769 this was made explicit.
  */
 
-/* 
+/*
  * Copyright (C) 2001 Anders Carlsson, Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -48,7 +48,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -97,7 +97,7 @@ typedef struct
 
   MetaRectangle start_rect;
   MetaRectangle end_rect;
-  
+
 } BoxAnimationContext;
 
 /**
@@ -131,7 +131,7 @@ struct MetaEffect
     MetaMinimizeEffect      minimize;
     /* ... and theoretically anything else */
   } u;
-  
+
   MetaEffectPriv *priv;
 };
 
@@ -183,7 +183,7 @@ effect_free (MetaEffect *effect)
 {
   if (effect->priv->finished)
     effect->priv->finished (effect->priv->finished_data);
-    
+
   g_free (effect->priv);
   g_free (effect);
 }
@@ -198,7 +198,7 @@ meta_effect_run_focus (MetaWindow	    *window,
     g_return_if_fail (window != NULL);
 
     effect = create_effect (META_EFFECT_FOCUS, window, finished, data);
-    
+
     run_handler (effect);
 }
 
@@ -213,7 +213,7 @@ meta_effect_run_minimize (MetaWindow         *window,
 
     g_return_if_fail (window != NULL);
     g_return_if_fail (icon_rect != NULL);
-    
+
     effect = create_effect (META_EFFECT_MINIMIZE, window, finished, data);
 
     effect->u.minimize.window_rect = *window_rect;
@@ -233,7 +233,7 @@ meta_effect_run_unminimize (MetaWindow         *window,
 
     g_return_if_fail (window != NULL);
     g_return_if_fail (icon_rect != NULL);
-    
+
     effect = create_effect (META_EFFECT_UNMINIMIZE, window, finished, data);
 
     effect->u.minimize.window_rect = *window_rect;
@@ -248,7 +248,7 @@ meta_effect_run_close (MetaWindow         *window,
 		       gpointer            data)
 {
     MetaEffect *effect;
-    
+
     g_return_if_fail (window != NULL);
 
     effect = create_effect (META_EFFECT_CLOSE, window,
@@ -260,7 +260,7 @@ meta_effect_run_close (MetaWindow         *window,
 
 /* old ugly minimization effect */
 
-#ifdef HAVE_SHAPE  
+#ifdef HAVE_SHAPE
 static void
 update_wireframe_window (MetaDisplay         *display,
                          Window               xwindow,
@@ -272,14 +272,14 @@ update_wireframe_window (MetaDisplay         *display,
                      rect->width, rect->height);
 
 #define OUTLINE_WIDTH 3
-  
+
   if (rect->width > OUTLINE_WIDTH * 2 &&
       rect->height > OUTLINE_WIDTH * 2)
     {
       XRectangle xrect;
       Region inner_xregion;
       Region outer_xregion;
-      
+
       inner_xregion = XCreateRegion ();
       outer_xregion = XCreateRegion ();
 
@@ -287,21 +287,21 @@ update_wireframe_window (MetaDisplay         *display,
       xrect.y = 0;
       xrect.width = rect->width;
       xrect.height = rect->height;
-  
+
       XUnionRectWithRegion (&xrect, outer_xregion, outer_xregion);
-  
+
       xrect.x += OUTLINE_WIDTH;
       xrect.y += OUTLINE_WIDTH;
       xrect.width -= OUTLINE_WIDTH * 2;
-      xrect.height -= OUTLINE_WIDTH * 2;  
-  
+      xrect.height -= OUTLINE_WIDTH * 2;
+
       XUnionRectWithRegion (&xrect, inner_xregion, inner_xregion);
 
       XSubtractRegion (outer_xregion, inner_xregion, outer_xregion);
 
       XShapeCombineRegion (display->xdisplay, xwindow,
                            ShapeBounding, 0, 0, outer_xregion, ShapeSet);
-  
+
       XDestroyRegion (outer_xregion);
       XDestroyRegion (inner_xregion);
     }
@@ -322,7 +322,7 @@ static void
 graphics_sync (BoxAnimationContext *context)
 {
   XImage *image;
-  
+
   image = XGetImage (context->screen->display->xdisplay,
                      context->screen->xroot,
                      0, 0, 1, 1,
@@ -338,7 +338,7 @@ effects_draw_box_animation_timeout (BoxAnimationContext *context)
   GTimeVal current_time;
   MetaRectangle draw_rect;
   double fraction;
-  
+
 #ifndef HAVE_SHAPE
   if (!context->first_time)
     {
@@ -355,12 +355,12 @@ effects_draw_box_animation_timeout (BoxAnimationContext *context)
 #endif /* !HAVE_SHAPE */
 
   g_get_current_time (&current_time);
-  
+
   /* We use milliseconds for all times */
   elapsed =
     ((((double)current_time.tv_sec - context->start_time.tv_sec) * G_USEC_PER_SEC +
       (current_time.tv_usec - context->start_time.tv_usec))) / 1000.0;
-  
+
   if (elapsed < 0)
     {
       /* Probably the system clock was set backwards? */
@@ -382,22 +382,22 @@ effects_draw_box_animation_timeout (BoxAnimationContext *context)
 #endif /* !HAVE_SHAPE */
 
       graphics_sync (context);
-      
+
       g_free (context);
       return FALSE;
     }
 
   g_assert (context->millisecs_duration > 0.0);
   fraction = elapsed / context->millisecs_duration;
-  
+
   draw_rect = context->start_rect;
-  
+
   /* Now add a delta proportional to elapsed time. */
   draw_rect.x += (context->end_rect.x - context->start_rect.x) * fraction;
   draw_rect.y += (context->end_rect.y - context->start_rect.y) * fraction;
   draw_rect.width += (context->end_rect.width - context->start_rect.width) * fraction;
   draw_rect.height += (context->end_rect.height - context->start_rect.height) * fraction;
-  
+
   /* don't confuse X or gdk-pixbuf with bogus rectangles */
   if (draw_rect.width < 1)
     draw_rect.width = 1;
@@ -417,15 +417,15 @@ effects_draw_box_animation_timeout (BoxAnimationContext *context)
                   context->gc,
                   draw_rect.x, draw_rect.y,
                   draw_rect.width, draw_rect.height);
-    
+
 #endif /* !HAVE_SHAPE */
 
   /* kick changes onto the server */
   graphics_sync (context);
-  
+
   return TRUE;
 }
- 
+
 void
 draw_box_animation (MetaScreen     *screen,
                     MetaRectangle  *initial_rect,
@@ -439,12 +439,12 @@ draw_box_animation (MetaScreen     *screen,
 #else
   XGCValues gc_values;
 #endif
-    
+
   g_return_if_fail (seconds_duration > 0.0);
 
   if (g_getenv ("MARCO_DEBUG_EFFECTS"))
     seconds_duration *= 10; /* slow things down */
-  
+
   /* Create the animation context */
   context = g_new0 (BoxAnimationContext, 1);
 
@@ -491,7 +491,7 @@ draw_box_animation (MetaScreen     *screen,
                            screen->xroot,
                            GCSubwindowMode | GCFunction,
                            &gc_values);
-      
+
   /* Grab the X server to avoid screen dirt */
   meta_display_grab (context->screen->display);
   meta_ui_push_delay_exposes (context->screen->ui);
@@ -501,7 +501,7 @@ draw_box_animation (MetaScreen     *screen,
    * so that the animation doesn't get truncated.
    */
   g_get_current_time (&context->start_time);
-  
+
   /* Add the timeout - a short one, could even use an idle,
    * but this is maybe more CPU-friendly.
    */
@@ -510,7 +510,7 @@ draw_box_animation (MetaScreen     *screen,
                  context);
 
   /* kick changes onto the server */
-  XFlush (context->screen->display->xdisplay);  
+  XFlush (context->screen->display->xdisplay);
 }
 
 void
@@ -521,9 +521,9 @@ meta_effects_begin_wireframe (MetaScreen          *screen,
 {
   /* Grab the X server to avoid screen dirt */
   meta_display_grab (screen->display);
-  meta_ui_push_delay_exposes (screen->ui);  
+  meta_ui_push_delay_exposes (screen->ui);
 
-  meta_effects_update_wireframe (screen, 
+  meta_effects_update_wireframe (screen,
                                  NULL, -1, -1,
                                  rect, width, height);
 }
@@ -541,7 +541,7 @@ draw_xor_rect (MetaScreen          *screen,
   XSegment segments[8];
   MetaRectangle shrunk_rect;
   int i;
-  
+
 #define LINE_WIDTH META_WIREFRAME_XOR_LINE_WIDTH
 
   /* We don't want the wireframe going outside the window area.
@@ -571,14 +571,14 @@ draw_xor_rect (MetaScreen          *screen,
       XGCValues gc_values = { 0 };
 
       if (XGetGCValues (screen->display->xdisplay,
-                        screen->root_xor_gc, 
+                        screen->root_xor_gc,
                         GCFont, &gc_values))
         {
           char *text;
           int text_length;
 
           XFontStruct *font_struct;
-          int text_width, text_height; 
+          int text_width, text_height;
           int box_x, box_y;
           int box_width, box_height;
 
@@ -591,7 +591,7 @@ draw_xor_rect (MetaScreen          *screen,
               text_length = strlen (text);
 
               text_width = text_length * font_struct->max_bounds.width;
-              text_height = font_struct->max_bounds.descent + 
+              text_height = font_struct->max_bounds.descent +
                             font_struct->max_bounds.ascent;
 
               box_width = text_width + 2 * LINE_WIDTH;
@@ -609,7 +609,7 @@ draw_xor_rect (MetaScreen          *screen,
                                   screen->root_xor_gc,
                                   box_x, box_y,
                                   box_width, box_height);
-                  XDrawString (screen->display->xdisplay, 
+                  XDrawString (screen->display->xdisplay,
                                screen->xroot,
                                screen->root_xor_gc,
                                box_x + LINE_WIDTH,
@@ -634,7 +634,7 @@ draw_xor_rect (MetaScreen          *screen,
   segments[0].x1 = shrunk_rect.x + shrunk_rect.width / 3;
   segments[0].y1 = shrunk_rect.y + LINE_WIDTH / 2 + LINE_WIDTH % 2;
   segments[0].x2 = segments[0].x1;
-  segments[0].y2 = shrunk_rect.y + shrunk_rect.height - LINE_WIDTH / 2;  
+  segments[0].y2 = shrunk_rect.y + shrunk_rect.height - LINE_WIDTH / 2;
 
   segments[1] = segments[0];
   segments[1].x1 = shrunk_rect.x + (shrunk_rect.width / 3) * 2;
@@ -652,7 +652,7 @@ draw_xor_rect (MetaScreen          *screen,
   segments[3] = segments[2];
   segments[3].x1 = segments[2].x2 + LINE_WIDTH;
   segments[3].x2 = segments[1].x1 - LINE_WIDTH / 2;
-  
+
   segments[4] = segments[3];
   segments[4].x1 = segments[3].x2 + LINE_WIDTH;
   segments[4].x2 = shrunk_rect.x + shrunk_rect.width - LINE_WIDTH / 2;
@@ -668,7 +668,7 @@ draw_xor_rect (MetaScreen          *screen,
       segments[i].y2 = segments[i].y1;
       ++i;
     }
-  
+
   XDrawSegments (screen->display->xdisplay,
                  screen->xroot,
                  screen->root_xor_gc,
@@ -687,10 +687,10 @@ meta_effects_update_wireframe (MetaScreen          *screen,
 {
   if (old_rect)
     draw_xor_rect (screen, old_rect, old_width, old_height);
-    
+
   if (new_rect)
     draw_xor_rect (screen, new_rect, new_width, new_height);
-    
+
   XFlush (screen->display->xdisplay);
 }
 
@@ -700,10 +700,10 @@ meta_effects_end_wireframe (MetaScreen          *screen,
                             int                  old_width,
                             int                  old_height)
 {
-  meta_effects_update_wireframe (screen, 
+  meta_effects_update_wireframe (screen,
                                  old_rect, old_width, old_height,
                                  NULL, -1, -1);
-  
+
   meta_display_ungrab (screen->display);
   meta_ui_pop_delay_exposes (screen->ui);
 }

--- a/src/core/effects.h
+++ b/src/core/effects.h
@@ -2,7 +2,7 @@
 
 /**
  * \file effects.h "Special effects" other than compositor effects.
- * 
+ *
  * Before we had a serious compositor, we supported swooping
  * rectangles for minimising and so on.  These are still supported
  * today, even when the compositor is enabled.  The file contains two
@@ -23,9 +23,9 @@
  * it can be found in svn r3769.
  */
 
-/* 
+/*
  * Copyright (C) 2001 Anders Carlsson, Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -35,7 +35,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA

--- a/src/core/errors.c
+++ b/src/core/errors.c
@@ -2,10 +2,10 @@
 
 /* Marco X error handling */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington, error trapping inspired by GDK
  * code copyrighted by the GTK team.
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -15,7 +15,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -118,14 +118,14 @@ meta_error_trap_push_internal (MetaDisplay *display,
     {
       XSync (display->xdisplay, False);
     }
-  
+
   gdk_error_trap_push ();
 
   /* old_error_handler will just be equal to x_error_handler
    * for nested traps
    */
   old_error_handler = XSetErrorHandler (x_error_handler);
-  
+
   /* Replace GDK handler, but save it so we can chain up */
   if (display->error_trap_handler == NULL)
     {
@@ -155,13 +155,13 @@ meta_error_trap_pop_internal  (MetaDisplay *display,
   result = gdk_error_trap_pop ();
 
   display->error_traps -= 1;
-  
+
   if (display->error_traps == 0)
     {
       /* check that GDK put our handler back; this
        * assumes that there are no pending GDK traps from GDK itself
        */
-      
+
       int UNUSED_VARIABLE (* restored_error_handler) (Display     *,
                                       XErrorEvent *);
 
@@ -172,7 +172,7 @@ meta_error_trap_pop_internal  (MetaDisplay *display,
     }
 
   meta_topic (META_DEBUG_ERRORS, "%d traps\n", display->error_traps);
-  
+
   return result;
 }
 
@@ -196,7 +196,7 @@ meta_error_trap_pop (MetaDisplay *display,
                 display->error_traps, last_request_was_roundtrip);
 
   display->error_trap_synced_at_last_pop = need_sync || last_request_was_roundtrip;
-  
+
   meta_error_trap_pop_internal (display, need_sync);
 }
 
@@ -222,7 +222,7 @@ meta_error_trap_push_with_return (MetaDisplay *display)
   if (need_sync)
     meta_topic (META_DEBUG_SYNC, "Syncing on error_trap_push_with_return, traps = %d\n",
                 display->error_traps);
-  
+
   meta_error_trap_push_internal (display, FALSE);
 }
 
@@ -235,7 +235,7 @@ meta_error_trap_pop_with_return  (MetaDisplay *display,
                 display->error_traps, last_request_was_roundtrip);
 
   display->error_trap_synced_at_last_pop = TRUE;
-  
+
   return meta_error_trap_pop_internal (display,
                                        !last_request_was_roundtrip);
 }
@@ -258,8 +258,8 @@ x_error_handler (Display     *xdisplay,
 	  return 0;
       }
   }
-  
-  XGetErrorText (xdisplay, error->error_code, buf, 63);  
+
+  XGetErrorText (xdisplay, error->error_code, buf, 63);
 
   display = meta_display_for_x_display (xdisplay);
 
@@ -273,22 +273,22 @@ x_error_handler (Display     *xdisplay,
        */
       meta_verbose ("X error: %s serial %ld error_code %d request_code %d minor_code %d)\n",
                     buf,
-                    error->serial, 
-                    error->error_code, 
+                    error->serial,
+                    error->error_code,
                     error->request_code,
                     error->minor_code);
 
       g_assert (display->error_trap_handler != NULL);
       g_assert (display->error_trap_handler != x_error_handler);
-      
+
       retval = (* display->error_trap_handler) (xdisplay, error);
     }
   else
     {
       meta_bug ("Unexpected X error: %s serial %ld error_code %d request_code %d minor_code %d)\n",
                 buf,
-                error->serial, 
-                error->error_code, 
+                error->serial,
+                error->error_code,
                 error->request_code,
                 error->minor_code);
 
@@ -307,7 +307,7 @@ x_io_error_handler (Display *xdisplay)
 
   if (display == NULL)
     meta_bug ("IO error received for unknown display?\n");
-  
+
   if (errno == EPIPE)
     {
       meta_warning (_("Lost connection to the display '%s';\n"
@@ -324,7 +324,7 @@ x_io_error_handler (Display *xdisplay)
 
   /* Xlib would force an exit anyhow */
   exit (1);
-  
+
   return 0;
 }
 

--- a/src/core/eventqueue.c
+++ b/src/core/eventqueue.c
@@ -2,10 +2,10 @@
 
 /* Marco X event source for main loop */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington (based on GDK code (C) Owen
  * Taylor, Red Hat Inc.)
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -15,7 +15,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -57,7 +57,7 @@ meta_event_queue_new (Display *display, MetaEventQueueFunc func, gpointer data)
 
   source = g_source_new (&eq_funcs, sizeof (MetaEventQueue));
   eq = (MetaEventQueue*) source;
-  
+
   eq->connection_fd = ConnectionNumber (display);
   eq->poll_fd.fd = eq->connection_fd;
   eq->poll_fd.events = G_IO_IN;
@@ -65,13 +65,13 @@ meta_event_queue_new (Display *display, MetaEventQueueFunc func, gpointer data)
   eq->events = g_queue_new ();
 
   eq->display = display;
-  
+
   g_source_set_priority (source, G_PRIORITY_DEFAULT);
   g_source_add_poll (source, &eq->poll_fd);
   g_source_set_can_recurse (source, TRUE);
 
   g_source_set_callback (source, (GSourceFunc) func, data, NULL);
-  
+
   g_source_attach (source, NULL);
   g_source_unref (source);
 
@@ -84,7 +84,7 @@ meta_event_queue_free (MetaEventQueue *eq)
   GSource *source;
 
   source = (GSource*) eq;
-  
+
   g_source_destroy (source);
 }
 
@@ -102,7 +102,7 @@ eq_queue_events (MetaEventQueue *eq)
   while (XPending (eq->display))
     {
       XEvent *copy;
-      
+
       XNextEvent (eq->display, &xevent);
 
       copy = g_new (XEvent, 1);
@@ -112,20 +112,20 @@ eq_queue_events (MetaEventQueue *eq)
     }
 }
 
-static gboolean  
+static gboolean
 eq_prepare (GSource *source, gint *timeout)
 {
   MetaEventQueue *eq;
 
   eq = (MetaEventQueue*) source;
-  
+
   *timeout = -1;
 
   return eq_events_pending (eq);
 }
 
-static gboolean  
-eq_check (GSource  *source) 
+static gboolean
+eq_check (GSource  *source)
 {
   MetaEventQueue *eq;
 
@@ -137,13 +137,13 @@ eq_check (GSource  *source)
     return FALSE;
 }
 
-static gboolean  
+static gboolean
 eq_dispatch (GSource *source, GSourceFunc callback, gpointer user_data)
 {
   MetaEventQueue *eq;
 
   eq = (MetaEventQueue*) source;
-  
+
   eq_queue_events (eq);
 
   if (eq->events->length > 0)
@@ -153,12 +153,12 @@ eq_dispatch (GSource *source, GSourceFunc callback, gpointer user_data)
 
       event = g_queue_pop_head (eq->events);
       func = (MetaEventQueueFunc) callback;
-      
+
       (* func) (event, user_data);
 
       g_free (event);
     }
-  
+
   return TRUE;
 }
 
@@ -172,7 +172,7 @@ eq_destroy (GSource *source)
   while (eq->events->length > 0)
     {
       XEvent *event;
-      
+
       event = g_queue_pop_head (eq->events);
 
       g_free (event);

--- a/src/core/eventqueue.h
+++ b/src/core/eventqueue.h
@@ -2,9 +2,9 @@
 
 /* Marco X event source for main loop */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA

--- a/src/core/frame-private.h
+++ b/src/core/frame-private.h
@@ -2,9 +2,9 @@
 
 /* Marco X window decorations */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -30,7 +30,7 @@
 typedef struct _MetaFrameGeometry MetaFrameGeometry;
 
 struct _MetaFrameGeometry
-{  
+{
   /* border sizes (space between frame and child) */
   int left_width;
   int right_width;

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -2,11 +2,11 @@
 
 /* Marco X window decorations */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2003, 2004 Red Hat, Inc.
  * Copyright (C) 2005 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -16,7 +16,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -48,13 +48,13 @@ meta_window_ensure_frame (MetaWindow *window)
   MetaFrame *frame;
   XSetWindowAttributes attrs;
   Visual *visual;
-  
+
   if (window->frame)
     return;
-  
+
   /* See comment below for why this is required. */
   meta_display_grab (window->display);
-  
+
   frame = g_new (MetaFrame, 1);
 
   frame->window = window;
@@ -70,7 +70,7 @@ meta_window_ensure_frame (MetaWindow *window)
   frame->mapped = FALSE;
   frame->need_reapply_frame_shape = TRUE;
   frame->is_flashing = FALSE;
-  
+
   meta_verbose ("Framing window %s: visual %s default, depth %d default depth %d\n",
                 window->desc,
                 XVisualIDFromVisual (window->xvisual) ==
@@ -80,7 +80,7 @@ meta_window_ensure_frame (MetaWindow *window)
   meta_verbose ("Frame geometry %d,%d  %dx%d\n",
                 frame->rect.x, frame->rect.y,
                 frame->rect.width, frame->rect.height);
-  
+
   /* Default depth/visual handles clients with weird visuals; they can
    * always be children of the root depth/visual obviously, but
    * e.g. DRI games can't be children of a parent that has the same
@@ -89,7 +89,7 @@ meta_window_ensure_frame (MetaWindow *window)
    * We look for an ARGB visual if we can find one, otherwise use
    * the default of NULL.
    */
-  
+
   /* Special case for depth 32 windows (assumed to be ARGB),
    * we use the window's visual. Otherwise we just use the system visual.
    */
@@ -97,7 +97,7 @@ meta_window_ensure_frame (MetaWindow *window)
     visual = window->xvisual;
   else
     visual = NULL;
-  
+
   frame->xwindow = meta_ui_create_frame_window (window->screen->ui,
                                                 window->display->xdisplay,
                                                 visual,
@@ -111,7 +111,7 @@ meta_window_ensure_frame (MetaWindow *window)
   attrs.event_mask = EVENT_MASK;
   XChangeWindowAttributes (window->display->xdisplay,
 			   frame->xwindow, CWEventMask, &attrs);
-  
+
   meta_display_register_x_window (window->display, &frame->xwindow, window);
 
   /* Now that frame->xwindow is registered with window, we can set its
@@ -148,10 +148,10 @@ meta_window_ensure_frame (MetaWindow *window)
                    window->rect.y);
   /* FIXME handle this error */
   meta_error_trap_pop (window->display, FALSE);
-  
+
   /* stick frame to the window */
   window->frame = frame;
-  
+
   if (window->title)
     meta_ui_set_frame_title (window->screen->ui,
                              window->frame->xwindow,
@@ -167,7 +167,7 @@ meta_window_ensure_frame (MetaWindow *window)
                              frame->rect.height,
                              frame->window->has_shape);
   frame->need_reapply_frame_shape = FALSE;
-  
+
   meta_display_ungrab (window->display);
 }
 
@@ -175,16 +175,16 @@ void
 meta_window_destroy_frame (MetaWindow *window)
 {
   MetaFrame *frame;
-  
+
   if (window->frame == NULL)
     return;
 
   meta_verbose ("Unframing window %s\n", window->desc);
-  
+
   frame = window->frame;
-  
+
   meta_bell_notify_frame_destroy (frame);
-  
+
   /* Unparent the client window; it may be destroyed,
    * thus the error trap.
    */
@@ -214,14 +214,14 @@ meta_window_destroy_frame (MetaWindow *window)
 
   meta_display_unregister_x_window (window->display,
                                     frame->xwindow);
-  
+
   window->frame = NULL;
 
   /* Move keybindings to window instead of frame */
   meta_window_grab_keys (window);
-  
+
   g_free (frame);
-  
+
   /* Put our state back where it should be */
   meta_window_queue (window, META_QUEUE_CALC_SHOWING);
   meta_window_queue (window, META_QUEUE_MOVE_RESIZE);
@@ -244,20 +244,20 @@ meta_frame_get_flags (MetaFrame *frame)
   else
     {
       flags |= META_FRAME_ALLOWS_MENU;
-      
+
       if (frame->window->has_close_func)
         flags |= META_FRAME_ALLOWS_DELETE;
-      
+
       if (frame->window->has_maximize_func)
         flags |= META_FRAME_ALLOWS_MAXIMIZE;
-      
+
       if (frame->window->has_minimize_func)
         flags |= META_FRAME_ALLOWS_MINIMIZE;
-      
+
       if (frame->window->has_shade_func)
         flags |= META_FRAME_ALLOWS_SHADE;
-    }  
-  
+    }
+
   if (META_WINDOW_ALLOWS_MOVE (frame->window))
     flags |= META_FRAME_ALLOWS_MOVE;
 
@@ -266,7 +266,7 @@ meta_frame_get_flags (MetaFrame *frame)
 
   if (META_WINDOW_ALLOWS_VERTICAL_RESIZE (frame->window))
     flags |= META_FRAME_ALLOWS_VERTICAL_RESIZE;
-  
+
   if (frame->window->has_focus)
     flags |= META_FRAME_HAS_FOCUS;
 
@@ -290,7 +290,7 @@ meta_frame_get_flags (MetaFrame *frame)
 
   if (frame->window->wm_state_above)
     flags |= META_FRAME_ABOVE;
-  
+
   return flags;
 }
 
@@ -309,7 +309,7 @@ meta_frame_calc_geometry (MetaFrame         *frame,
                               &geom.bottom_height,
                               &geom.left_width,
                               &geom.right_width);
-  
+
   *geomp = geom;
 }
 
@@ -365,7 +365,7 @@ meta_frame_sync_to_window (MetaFrame *frame,
    * shaped, which might be more visible.
    */
   update_shape (frame);
-  
+
   meta_ui_move_resize_frame (frame->window->screen->ui,
 			     frame->xwindow,
 			     frame->rect.x,
@@ -406,7 +406,7 @@ meta_frame_set_screen_cursor (MetaFrame	*frame,
   if (cursor == META_CURSOR_DEFAULT)
     XUndefineCursor (frame->window->display->xdisplay, frame->xwindow);
   else
-    { 
+    {
       xcursor = meta_display_create_x_cursor (frame->window->display, cursor);
       XDefineCursor (frame->window->display->xdisplay, frame->xwindow, xcursor);
       XFlush (frame->window->display->xdisplay);

--- a/src/core/group-private.h
+++ b/src/core/group-private.h
@@ -2,9 +2,9 @@
 
 /* Marco window group private header */
 
-/* 
+/*
  * Copyright (C) 2002 Red Hat Inc.
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA

--- a/src/core/group-props.c
+++ b/src/core/group-props.c
@@ -2,9 +2,9 @@
 
 /* MetaGroup property handling */
 
-/* 
+/*
  * Copyright (C) 2002 Red Hat, Inc.
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -67,16 +67,16 @@ meta_group_reload_properties (MetaGroup  *group,
 
   g_return_if_fail (properties != NULL);
   g_return_if_fail (n_properties > 0);
-  
+
   values = g_new0 (MetaPropValue, n_properties);
-  
+
   i = 0;
   while (i < n_properties)
     {
       init_prop_value (group->display, properties[i], &values[i]);
       ++i;
     }
-  
+
   meta_prop_get_values (group->display, group->group_leader,
                         values, n_properties);
 
@@ -84,12 +84,12 @@ meta_group_reload_properties (MetaGroup  *group,
   while (i < n_properties)
     {
       reload_prop_value (group, &values[i]);
-      
+
       ++i;
     }
 
   meta_prop_free_values (values, n_properties);
-  
+
   g_free (values);
 }
 
@@ -99,11 +99,11 @@ init_prop_value (MetaDisplay   *display,
                  Atom           property,
                  MetaPropValue *value)
 {
-  MetaGroupPropHooks *hooks;  
+  MetaGroupPropHooks *hooks;
 
   value->type = META_PROP_VALUE_INVALID;
   value->atom = None;
-  
+
   hooks = find_hooks (display, property);
   if (hooks && hooks->init_func != NULL)
     (* hooks->init_func) (display, property, value);
@@ -113,8 +113,8 @@ static void
 reload_prop_value (MetaGroup    *group,
                    MetaPropValue *value)
 {
-  MetaGroupPropHooks *hooks;  
-  
+  MetaGroupPropHooks *hooks;
+
   hooks = find_hooks (group->display, value->atom);
   if (hooks && hooks->reload_func != NULL)
     (* hooks->reload_func) (group, value);
@@ -135,7 +135,7 @@ reload_wm_client_machine (MetaGroup     *group,
 {
   g_free (group->wm_client_machine);
   group->wm_client_machine = NULL;
-  
+
   if (value->type != META_PROP_VALUE_INVALID)
     group->wm_client_machine = g_strdup (value->v.str);
 
@@ -158,10 +158,10 @@ reload_net_startup_id (MetaGroup     *group,
 {
   g_free (group->startup_id);
   group->startup_id = NULL;
-  
+
   if (value->type != META_PROP_VALUE_INVALID)
     group->startup_id = g_strdup (value->v.str);
-  
+
   meta_verbose ("Group has startup id \"%s\"\n",
                 group->startup_id ? group->startup_id : "unset");
 }
@@ -173,12 +173,12 @@ meta_display_init_group_prop_hooks (MetaDisplay *display)
 {
   int i;
   MetaGroupPropHooks *hooks;
-  
+
   g_assert (display->group_prop_hooks == NULL);
 
-  display->group_prop_hooks = g_new0 (MetaGroupPropHooks, N_HOOKS); 
+  display->group_prop_hooks = g_new0 (MetaGroupPropHooks, N_HOOKS);
   hooks = display->group_prop_hooks;
-  
+
   i = 0;
 
   hooks[i].property = display->atom_WM_CLIENT_MACHINE;
@@ -195,7 +195,7 @@ meta_display_init_group_prop_hooks (MetaDisplay *display)
   hooks[i].init_func = init_net_startup_id;
   hooks[i].reload_func = reload_net_startup_id;
   ++i;
-  
+
   if (i != N_HOOKS)
     {
       g_error ("Initialized %d group hooks should have been %d\n", i, N_HOOKS);
@@ -206,7 +206,7 @@ void
 meta_display_free_group_prop_hooks (MetaDisplay *display)
 {
   g_assert (display->group_prop_hooks != NULL);
-  
+
   g_free (display->group_prop_hooks);
   display->group_prop_hooks = NULL;
 }
@@ -220,13 +220,13 @@ find_hooks (MetaDisplay *display,
   /* FIXME we could sort the array and do binary search or
    * something
    */
-  
+
   i = 0;
   while (i < N_HOOKS)
     {
       if (display->group_prop_hooks[i].property == property)
         return &display->group_prop_hooks[i];
-      
+
       ++i;
     }
 

--- a/src/core/group-props.h
+++ b/src/core/group-props.h
@@ -2,9 +2,9 @@
 
 /* MetaGroup property handling */
 
-/* 
+/*
  * Copyright (C) 2002 Red Hat, Inc.
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA

--- a/src/core/group.c
+++ b/src/core/group.c
@@ -2,10 +2,10 @@
 
 /* Marco window groups */
 
-/* 
+/*
  * Copyright (C) 2002 Red Hat Inc.
  * Copyright (C) 2003 Rob Adams
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -15,7 +15,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -36,16 +36,16 @@ meta_group_new (MetaDisplay *display,
 #define N_INITIAL_PROPS 3
   Atom initial_props[N_INITIAL_PROPS];
   int i;
-  
+
   g_assert (N_INITIAL_PROPS == (int) G_N_ELEMENTS (initial_props));
-  
+
   group = g_new0 (MetaGroup, 1);
 
   group->display = display;
   group->windows = NULL;
   group->group_leader = group_leader;
   group->refcount = 1; /* owned by caller, hash table has only weak ref */
-  
+
   if (display->groups_by_leader == NULL)
     display->groups_by_leader = g_hash_table_new (meta_unsigned_long_hash,
                                                   meta_unsigned_long_equal);
@@ -62,13 +62,13 @@ meta_group_new (MetaDisplay *display,
   initial_props[i++] = display->atom__NET_WM_PID;
   initial_props[i++] = display->atom__NET_STARTUP_ID;
   g_assert (N_INITIAL_PROPS == i);
-  
+
   meta_group_reload_properties (group, initial_props, N_INITIAL_PROPS);
 
   meta_topic (META_DEBUG_GROUPS,
               "Created new group with leader 0x%lx\n",
               group->group_leader);
-  
+
   return group;
 }
 
@@ -82,10 +82,10 @@ meta_group_unref (MetaGroup *group)
     {
       meta_topic (META_DEBUG_GROUPS,
                   "Destroying group with leader 0x%lx\n",
-                  group->group_leader);      
-      
+                  group->group_leader);
+
       g_assert (group->display->groups_by_leader != NULL);
-      
+
       g_hash_table_remove (group->display->groups_by_leader,
                            &group->group_leader);
 
@@ -98,7 +98,7 @@ meta_group_unref (MetaGroup *group)
 
       g_free (group->wm_client_machine);
       g_free (group->startup_id);
-      
+
       g_free (group);
     }
 }
@@ -119,9 +119,9 @@ meta_window_compute_group (MetaWindow* window)
   MetaWindow *ancestor;
 
   /* use window->xwindow if no window->xgroup_leader */
-      
+
   group = NULL;
-      
+
   /* Determine the ancestor of the window; its group setting will override the
    * normal grouping rules; see bug 328211.
    */
@@ -138,7 +138,7 @@ meta_window_compute_group (MetaWindow* window)
         group = g_hash_table_lookup (window->display->groups_by_leader,
                                      &window->xwindow);
     }
-      
+
   if (group != NULL)
     {
       window->group = group;
@@ -155,7 +155,7 @@ meta_window_compute_group (MetaWindow* window)
       else
         group = meta_group_new (window->display,
                                 window->xwindow);
-          
+
       window->group = group;
     }
 
@@ -175,7 +175,7 @@ remove_window_from_group (MetaWindow *window)
       meta_topic (META_DEBUG_GROUPS,
                   "Removing %s from group with leader 0x%lx\n",
                   window->desc, window->group->group_leader);
-      
+
       window->group->windows =
         g_slist_remove (window->group->windows,
                         window);
@@ -202,9 +202,9 @@ meta_display_lookup_group (MetaDisplay *display,
                            Window       group_leader)
 {
   MetaGroup *group;
-  
+
   group = NULL;
-  
+
   if (display->groups_by_leader)
     group = g_hash_table_lookup (display->groups_by_leader,
                                  &group_leader);
@@ -223,7 +223,7 @@ meta_group_update_layers (MetaGroup *group)
 {
   GSList *tmp;
   GSList *frozen_stacks;
-  
+
   if (group->windows == NULL)
     return;
 
@@ -242,7 +242,7 @@ meta_group_update_layers (MetaGroup *group)
 
       meta_stack_update_layer (window->screen->stack,
                                window);
-      
+
       tmp = tmp->next;
     }
 

--- a/src/core/group.h
+++ b/src/core/group.h
@@ -2,9 +2,9 @@
 
 /* Marco window groups */
 
-/* 
+/*
  * Copyright (C) 2002 Red Hat Inc.
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA

--- a/src/core/iconcache.c
+++ b/src/core/iconcache.c
@@ -440,7 +440,7 @@ try_pixmap_and_mask (MetaDisplay *display,
                                  GDK_INTERP_BILINEAR);
 
       g_object_unref (G_OBJECT (unscaled));
-      
+
       if (*iconp && *mini_iconp)
         return TRUE;
       else
@@ -538,7 +538,7 @@ clear_icon_cache (MetaIconCache *icon_cache,
     g_object_unref (G_OBJECT (icon_cache->mini_icon));
   icon_cache->mini_icon = NULL;
 #endif
-  
+
   icon_cache->origin = USING_NO_ICON;
 
   if (dirty_all)
@@ -624,13 +624,13 @@ scaled_from_pixdata (guchar *pixdata,
 {
   GdkPixbuf *src;
   GdkPixbuf *dest;
-  
+
   src = gdk_pixbuf_new_from_data (pixdata,
                                   GDK_COLORSPACE_RGB,
                                   TRUE,
                                   8,
                                   w, h, w * 4,
-                                  free_pixels, 
+                                  free_pixels,
                                   NULL);
 
   if (src == NULL)
@@ -642,7 +642,7 @@ scaled_from_pixdata (guchar *pixdata,
       int size;
 
       size = MAX (w, h);
-      
+
       tmp = gdk_pixbuf_new (GDK_COLORSPACE_RGB, TRUE, 8, size, size);
 
       if (tmp)
@@ -651,16 +651,16 @@ scaled_from_pixdata (guchar *pixdata,
 	  gdk_pixbuf_copy_area (src, 0, 0, w, h,
 				tmp,
 				(size - w) / 2, (size - h) / 2);
-	  
+
 	  g_object_unref (src);
 	  src = tmp;
 	}
     }
-  
+
   if (w != new_w || h != new_h)
     {
       dest = gdk_pixbuf_scale_simple (src, new_w, new_h, GDK_INTERP_BILINEAR);
-      
+
       g_object_unref (G_OBJECT (src));
     }
   else
@@ -710,7 +710,7 @@ meta_read_icons (MetaScreen     *screen,
   icon_cache->ideal_mini_width = ideal_mini_width;
   icon_cache->ideal_mini_height = ideal_mini_height;
 #endif
-  
+
   if (!meta_icon_cache_get_icon_invalidated (icon_cache))
     return FALSE; /* we have no new info to use */
 
@@ -747,7 +747,7 @@ meta_read_icons (MetaScreen     *screen,
             {
               replace_cache (icon_cache, USING_NET_WM_ICON,
                              *iconp, *mini_iconp);
-              
+
               return TRUE;
             }
           else
@@ -831,7 +831,7 @@ meta_read_icons (MetaScreen     *screen,
 
       replace_cache (icon_cache, USING_FALLBACK_ICON,
                      *iconp, *mini_iconp);
-      
+
       return TRUE;
     }
 

--- a/src/core/iconcache.h
+++ b/src/core/iconcache.h
@@ -2,9 +2,9 @@
 
 /* Marco window icons */
 
-/* 
+/*
  * Copyright (C) 2002 Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA

--- a/src/core/keybindings.c
+++ b/src/core/keybindings.c
@@ -1,12 +1,12 @@
 /* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
 
-/* Marco Keybindings */ 
-/* 
+/* Marco Keybindings */
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2002 Red Hat Inc.
  * Copyright (C) 2003 Rob Adams
  * Copyright (C) 2004-2006 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -16,7 +16,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -142,7 +142,7 @@ reload_keymap (MetaDisplay *display)
                                          display->min_keycode,
                                          display->max_keycode -
                                          display->min_keycode + 1,
-                                         &display->keysyms_per_keycode);  
+                                         &display->keysyms_per_keycode);
 }
 
 static void
@@ -151,7 +151,7 @@ reload_modmap (MetaDisplay *display)
   XModifierKeymap *modmap;
   int map_size;
   int i;
-  
+
   if (display->modmap)
     XFreeModifiermap (display->modmap);
 
@@ -166,7 +166,7 @@ reload_modmap (MetaDisplay *display)
   display->meta_mask = 0;
   display->hyper_mask = 0;
   display->super_mask = 0;
-  
+
   /* there are 8 modifiers, and the first 3 are shift, shift lock,
    * and control
    */
@@ -178,7 +178,7 @@ reload_modmap (MetaDisplay *display)
        * see if its keysym is one we're interested in
        */
       int keycode = modmap->modifiermap[i];
-      
+
       if (keycode >= display->min_keycode &&
           keycode <= display->max_keycode)
         {
@@ -191,21 +191,21 @@ reload_modmap (MetaDisplay *display)
               if (syms[j] != 0)
                 {
                   const char *str;
-                  
+
                   str = XKeysymToString (syms[j]);
                   meta_topic (META_DEBUG_KEYBINDINGS,
                               "Keysym %s bound to modifier 0x%x\n",
                               str ? str : "none",
                               (1 << ( i / modmap->max_keypermod)));
                 }
-              
+
               if (syms[j] == XK_Num_Lock)
                 {
                   /* Mod1Mask is 1 << 3 for example, i.e. the
                    * fourth modifier, i / keyspermod is the modifier
                    * index
                    */
-                  
+
                   display->num_lock_mask |= (1 << ( i / modmap->max_keypermod));
                 }
               else if (syms[j] == XK_Scroll_Lock)
@@ -221,17 +221,17 @@ reload_modmap (MetaDisplay *display)
                        syms[j] == XK_Hyper_R)
                 {
                   display->hyper_mask |= (1 << ( i / modmap->max_keypermod));
-                }              
+                }
               else if (syms[j] == XK_Meta_L ||
                        syms[j] == XK_Meta_R)
                 {
                   display->meta_mask |= (1 << ( i / modmap->max_keypermod));
                 }
-              
+
               ++j;
             }
         }
-      
+
       ++i;
     }
 
@@ -258,14 +258,14 @@ reload_keycodes (MetaDisplay *display)
   if (display->key_bindings)
     {
       int i;
-      
+
       i = 0;
       while (i < display->n_key_bindings)
         {
           if (display->key_bindings[i].keycode == 0)
               display->key_bindings[i].keycode = XKeysymToKeycode (
                       display->xdisplay, display->key_bindings[i].keysym);
-          
+
           ++i;
         }
     }
@@ -276,11 +276,11 @@ reload_modifiers (MetaDisplay *display)
 {
   meta_topic (META_DEBUG_KEYBINDINGS,
               "Reloading keycodes for binding tables\n");
-  
+
   if (display->key_bindings)
     {
       int i;
-      
+
       i = 0;
       while (i < display->n_key_bindings)
         {
@@ -292,8 +292,8 @@ reload_modifiers (MetaDisplay *display)
                       " Devirtualized mods 0x%x -> 0x%x (%s)\n",
                       display->key_bindings[i].modifiers,
                       display->key_bindings[i].mask,
-                      display->key_bindings[i].name);          
-          
+                      display->key_bindings[i].name);
+
           ++i;
         }
     }
@@ -328,7 +328,7 @@ count_bindings (const MetaKeyPref *prefs,
 
           tmp = tmp->next;
         }
-      
+
       ++i;
     }
 
@@ -363,7 +363,7 @@ rebuild_binding_table (MetaDisplay        *display,
 {
   int n_bindings;
   int src, dest;
-  
+
   n_bindings = count_bindings (prefs, n_prefs);
   g_free (*bindings_p);
   *bindings_p = g_new0 (MetaKeyBinding, n_bindings);
@@ -388,7 +388,7 @@ rebuild_binding_table (MetaDisplay        *display,
               (*bindings_p)[dest].keycode = combo->keycode;
               (*bindings_p)[dest].modifiers = combo->modifiers;
               (*bindings_p)[dest].mask = 0;
-          
+
               ++dest;
 
               if (prefs[src].add_shift &&
@@ -397,7 +397,7 @@ rebuild_binding_table (MetaDisplay        *display,
                   meta_topic (META_DEBUG_KEYBINDINGS,
                               "Binding %s also needs Shift grabbed\n",
                                prefs[src].name);
-              
+
                   (*bindings_p)[dest].name = prefs[src].name;
                   (*bindings_p)[dest].handler = handler;
                   (*bindings_p)[dest].keysym = combo->keysym;
@@ -405,19 +405,19 @@ rebuild_binding_table (MetaDisplay        *display,
                   (*bindings_p)[dest].modifiers = combo->modifiers |
                     META_VIRTUAL_SHIFT_MASK;
                   (*bindings_p)[dest].mask = 0;
-              
+
                   ++dest;
                 }
             }
-            
+
           tmp = tmp->next;
         }
-      
+
       ++src;
     }
 
   g_assert (dest == n_bindings);
-  
+
   *n_bindings_p = dest;
 
   meta_topic (META_DEBUG_KEYBINDINGS,
@@ -430,10 +430,10 @@ rebuild_key_binding_table (MetaDisplay *display)
 {
   const MetaKeyPref *prefs;
   int n_prefs;
-  
+
   meta_topic (META_DEBUG_KEYBINDINGS,
               "Rebuilding key binding table from preferences\n");
-  
+
   meta_prefs_get_key_bindings (&prefs, &n_prefs);
   rebuild_binding_table (display,
                          &display->key_bindings,
@@ -448,7 +448,7 @@ regrab_key_bindings (MetaDisplay *display)
   GSList *windows;
 
   meta_error_trap_push (display); /* for efficiency push outer trap */
-  
+
   tmp = display->screens;
   while (tmp != NULL)
     {
@@ -465,10 +465,10 @@ regrab_key_bindings (MetaDisplay *display)
   while (tmp != NULL)
     {
       MetaWindow *w = tmp->data;
-      
+
       meta_window_ungrab_keys (w);
       meta_window_grab_keys (w);
-      
+
       tmp = tmp->next;
     }
   meta_error_trap_pop (display, FALSE);
@@ -493,7 +493,7 @@ display_get_keybinding_action (MetaDisplay  *display,
         {
           return meta_prefs_get_keybinding_action (display->key_bindings[i].name);
         }
-      
+
       --i;
     }
 
@@ -503,7 +503,7 @@ display_get_keybinding_action (MetaDisplay  *display,
 void
 meta_display_process_mapping_event (MetaDisplay *display,
                                     XEvent      *event)
-{ 
+{
   if (event->xmapping.request == MappingModifier)
     {
       meta_topic (META_DEBUG_KEYBINDINGS,
@@ -512,7 +512,7 @@ meta_display_process_mapping_event (MetaDisplay *display,
       reload_modmap (display);
 
       reload_modifiers (display);
-      
+
       regrab_key_bindings (display);
     }
   else if (event->xmapping.request == MappingKeyboard)
@@ -522,7 +522,7 @@ meta_display_process_mapping_event (MetaDisplay *display,
 
       reload_keymap (display);
       reload_modmap (display);
-      
+
       reload_keycodes (display);
 
       regrab_key_bindings (display);
@@ -536,7 +536,7 @@ bindings_changed_callback (MetaPreference pref,
   MetaDisplay *display;
 
   display = data;
-  
+
   switch (pref)
     {
     case META_PREF_KEYBINDINGS:
@@ -585,9 +585,9 @@ meta_display_init_keys (MetaDisplay *display)
 
   reload_keycodes (display);
   reload_modifiers (display);
-  
+
   /* Keys are actually grabbed in meta_screen_grab_keys() */
-  
+
   meta_prefs_add_listener (bindings_changed_callback, display);
 }
 
@@ -595,12 +595,12 @@ void
 meta_display_shutdown_keys (MetaDisplay *display)
 {
   /* Note that display->xdisplay is invalid in this function */
-  
+
   meta_prefs_remove_listener (bindings_changed_callback, display);
 
   if (display->keymap)
     meta_XFree (display->keymap);
-  
+
   if (display->modmap)
     XFreeModifiermap (display->modmap);
   g_free (display->key_bindings);
@@ -610,7 +610,7 @@ static const char*
 keysym_name (int keysym)
 {
   const char *name;
-  
+
   name = XKeysymToString (keysym);
   if (name == NULL)
     name = "(unknown)";
@@ -642,7 +642,7 @@ meta_change_keygrab (MetaDisplay *display,
 
   /* efficiency, avoid so many XSync() */
   meta_error_trap_push (display);
-  
+
   ignored_mask = 0;
   while (ignored_mask <= display->ignored_modifier_mask)
     {
@@ -671,11 +671,11 @@ meta_change_keygrab (MetaDisplay *display,
       if (meta_is_debugging ())
         {
           int result;
-          
+
           result = meta_error_trap_pop_with_return (display, FALSE);
-          
+
           if (grab && result != Success)
-            {      
+            {
               if (result == BadAccess)
                 meta_warning (_("Some other program is already using the key %s with modifiers %x as a binding\n"), keysym_name (keysym), modmask | ignored_mask);
               else
@@ -713,7 +713,7 @@ grab_keys (MetaKeyBinding *bindings,
   g_assert (n_bindings == 0 || bindings != NULL);
 
   meta_error_trap_push (display);
-  
+
   i = 0;
   while (i < n_bindings)
     {
@@ -726,7 +726,7 @@ grab_keys (MetaKeyBinding *bindings,
                          bindings[i].keycode,
                          bindings[i].mask);
         }
-      
+
       ++i;
     }
 
@@ -748,10 +748,10 @@ ungrab_all_keys (MetaDisplay *display,
   if (meta_is_debugging ())
     {
       int result;
-      
+
       result = meta_error_trap_pop_with_return (display, FALSE);
-      
-      if (result != Success)    
+
+      if (result != Success)
         meta_topic (META_DEBUG_KEYBINDINGS,
                     "Ungrabbing all keys on 0x%lx failed\n", xwindow);
     }
@@ -799,7 +799,7 @@ meta_window_grab_keys (MetaWindow  *window)
       window->keys_grabbed = FALSE;
       return;
     }
-  
+
   if (window->keys_grabbed)
     {
       if (window->frame && !window->grab_on_frame)
@@ -810,7 +810,7 @@ meta_window_grab_keys (MetaWindow  *window)
       else
         return; /* already all good */
     }
-  
+
   grab_keys (window->display->key_bindings,
              window->display->n_key_bindings,
              window->display,
@@ -867,7 +867,7 @@ grab_keyboard (MetaDisplay *display,
 {
   int result;
   int grab_status;
-  
+
   /* Grab the keyboard, so we get key releases and all key
    * presses
    */
@@ -877,7 +877,7 @@ grab_keyboard (MetaDisplay *display,
                                xwindow, True,
                                GrabModeAsync, GrabModeAsync,
                                timestamp);
-  
+
   if (grab_status != GrabSuccess)
     {
       meta_error_trap_pop_with_return (display, TRUE);
@@ -897,9 +897,9 @@ grab_keyboard (MetaDisplay *display,
           return FALSE;
         }
     }
-       
+
   meta_topic (META_DEBUG_KEYBINDINGS, "Grabbed all keys\n");
-       
+
   return TRUE;
 }
 
@@ -922,7 +922,7 @@ meta_screen_grab_all_keys (MetaScreen *screen, guint32 timestamp)
 
   if (screen->all_keys_grabbed)
     return FALSE;
-  
+
   if (screen->keys_grabbed)
     meta_screen_ungrab_keys (screen);
 
@@ -958,10 +958,10 @@ meta_window_grab_all_keys (MetaWindow  *window,
 {
   Window grabwindow;
   gboolean retval;
-  
+
   if (window->all_keys_grabbed)
     return FALSE;
-  
+
   if (window->keys_grabbed)
     meta_window_ungrab_keys (window);
 
@@ -972,7 +972,7 @@ meta_window_grab_all_keys (MetaWindow  *window,
               "Focusing %s because we're grabbing all its keys\n",
               window->desc);
   meta_window_focus (window, timestamp);
-  
+
   grabwindow = window->frame ? window->frame->xwindow : window->xwindow;
 
   meta_topic (META_DEBUG_KEYBINDINGS,
@@ -1004,16 +1004,16 @@ meta_window_ungrab_all_keys (MetaWindow *window, guint32 timestamp)
     }
 }
 
-static gboolean 
+static gboolean
 is_modifier (MetaDisplay *display,
              unsigned int keycode)
 {
   int i;
   int map_size;
-  gboolean retval = FALSE;  
+  gboolean retval = FALSE;
 
   g_assert (display->modmap);
-  
+
   map_size = 8 * display->modmap->max_keypermod;
   i = 0;
   while (i < map_size)
@@ -1025,7 +1025,7 @@ is_modifier (MetaDisplay *display,
         }
       ++i;
     }
-  
+
   return retval;
 }
 
@@ -1040,7 +1040,7 @@ is_modifier (MetaDisplay *display,
  * mod5 = 7
  */
 
-static gboolean 
+static gboolean
 is_specific_modifier (MetaDisplay *display,
                       unsigned int keycode,
                       unsigned int mask)
@@ -1049,13 +1049,13 @@ is_specific_modifier (MetaDisplay *display,
   int end;
   gboolean retval = FALSE;
   int mod_index;
-  
+
   g_assert (display->modmap);
 
   meta_topic (META_DEBUG_KEYBINDINGS,
               "Checking whether code 0x%x is bound to modifier 0x%x\n",
               keycode, mask);
-  
+
   mod_index = 0;
   mask = mask >> 1;
   while (mask != 0)
@@ -1066,7 +1066,7 @@ is_specific_modifier (MetaDisplay *display,
 
   meta_topic (META_DEBUG_KEYBINDINGS,
               "Modifier has index %d\n", mod_index);
-  
+
   end = (mod_index + 1) * display->modmap->max_keypermod;
   i = mod_index * display->modmap->max_keypermod;
   while (i < end)
@@ -1078,7 +1078,7 @@ is_specific_modifier (MetaDisplay *display,
         }
       ++i;
     }
-  
+
   return retval;
 }
 
@@ -1097,7 +1097,7 @@ get_primary_modifier (MetaDisplay *display,
                            ShiftMask, LockMask };
 
   int i;
-  
+
   i = 0;
   while (i < (int) G_N_ELEMENTS (masks))
     {
@@ -1119,7 +1119,7 @@ keycode_is_primary_modifier (MetaDisplay *display,
   meta_topic (META_DEBUG_KEYBINDINGS,
               "Checking whether code 0x%x is the primary modifier of mask 0x%x\n",
               keycode, entire_binding_mask);
-  
+
   primary_modifier = get_primary_modifier (display, entire_binding_mask);
   if (primary_modifier != 0)
     return is_specific_modifier (display, keycode, primary_modifier);
@@ -1137,9 +1137,9 @@ primary_modifier_still_pressed (MetaDisplay *display,
   guint mask;
   MetaScreen *random_screen;
   Window      random_xwindow;
-  
+
   primary_modifier = get_primary_modifier (display, entire_binding_mask);
-  
+
   random_screen = display->screens->data;
   random_xwindow = random_screen->no_focus_window;
   XQueryPointer (display->xdisplay,
@@ -1152,7 +1152,7 @@ primary_modifier_still_pressed (MetaDisplay *display,
   meta_topic (META_DEBUG_KEYBINDINGS,
               "Primary modifier 0x%x full grab mask 0x%x current state 0x%x\n",
               primary_modifier, entire_binding_mask, mask);
-  
+
   if ((mask & primary_modifier) == 0)
     return FALSE;
   else
@@ -1190,7 +1190,7 @@ process_event (MetaKeyBinding       *bindings,
           ((event->xkey.state & 0xff & ~(display->ignored_modifier_mask)) !=
            bindings[i].mask))
         continue;
-        
+
       /*
        * window must be non-NULL for on_window to be true,
        * and so also window must be non-NULL if we get here and
@@ -1208,7 +1208,7 @@ process_event (MetaKeyBinding       *bindings,
         meta_topic (META_DEBUG_KEYBINDINGS,
                     "Running handler for %s\n",
                     bindings[i].name);
-          
+
       /* Global keybindings count as a let-the-terminal-lose-focus
        * due to new window mapping until the user starts
        * interacting with the terminal again.
@@ -1254,10 +1254,10 @@ meta_display_process_key_event (MetaDisplay *display,
                 event->xkey.time);
   if (all_bindings_disabled)
     return;
-  
+
   /* if key event was on root window, we have a shortcut */
   screen = meta_display_screen_for_root (display, event->xkey.window);
-  
+
   /* else round-trip to server */
   if (screen == NULL)
     screen = meta_display_screen_for_xwindow (display,
@@ -1265,18 +1265,18 @@ meta_display_process_key_event (MetaDisplay *display,
 
   if (screen == NULL)
     return; /* event window is destroyed */
-  
+
   /* ignore key events on popup menus and such. */
   if (window == NULL &&
       meta_ui_window_is_widget (screen->ui, event->xany.window))
     return;
-  
+
   /* window may be NULL */
-  
+
   keysym = XKeycodeToKeysym (display->xdisplay, event->xkey.keycode, 0);
 
   str = XKeysymToString (keysym);
-  
+
   /* was topic */
   meta_topic (META_DEBUG_KEYBINDINGS,
               "Processing key %s event, keysym: %s state: 0x%x window: %s\n",
@@ -1301,8 +1301,8 @@ meta_display_process_key_event (MetaDisplay *display,
             {
             case META_GRAB_OP_MOVING:
             case META_GRAB_OP_RESIZING_SE:
-            case META_GRAB_OP_RESIZING_S:      
-            case META_GRAB_OP_RESIZING_SW:      
+            case META_GRAB_OP_RESIZING_S:
+            case META_GRAB_OP_RESIZING_SW:
             case META_GRAB_OP_RESIZING_N:
             case META_GRAB_OP_RESIZING_NE:
             case META_GRAB_OP_RESIZING_NW:
@@ -1314,7 +1314,7 @@ meta_display_process_key_event (MetaDisplay *display,
               keep_grab = process_mouse_move_resize_grab (display, screen,
                                                           window, event, keysym);
               break;
- 
+
             case META_GRAB_OP_KEYBOARD_MOVING:
               meta_topic (META_DEBUG_KEYBINDINGS,
                           "Processing event for keyboard move\n");
@@ -1322,7 +1322,7 @@ meta_display_process_key_event (MetaDisplay *display,
               keep_grab = process_keyboard_move_grab (display, screen,
                                                       window, event, keysym);
               break;
-              
+
             case META_GRAB_OP_KEYBOARD_RESIZING_UNKNOWN:
             case META_GRAB_OP_KEYBOARD_RESIZING_S:
             case META_GRAB_OP_KEYBOARD_RESIZING_N:
@@ -1331,14 +1331,14 @@ meta_display_process_key_event (MetaDisplay *display,
             case META_GRAB_OP_KEYBOARD_RESIZING_SE:
             case META_GRAB_OP_KEYBOARD_RESIZING_NE:
             case META_GRAB_OP_KEYBOARD_RESIZING_SW:
-            case META_GRAB_OP_KEYBOARD_RESIZING_NW:          
+            case META_GRAB_OP_KEYBOARD_RESIZING_NW:
               meta_topic (META_DEBUG_KEYBINDINGS,
                           "Processing event for keyboard resize\n");
               g_assert (window != NULL);
               keep_grab = process_keyboard_resize_grab (display, screen,
                                                         window, event, keysym);
               break;
- 
+
             case META_GRAB_OP_KEYBOARD_TABBING_NORMAL:
             case META_GRAB_OP_KEYBOARD_TABBING_NORMAL_ALL_WORKSPACES:
             case META_GRAB_OP_KEYBOARD_TABBING_DOCK:
@@ -1351,13 +1351,13 @@ meta_display_process_key_event (MetaDisplay *display,
                           "Processing event for keyboard tabbing/cycling\n");
               keep_grab = process_tab_grab (display, screen, event, keysym);
               break;
-              
+
             case META_GRAB_OP_KEYBOARD_WORKSPACE_SWITCHING:
               meta_topic (META_DEBUG_KEYBINDINGS,
                           "Processing event for keyboard workspace switching\n");
               keep_grab = process_workspace_switch_grab (display, screen, event, keysym);
               break;
- 
+
             default:
               break;
             }
@@ -1430,7 +1430,7 @@ process_keyboard_move_grab (MetaDisplay *display,
   int x, y;
   int incr;
   gboolean smart_snap;
-  
+
   handled = FALSE;
 
   /* don't care about releases, but eat them, don't end grab */
@@ -1452,7 +1452,7 @@ process_keyboard_move_grab (MetaDisplay *display,
     }
 
   smart_snap = (event->xkey.state & ShiftMask) != 0;
-  
+
 #define SMALL_INCREMENT 1
 #define NORMAL_INCREMENT 10
 
@@ -1486,7 +1486,7 @@ process_keyboard_move_grab (MetaDisplay *display,
       else
         display->grab_was_cancelled = TRUE;
     }
-  
+
   /* When moving by increments, we still snap to edges if the move
    * to the edge is smaller than the increment. This is because
    * Shift + arrow to snap is sort of a hidden feature. This way
@@ -1509,7 +1509,7 @@ process_keyboard_move_grab (MetaDisplay *display,
       handled = TRUE;
       break;
     }
-  
+
   switch (keysym)
     {
     case XK_KP_Home:
@@ -1540,7 +1540,7 @@ process_keyboard_move_grab (MetaDisplay *display,
       else
         meta_window_get_client_root_coords (window, &old_rect);
 
-      meta_window_edge_resistance_for_move (window, 
+      meta_window_edge_resistance_for_move (window,
                                             old_rect.x,
                                             old_rect.y,
                                             &x,
@@ -1559,7 +1559,7 @@ process_keyboard_move_grab (MetaDisplay *display,
         {
           meta_window_move (window, TRUE, x, y);
         }
-      
+
       meta_window_update_keyboard_move (window);
     }
 
@@ -1583,7 +1583,7 @@ process_keyboard_resize_grab_op_change (MetaDisplay *display,
         {
         case XK_Up:
         case XK_KP_Up:
-          display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_N;          
+          display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_N;
           handled = TRUE;
           break;
         case XK_Down:
@@ -1603,7 +1603,7 @@ process_keyboard_resize_grab_op_change (MetaDisplay *display,
           break;
         }
       break;
-      
+
     case META_GRAB_OP_KEYBOARD_RESIZING_S:
       switch (keysym)
         {
@@ -1635,13 +1635,13 @@ process_keyboard_resize_grab_op_change (MetaDisplay *display,
           break;
         }
       break;
-      
+
     case META_GRAB_OP_KEYBOARD_RESIZING_W:
       switch (keysym)
         {
         case XK_Up:
         case XK_KP_Up:
-          display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_N;          
+          display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_N;
           handled = TRUE;
           break;
         case XK_Down:
@@ -1657,7 +1657,7 @@ process_keyboard_resize_grab_op_change (MetaDisplay *display,
         {
         case XK_Up:
         case XK_KP_Up:
-          display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_N; 
+          display->grab_op = META_GRAB_OP_KEYBOARD_RESIZING_N;
           handled = TRUE;
           break;
         case XK_Down:
@@ -1667,7 +1667,7 @@ process_keyboard_resize_grab_op_change (MetaDisplay *display,
           break;
         }
       break;
-      
+
     case META_GRAB_OP_KEYBOARD_RESIZING_SE:
     case META_GRAB_OP_KEYBOARD_RESIZING_NE:
     case META_GRAB_OP_KEYBOARD_RESIZING_SW:
@@ -1682,7 +1682,7 @@ process_keyboard_resize_grab_op_change (MetaDisplay *display,
   if (handled)
     {
       meta_window_update_keyboard_resize (window, TRUE);
-      return TRUE; 
+      return TRUE;
     }
 
   return FALSE;
@@ -1701,7 +1701,7 @@ process_keyboard_resize_grab (MetaDisplay *display,
   int width, height;
   gboolean smart_snap;
   int gravity;
-  
+
   handled = FALSE;
 
   /* don't care about releases, but eat them, don't end grab */
@@ -1733,7 +1733,7 @@ process_keyboard_resize_grab (MetaDisplay *display,
       return FALSE;
     }
 
-  if (process_keyboard_resize_grab_op_change (display, screen, window, 
+  if (process_keyboard_resize_grab_op_change (display, screen, window,
                                               event, keysym))
     return TRUE;
 
@@ -1751,7 +1751,7 @@ process_keyboard_resize_grab (MetaDisplay *display,
   gravity = meta_resize_gravity_from_grab_op (display->grab_op);
 
   smart_snap = (event->xkey.state & ShiftMask) != 0;
-  
+
 #define SMALL_INCREMENT 1
 #define NORMAL_INCREMENT 10
 
@@ -1764,7 +1764,7 @@ process_keyboard_resize_grab (MetaDisplay *display,
     {
       width_inc = SMALL_INCREMENT;
       height_inc = SMALL_INCREMENT;
-    }  
+    }
   else
     {
       width_inc = NORMAL_INCREMENT;
@@ -1778,7 +1778,7 @@ process_keyboard_resize_grab (MetaDisplay *display,
     width_inc = window->size_hints.width_inc;
   if (window->size_hints.height_inc > 1)
     height_inc = window->size_hints.height_inc;
-  
+
   switch (keysym)
     {
     case XK_Up:
@@ -1805,7 +1805,7 @@ process_keyboard_resize_grab (MetaDisplay *display,
           g_assert_not_reached ();
           break;
         }
-      
+
       handled = TRUE;
       break;
 
@@ -1833,10 +1833,10 @@ process_keyboard_resize_grab (MetaDisplay *display,
           g_assert_not_reached ();
           break;
         }
-      
+
       handled = TRUE;
       break;
-      
+
     case XK_Left:
     case XK_KP_Left:
       switch (gravity)
@@ -1861,10 +1861,10 @@ process_keyboard_resize_grab (MetaDisplay *display,
           g_assert_not_reached ();
           break;
         }
-      
+
       handled = TRUE;
       break;
-      
+
     case XK_Right:
     case XK_KP_Right:
       switch (gravity)
@@ -1889,10 +1889,10 @@ process_keyboard_resize_grab (MetaDisplay *display,
           g_assert_not_reached ();
           break;
         }
-      
+
       handled = TRUE;
       break;
-          
+
     default:
       break;
     }
@@ -1902,7 +1902,7 @@ process_keyboard_resize_grab (MetaDisplay *display,
     height = 1;
   if (width < 1)
     width = 1;
-  
+
   if (handled)
     {
       MetaRectangle old_rect;
@@ -1910,7 +1910,7 @@ process_keyboard_resize_grab (MetaDisplay *display,
                   "Computed new window size due to keypress: "
                   "%dx%d, gravity %s\n",
                   width, height, meta_gravity_to_string (gravity));
-      
+
       if (display->grab_wireframe_active)
         old_rect = display->grab_wireframe_rect;
       else
@@ -1930,15 +1930,15 @@ process_keyboard_resize_grab (MetaDisplay *display,
       if (display->grab_wireframe_active)
         {
           MetaRectangle new_position;
-          meta_rectangle_resize_with_gravity (&display->grab_wireframe_rect, 
+          meta_rectangle_resize_with_gravity (&display->grab_wireframe_rect,
                                               &new_position,
                                               gravity,
                                               width,
                                               height);
-          meta_window_update_wireframe (window, 
+          meta_window_update_wireframe (window,
                                         new_position.x,
                                         new_position.y,
-                                        new_position.width, 
+                                        new_position.width,
                                         new_position.height);
         }
       else
@@ -1947,7 +1947,7 @@ process_keyboard_resize_grab (MetaDisplay *display,
            * are actually different from what we had before.
            */
           if (window->rect.width != width || window->rect.height != height)
-            meta_window_resize_with_gravity (window, 
+            meta_window_resize_with_gravity (window,
                                              TRUE,
                                              width,
                                              height,
@@ -1968,9 +1968,9 @@ end_keyboard_grab (MetaDisplay *display,
     {
       unsigned int primary_modifier;
       XkbStateRec state;
-  
+
       primary_modifier = get_primary_modifier (display, display->grab_mask);
-      
+
       XkbGetState (display->xdisplay, XkbUseCoreKbd, &state);
 
       if (!(primary_modifier & state.mods))
@@ -2018,7 +2018,7 @@ process_tab_grab (MetaDisplay *display,
 
       meta_topic (META_DEBUG_KEYBINDINGS,
                   "Ending tab operation, primary modifier released\n");
-      
+
       if (target_window)
         {
           target_window->tab_unminimized = FALSE;
@@ -2039,10 +2039,10 @@ process_tab_grab (MetaDisplay *display,
 
           return TRUE; /* we already ended the grab */
         }
-      
+
       return FALSE; /* end grab */
     }
-  
+
   /* don't care about other releases, but eat them, don't end grab */
   if (event->type == KeyRelease)
     return TRUE;
@@ -2122,7 +2122,7 @@ process_tab_grab (MetaDisplay *display,
         default:
              return FALSE;
         }
- 
+
       break;
     default:
       break;
@@ -2134,7 +2134,7 @@ process_tab_grab (MetaDisplay *display,
    * of course).
    * See _{SWITCH,CYCLE}_GROUP.@@@
    */
-   
+
   popup_not_showing = FALSE;
   key_used = FALSE;
   backward = FALSE;
@@ -2168,7 +2168,7 @@ process_tab_grab (MetaDisplay *display,
     default:
       break;
     }
-  
+
   if (key_used)
     {
       meta_topic (META_DEBUG_KEYBINDINGS,
@@ -2181,7 +2181,7 @@ process_tab_grab (MetaDisplay *display,
         meta_ui_tab_popup_backward (screen->tab_popup);
       else
         meta_ui_tab_popup_forward (screen->tab_popup);
-      
+
       if (popup_not_showing)
         {
           /* We can't actually change window focus, due to the grab.
@@ -2197,7 +2197,7 @@ process_tab_grab (MetaDisplay *display,
             (Window) meta_ui_tab_popup_get_selected (screen->tab_popup);
           target_window =
             meta_display_lookup_x_window (display, target_xwindow);
-          
+
           if (prev_window && prev_window->tab_unminimized)
             {
               prev_window->tab_unminimized = FALSE;
@@ -2218,7 +2218,7 @@ process_tab_grab (MetaDisplay *display,
       meta_topic (META_DEBUG_KEYBINDINGS,
                   "Ending tabbing/cycling, uninteresting key pressed\n");
 
-      meta_topic (META_DEBUG_KEYBINDINGS, 
+      meta_topic (META_DEBUG_KEYBINDINGS,
                   "Syncing to old stack positions.\n");
       meta_stack_set_positions (screen->stack,
                                 screen->display->grab_old_window_stacking);
@@ -2229,7 +2229,7 @@ process_tab_grab (MetaDisplay *display,
           prev_window->tab_unminimized = FALSE;
         }
     }
-  
+
   return key_used;
 }
 
@@ -2268,7 +2268,7 @@ handle_switch_to_workspace (MetaDisplay    *display,
     }
 
   workspace = meta_screen_get_workspace_by_index (screen, which);
-  
+
   if (workspace)
     {
       meta_workspace_activate (workspace, event->xkey.time);
@@ -2287,14 +2287,14 @@ error_on_command (int         command_index,
                   guint32     timestamp)
 {
   if (command_index < 0)
-    meta_warning ("Error on terminal command \"%s\": %s\n", command, message);  
+    meta_warning ("Error on terminal command \"%s\": %s\n", command, message);
   else
     meta_warning ("Error on command %d \"%s\": %s\n",
-                  command_index, command, message);  
+                  command_index, command, message);
 
   /*
     marco-dialog said:
-        
+
     FIXME offer to change the value of the command's mateconf key
   */
 
@@ -2341,7 +2341,7 @@ set_display_setup_func (void *data)
   putenv (full);
 
   /* do not free full, because putenv is lame */
-} 
+}
 
 static gboolean
 meta_spawn_command_line_async_on_screen (const gchar *command_line,
@@ -2357,7 +2357,7 @@ meta_spawn_command_line_async_on_screen (const gchar *command_line,
                            NULL, &argv,
                            error))
     return FALSE;
-  
+
   retval = g_spawn_async (NULL,
                           argv,
                           NULL,
@@ -2382,7 +2382,7 @@ handle_run_command (MetaDisplay    *display,
   gint which = binding->handler->data;
   const char *command;
   GError *err;
-  
+
   command = meta_prefs_get_command (which);
 
   if (command == NULL)
@@ -2392,12 +2392,12 @@ handle_run_command (MetaDisplay    *display,
       meta_topic (META_DEBUG_KEYBINDINGS,
                   "No command %d to run in response to keybinding press\n",
                   which);
-      
+
       s = g_strdup_printf (_("No command %d has been defined.\n"),
                            which + 1);
       error_on_command (which, NULL, s, screen->number, event->xkey.time);
       g_free (s);
-      
+
       return;
     }
 
@@ -2405,7 +2405,7 @@ handle_run_command (MetaDisplay    *display,
   if (!meta_spawn_command_line_async_on_screen (command, screen, &err))
     {
       error_on_command (which, command, err->message, screen->number, event->xkey.time);
-      
+
       g_error_free (err);
     }
 }
@@ -2636,7 +2636,7 @@ process_workspace_switch_grab (MetaDisplay *display,
           meta_topic (META_DEBUG_KEYBINDINGS,
                       "Focusing default window on target workspace\n");
 
-          meta_workspace_focus_default_window (target_workspace, 
+          meta_workspace_focus_default_window (target_workspace,
                                                NULL,
                                                event->xkey.time);
 
@@ -2645,10 +2645,10 @@ process_workspace_switch_grab (MetaDisplay *display,
 
       /* Workspace switching should have already occurred on KeyPress */
       meta_warning ("target_workspace != active_workspace.  Some other event must have occurred.\n");
-      
+
       return FALSE; /* end grab */
     }
-  
+
   /* don't care about other releases, but eat them, don't end grab */
   if (event->type == KeyRelease)
     return TRUE;
@@ -2660,7 +2660,7 @@ process_workspace_switch_grab (MetaDisplay *display,
   /* select the next workspace in the tabpopup */
   workspace =
     (MetaWorkspace *) meta_ui_tab_popup_get_selected (screen->tab_popup);
-  
+
   if (workspace)
     {
       MetaWorkspace *target_workspace;
@@ -2733,7 +2733,7 @@ handle_show_desktop (MetaDisplay    *display,
   if (screen->active_workspace->showing_desktop)
     {
       meta_screen_unshow_desktop (screen);
-      meta_workspace_focus_default_window (screen->active_workspace, 
+      meta_workspace_focus_default_window (screen->active_workspace,
                                            NULL,
                                            event->xkey.time);
     }
@@ -2765,7 +2765,7 @@ handle_panel (MetaDisplay    *display,
     default:
       return;
     }
-   
+
   ev.type = ClientMessage;
   ev.window = screen->xroot;
   ev.message_type = display->atom__MATE_PANEL_ACTION;
@@ -2805,7 +2805,7 @@ handle_activate_window_menu (MetaDisplay    *display,
 
       meta_window_get_position (display->focus_window,
                                 &x, &y);
-      
+
       if (meta_ui_get_direction() == META_UI_DIRECTION_RTL)
 	  x += display->focus_window->rect.width;
 
@@ -2832,7 +2832,7 @@ tab_op_from_tab_type (MetaTabList type)
     }
 
   g_assert_not_reached ();
-  
+
   return 0;
 }
 
@@ -2852,7 +2852,7 @@ cycle_op_from_tab_type (MetaTabList type)
     }
 
   g_assert_not_reached ();
-  
+
   return 0;
 }
 
@@ -2870,11 +2870,11 @@ do_choose_window (MetaDisplay    *display,
 
   meta_topic (META_DEBUG_KEYBINDINGS,
               "Tab list = %u show_popup = %d\n", type, show_popup);
-  
+
   /* reverse direction if shift is down */
   if (event->xkey.state & ShiftMask)
     backward = !backward;
-  
+
   initial_selection = meta_display_get_tab_next (display,
                                                  type,
                                                  screen,
@@ -2887,10 +2887,10 @@ do_choose_window (MetaDisplay    *display,
     initial_selection = meta_display_get_tab_current (display,
                                                       type, screen,
                                                       screen->active_workspace);
-  
+
   meta_topic (META_DEBUG_KEYBINDINGS,
               "Initially selecting window %s\n",
-              initial_selection ? initial_selection->desc : "(none)");  
+              initial_selection ? initial_selection->desc : "(none)");
 
   if (initial_selection != NULL)
     {
@@ -2927,7 +2927,7 @@ do_choose_window (MetaDisplay    *display,
                * before we establish the grab. must end grab
                * prior to trying to focus a window.
                */
-              meta_topic (META_DEBUG_FOCUS, 
+              meta_topic (META_DEBUG_FOCUS,
                           "Ending grab, activating %s, and turning off "
                           "mouse_mode due to switch/cycle windows where "
                           "modifier was released prior to grab\n",
@@ -2941,14 +2941,14 @@ do_choose_window (MetaDisplay    *display,
             {
               meta_ui_tab_popup_select (screen->tab_popup,
                                         (MetaTabEntryKey) initial_selection->xwindow);
-              
+
               if (show_popup)
                 meta_ui_tab_popup_set_showing (screen->tab_popup,
                                                TRUE);
               else
                 {
                   meta_window_raise (initial_selection);
-                  initial_selection->tab_unminimized = 
+                  initial_selection->tab_unminimized =
                     initial_selection->minimized;
                   meta_window_unminimize (initial_selection);
                 }
@@ -3143,7 +3143,7 @@ handle_move_to_workspace  (MetaDisplay    *display,
   gint which = binding->handler->data;
   gboolean flip = (which < 0);
   MetaWorkspace *workspace;
-  
+
   /* If which is zero or positive, it's a workspace number, and the window
    * should move to the workspace with that number.
    *
@@ -3154,10 +3154,10 @@ handle_move_to_workspace  (MetaDisplay    *display,
 
   if (window->always_sticky)
     return;
-  
+
   workspace = NULL;
   if (flip)
-    {      
+    {
       workspace = meta_workspace_get_neighbor (screen->active_workspace,
                                                which);
     }
@@ -3165,7 +3165,7 @@ handle_move_to_workspace  (MetaDisplay    *display,
     {
       workspace = meta_screen_get_workspace_by_index (screen, which);
     }
-  
+
   if (workspace)
     {
       /* Activate second, so the window is never unmapped */
@@ -3184,10 +3184,10 @@ handle_move_to_workspace  (MetaDisplay    *display,
   else
     {
       /* We could offer to create it I suppose */
-    }  
+    }
 }
 
-static void 
+static void
 handle_raise_or_lower (MetaDisplay    *display,
                        MetaScreen     *screen,
 		       MetaWindow     *window,
@@ -3195,29 +3195,29 @@ handle_raise_or_lower (MetaDisplay    *display,
 		       MetaKeyBinding *binding)
 {
   /* Get window at pointer */
-  
+
   MetaWindow *above = NULL;
-      
+
   /* Check if top */
   if (meta_stack_get_top (window->screen->stack) == window)
     {
       meta_window_lower (window);
       return;
     }
-      
+
   /* else check if windows in same layer are intersecting it */
-  
-  above = meta_stack_get_above (window->screen->stack, window, TRUE); 
+
+  above = meta_stack_get_above (window->screen->stack, window, TRUE);
 
   while (above)
     {
       MetaRectangle tmp, win_rect, above_rect;
-      
+
       if (above->mapped)
         {
           meta_window_get_outer_rect (window, &win_rect);
           meta_window_get_outer_rect (above, &above_rect);
-          
+
           /* Check if obscured */
           if (meta_rectangle_intersect (&win_rect, &above_rect, &tmp))
             {
@@ -3225,8 +3225,8 @@ handle_raise_or_lower (MetaDisplay    *display,
               return;
             }
         }
-	  
-      above = meta_stack_get_above (window->screen->stack, above, TRUE); 
+
+      above = meta_stack_get_above (window->screen->stack, above, TRUE);
     }
 
   /* window is not obscured */
@@ -3262,15 +3262,15 @@ handle_workspace_switch  (MetaDisplay    *display,
 {
   gint motion = binding->handler->data;
   unsigned int grab_mask;
-     
-  g_assert (motion < 0); 
+
+  g_assert (motion < 0);
 
   meta_topic (META_DEBUG_KEYBINDINGS,
               "Starting tab between workspaces, showing popup\n");
 
   /* FIXME should we use binding->mask ? */
   grab_mask = event->xkey.state & ~(display->ignored_modifier_mask);
-  
+
   if (meta_display_begin_grab_op (display,
                                   screen,
                                   NULL,
@@ -3284,12 +3284,12 @@ handle_workspace_switch  (MetaDisplay    *display,
     {
       MetaWorkspace *next;
       gboolean grabbed_before_release;
-      
+
       next = meta_workspace_get_neighbor (screen->active_workspace, motion);
-      g_assert (next); 
+      g_assert (next);
 
       grabbed_before_release = primary_modifier_still_pressed (display, grab_mask);
-      
+
       meta_topic (META_DEBUG_KEYBINDINGS,
 		  "Activating target workspace\n");
 
@@ -3302,13 +3302,13 @@ handle_workspace_switch  (MetaDisplay    *display,
            */
           meta_display_end_grab_op (display, event->xkey.time);
         }
-      
+
       meta_workspace_activate (next, event->xkey.time);
 
       if (grabbed_before_release)
         {
           meta_ui_tab_popup_select (screen->tab_popup, (MetaTabEntryKey) next);
-          
+
           /* only after selecting proper space */
           meta_ui_tab_popup_set_showing (screen->tab_popup, TRUE);
         }
@@ -3342,7 +3342,7 @@ handle_run_terminal (MetaDisplay    *display,
 {
   const char *command;
   GError *err;
-  
+
   command = meta_prefs_get_terminal_command ();
 
   if (command == NULL)
@@ -3352,11 +3352,11 @@ handle_run_terminal (MetaDisplay    *display,
       meta_topic (META_DEBUG_KEYBINDINGS,
                   "No terminal command to run in response to "
 		  "keybinding press\n");
-      
+
       s = g_strdup_printf (_("No terminal command has been defined.\n"));
       error_on_command (-1, NULL, s, screen->number, event->xkey.time);
       g_free (s);
-      
+
       return;
     }
 
@@ -3365,7 +3365,7 @@ handle_run_terminal (MetaDisplay    *display,
     {
       error_on_command (-1, command, err->message, screen->number,
                         event->xkey.time);
-      
+
       g_error_free (err);
     }
 }

--- a/src/core/keybindings.h
+++ b/src/core/keybindings.h
@@ -7,9 +7,9 @@
  * the one to close a window.  It also deals with incoming key events.
  */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -19,7 +19,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -38,7 +38,7 @@ void     meta_screen_grab_keys              (MetaScreen  *screen);
 void     meta_screen_ungrab_keys            (MetaScreen  *screen);
 gboolean meta_screen_grab_all_keys          (MetaScreen  *screen,
                                              guint32      timestamp);
-void     meta_screen_ungrab_all_keys        (MetaScreen  *screen, 
+void     meta_screen_ungrab_all_keys        (MetaScreen  *screen,
                                              guint32      timestamp);
 void     meta_window_grab_keys              (MetaWindow  *window);
 void     meta_window_ungrab_keys            (MetaWindow  *window);

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -2,10 +2,10 @@
 
 /* Marco main() */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2006 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -15,7 +15,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -23,7 +23,7 @@
  */
 
 /**
- * \file 
+ * \file
  * Program startup.
  * Functions which parse the command-line arguments, create the display,
  * kick everything off and then close down Marco when it's time to go.
@@ -214,7 +214,7 @@ meta_print_self_identity (void)
   g_date_strftime (buf, sizeof (buf), "%x", &d);
   meta_verbose ("Marco version %s running on %s\n",
     VERSION, buf);
-  
+
   /* Locale and encoding. */
   g_get_charset (&charset);
   meta_verbose ("Running in locale \"%s\" with encoding \"%s\"\n",
@@ -427,12 +427,12 @@ main (int argc, char **argv)
   if (!g_thread_supported ())
     g_thread_init (NULL);
 #endif
-  
+
   if (setlocale (LC_ALL, "") == NULL)
     meta_warning ("Locale not understood by C library, internationalization will not work\n");
 
   g_type_init ();
-  
+
   sigemptyset (&empty_mask);
   act.sa_handler = SIG_IGN;
   act.sa_mask    = empty_mask;
@@ -472,7 +472,7 @@ main (int argc, char **argv)
                     g_get_home_dir ());
 
   meta_print_self_identity ();
-  
+
   bindtextdomain (GETTEXT_PACKAGE, MARCO_LOCALEDIR);
   bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
   textdomain (GETTEXT_PACKAGE);
@@ -486,16 +486,16 @@ main (int argc, char **argv)
     version ();
 
   meta_select_display (meta_args.display_name);
-  
+
   if (meta_args.replace_wm)
     meta_set_replace_current_wm (TRUE);
 
   if (meta_args.save_file && meta_args.client_id)
     meta_fatal ("Can't specify both SM save file and SM client id\n");
-  
+
   meta_main_loop = g_main_loop_new (NULL, FALSE);
-  
-  meta_ui_init (&argc, &argv);  
+
+  meta_ui_init (&argc, &argv);
 
   /* must be after UI init so we can override GDK handlers */
   meta_errors_init ();
@@ -516,7 +516,7 @@ main (int argc, char **argv)
 
   if (g_getenv ("MARCO_G_FATAL_WARNINGS") != NULL)
     g_log_set_always_fatal (G_LOG_LEVEL_MASK);
-  
+
   meta_ui_set_current_theme (meta_prefs_get_theme (), FALSE);
 
   /* Try to find some theme that'll work if the theme preference
@@ -525,34 +525,34 @@ main (int argc, char **argv)
    */
   if (!meta_ui_have_a_theme ())
     meta_ui_set_current_theme ("Simple", FALSE);
-  
+
   if (!meta_ui_have_a_theme ())
     {
       const char *dir_entry = NULL;
       GError *err = NULL;
       GDir   *themes_dir = NULL;
-      
+
       if (!(themes_dir = g_dir_open (MARCO_DATADIR"/themes", 0, &err)))
         {
           meta_fatal (_("Failed to scan themes directory: %s\n"), err->message);
           g_error_free (err);
-        } 
-      else 
+        }
+      else
         {
-          while (((dir_entry = g_dir_read_name (themes_dir)) != NULL) && 
+          while (((dir_entry = g_dir_read_name (themes_dir)) != NULL) &&
                  (!meta_ui_have_a_theme ()))
             {
               meta_ui_set_current_theme (dir_entry, FALSE);
             }
-          
+
           g_dir_close (themes_dir);
         }
     }
-  
+
   if (!meta_ui_have_a_theme ())
     meta_fatal (_("Could not find a theme! Be sure %s exists and contains the usual themes.\n"),
                 MARCO_DATADIR"/themes");
-  
+
   /* Connect to SM as late as possible - but before managing display,
    * or we might try to manage a window before we have the session
    * info
@@ -562,9 +562,9 @@ main (int argc, char **argv)
       if (meta_args.client_id == NULL)
         {
           const gchar *desktop_autostart_id;
-  
+
           desktop_autostart_id = g_getenv ("DESKTOP_AUTOSTART_ID");
- 
+
           if (desktop_autostart_id != NULL)
             meta_args.client_id = g_strdup (desktop_autostart_id);
         }
@@ -590,7 +590,7 @@ main (int argc, char **argv)
 
   if (!meta_display_open ())
     meta_exit (META_EXIT_ERROR);
-  
+
   g_main_loop_run (meta_main_loop);
 
   meta_finalize ();
@@ -615,7 +615,7 @@ main (int argc, char **argv)
           meta_exit_code = META_EXIT_ERROR;
         }
     }
-  
+
   return meta_exit_code;
 }
 

--- a/src/core/marco-Xatomtype.h
+++ b/src/core/marco-Xatomtype.h
@@ -39,13 +39,13 @@ Copyright 1987 by Digital Equipment Corporation, Maynard, Massachusetts.
 
                         All Rights Reserved
 
-Permission to use, copy, modify, and distribute this software and its 
-documentation for any purpose and without fee is hereby granted, 
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose and without fee is hereby granted,
 provided that the above copyright notice appear in all copies and that
-both that copyright notice and this permission notice appear in 
+both that copyright notice and this permission notice appear in
 supporting documentation, and that the name of Digital not be
 used in advertising or publicity pertaining to distribution of the
-software without specific, written prior permission.  
+software without specific, written prior permission.
 
 DIGITAL DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING
 ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO EVENT SHALL

--- a/src/core/place.c
+++ b/src/core/place.c
@@ -2,12 +2,12 @@
 
 /* Marco window placement */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2002, 2003 Red Hat, Inc.
  * Copyright (C) 2003 Rob Adams
  * Copyright (C) 2005 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -17,7 +17,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -74,11 +74,11 @@ northwestcmp (gconstpointer a, gconstpointer b)
       bx = bw->rect.x;
       by = bw->rect.y;
     }
-  
+
   /* probably there's a fast good-enough-guess we could use here. */
   from_origin_a = sqrt (ax * ax + ay * ay);
   from_origin_b = sqrt (bx * bx + by * by);
-    
+
   if (from_origin_a < from_origin_b)
     return -1;
   else if (from_origin_a > from_origin_b)
@@ -105,16 +105,16 @@ find_next_cascade (MetaWindow *window,
   int cascade_stage;
   MetaRectangle work_area;
   const MetaXineramaScreenInfo* current;
-  
+
   sorted = g_list_copy (windows);
   sorted = g_list_sort (sorted, northwestcmp);
 
-  /* This is a "fuzzy" cascade algorithm. 
+  /* This is a "fuzzy" cascade algorithm.
    * For each window in the list, we find where we'd cascade a
    * new window after it. If a window is already nearly at that
    * position, we move on.
    */
-  
+
   /* arbitrary-ish threshold, honors user attempts to
    * manually cascade.
    */
@@ -129,7 +129,7 @@ find_next_cascade (MetaWindow *window,
       x_threshold = CASCADE_FUZZ;
       y_threshold = CASCADE_FUZZ;
     }
-  
+
   /* Find furthest-SE origin of all workspaces.
    * cascade_x, cascade_y are the target position
    * of NW corner of window frame.
@@ -140,19 +140,19 @@ find_next_cascade (MetaWindow *window,
 
   cascade_x = MAX (0, work_area.x);
   cascade_y = MAX (0, work_area.y);
-  
+
   /* Find first cascade position that's not used. */
-  
+
   window_width = window->frame ? window->frame->rect.width : window->rect.width;
   window_height = window->frame ? window->frame->rect.height : window->rect.height;
-  
+
   cascade_stage = 0;
   tmp = sorted;
   while (tmp != NULL)
     {
       MetaWindow *w;
       int wx, wy;
-      
+
       w = tmp->data;
 
       /* we want frame position, not window position */
@@ -166,7 +166,7 @@ find_next_cascade (MetaWindow *window,
           wx = w->rect.x;
           wy = w->rect.y;
         }
-      
+
       if (ABS (wx - cascade_x) < x_threshold &&
           ABS (wy - cascade_y) < y_threshold)
         {
@@ -177,7 +177,7 @@ find_next_cascade (MetaWindow *window,
           meta_window_get_position (w, &wx, &wy);
           cascade_x = wx;
           cascade_y = wy;
-          
+
           /* If we go off the screen, start over with a new cascade */
 	  if (((cascade_x + window_width) >
                (work_area.x + work_area.width)) ||
@@ -186,11 +186,11 @@ find_next_cascade (MetaWindow *window,
 	    {
 	      cascade_x = MAX (0, work_area.x);
 	      cascade_y = MAX (0, work_area.y);
-              
+
 #define CASCADE_INTERVAL 50 /* space between top-left corners of cascades */
               cascade_stage += 1;
 	      cascade_x += CASCADE_INTERVAL * cascade_stage;
-              
+
 	      /* start over with a new cascade translated to the right, unless
                * we are out of space
                */
@@ -212,14 +212,14 @@ find_next_cascade (MetaWindow *window,
         {
           /* Keep searching for a further-down-the-diagonal window. */
         }
-        
+
       tmp = tmp->next;
     }
 
   /* cascade_x and cascade_y will match the last window in the list
    * that was "in the way" (in the approximate cascade diagonal)
    */
-  
+
   g_list_free (sorted);
 
   /* Convert coords to position of window, not position of frame. */
@@ -380,12 +380,12 @@ rectangle_overlaps_some_window (MetaRectangle *rect,
 {
   GList *tmp;
   MetaRectangle dest;
-  
+
   tmp = windows;
   while (tmp != NULL)
     {
       MetaWindow *other = tmp->data;
-      MetaRectangle other_rect;      
+      MetaRectangle other_rect;
 
       switch (other->type)
         {
@@ -401,12 +401,12 @@ rectangle_overlaps_some_window (MetaRectangle *rect,
         case META_WINDOW_TOOLBAR:
         case META_WINDOW_MENU:
           meta_window_get_outer_rect (other, &other_rect);
-          
+
           if (meta_rectangle_intersect (rect, &other_rect, &dest))
             return TRUE;
           break;
         }
-      
+
       tmp = tmp->next;
     }
 
@@ -520,29 +520,29 @@ find_first_fit (MetaWindow *window,
    * the bottom of each existing window, and then to the right
    * of each existing window, aligned with the left/top of the
    * existing window in each of those cases.
-   */  
+   */
   int retval;
   GList *below_sorted;
   GList *right_sorted;
   GList *tmp;
   MetaRectangle rect;
   MetaRectangle work_area;
-  
+
   retval = FALSE;
 
   /* Below each window */
   below_sorted = g_list_copy (windows);
   below_sorted = g_list_sort (below_sorted, leftmost_cmp);
-  below_sorted = g_list_sort (below_sorted, topmost_cmp);  
+  below_sorted = g_list_sort (below_sorted, topmost_cmp);
 
   /* To the right of each window */
   right_sorted = g_list_copy (windows);
   right_sorted = g_list_sort (right_sorted, topmost_cmp);
   right_sorted = g_list_sort (right_sorted, leftmost_cmp);
-  
+
   rect.width = window->rect.width;
   rect.height = window->rect.height;
-  
+
   if (fgeom)
     {
       rect.width += fgeom->left_width + fgeom->right_width;
@@ -578,9 +578,9 @@ find_first_fit (MetaWindow *window,
             *new_x += fgeom->left_width;
             *new_y += fgeom->top_height;
           }
-    
+
         retval = TRUE;
-       
+
         goto out;
       }
 
@@ -592,10 +592,10 @@ find_first_fit (MetaWindow *window,
         MetaRectangle outer_rect;
 
         meta_window_get_outer_rect (w, &outer_rect);
-      
+
         rect.x = outer_rect.x;
         rect.y = outer_rect.y + outer_rect.height;
-      
+
         if (meta_rectangle_contains_rect (&work_area, &rect) &&
             !rectangle_overlaps_some_window (&rect, below_sorted))
           {
@@ -606,9 +606,9 @@ find_first_fit (MetaWindow *window,
                 *new_x += fgeom->left_width;
                 *new_y += fgeom->top_height;
               }
-          
+
             retval = TRUE;
-          
+
             goto out;
           }
 
@@ -621,12 +621,12 @@ find_first_fit (MetaWindow *window,
       {
         MetaWindow *w = tmp->data;
         MetaRectangle outer_rect;
-   
+
         meta_window_get_outer_rect (w, &outer_rect);
-     
+
         rect.x = outer_rect.x + outer_rect.width;
         rect.y = outer_rect.y;
-   
+
         if (meta_rectangle_contains_rect (&work_area, &rect) &&
             !rectangle_overlaps_some_window (&rect, right_sorted))
           {
@@ -637,15 +637,15 @@ find_first_fit (MetaWindow *window,
                 *new_x += fgeom->left_width;
                 *new_y += fgeom->top_height;
               }
-        
+
             retval = TRUE;
-       
+
             goto out;
           }
 
         tmp = tmp->next;
       }
-      
+
  out:
 
   g_list_free (below_sorted);
@@ -670,11 +670,11 @@ meta_window_place (MetaWindow        *window,
    * NEVER have side effects other than computing the
    * placement coordinates.
    */
-  
+
   meta_topic (META_DEBUG_PLACEMENT, "Placing window %s\n", window->desc);
 
   windows = NULL;
-  
+
   switch (window->type)
     {
       /* Run placement algorithm on these. */
@@ -683,7 +683,7 @@ meta_window_place (MetaWindow        *window,
     case META_WINDOW_MODAL_DIALOG:
     case META_WINDOW_SPLASHSCREEN:
       break;
-          
+
       /* Assume the app knows best how to place these, no placement
        * algorithm ever (other than "leave them as-is")
        */
@@ -694,7 +694,7 @@ meta_window_place (MetaWindow        *window,
     case META_WINDOW_UTILITY:
       goto done_no_constraints;
     }
-  
+
   if (meta_prefs_get_disable_workarounds ())
     {
       switch (window->type)
@@ -718,7 +718,7 @@ meta_window_place (MetaWindow        *window,
         case META_WINDOW_MODAL_DIALOG:
         case META_WINDOW_SPLASHSCREEN:
           break;
-          
+
           /* Assume the app knows best how to place these. */
         case META_WINDOW_DESKTOP:
         case META_WINDOW_DOCK:
@@ -737,7 +737,7 @@ meta_window_place (MetaWindow        *window,
   else
     {
       /* workarounds enabled */
-      
+
       if ((window->size_hints.flags & PPosition) ||
           (window->size_hints.flags & USPosition))
         {
@@ -747,7 +747,7 @@ meta_window_place (MetaWindow        *window,
           goto done_no_constraints;
         }
     }
-  
+
   if ((window->type == META_WINDOW_DIALOG ||
        window->type == META_WINDOW_MODAL_DIALOG) &&
       window->xtransient_for != None)
@@ -755,7 +755,7 @@ meta_window_place (MetaWindow        *window,
       /* Center horizontally, at top of parent vertically */
 
       MetaWindow *parent;
-          
+
       parent =
         meta_display_lookup_x_window (window->display,
                                       window->xtransient_for);
@@ -783,17 +783,17 @@ meta_window_place (MetaWindow        *window,
 
           meta_topic (META_DEBUG_PLACEMENT, "Centered window %s over transient parent\n",
                       window->desc);
-          
+
           avoid_being_obscured_as_second_modal_dialog (window, fgeom, &x, &y);
 
           goto done;
         }
     }
-  
+
   /* FIXME UTILITY with transient set should be stacked up
    * on the sides of the parent window or something.
    */
-  
+
   if (window->type == META_WINDOW_DIALOG ||
       window->type == META_WINDOW_MODAL_DIALOG ||
       window->type == META_WINDOW_SPLASHSCREEN)
@@ -812,13 +812,13 @@ meta_window_place (MetaWindow        *window,
 
       x += xi->rect.x;
       y += xi->rect.y;
-      
+
       meta_topic (META_DEBUG_PLACEMENT, "Centered window %s on screen %d xinerama %d\n",
                   window->desc, window->screen->number, xi->number);
 
       goto done_check_denied_focus;
     }
-  
+
   /* Find windows that matter (not minimized, on same workspace
    * as placed window, may be shaded - if shaded we pretend it isn't
    * for placement purposes)
@@ -826,7 +826,7 @@ meta_window_place (MetaWindow        *window,
   {
     GSList *all_windows;
     GSList *tmp;
-    
+
     all_windows = meta_display_list_windows (window->display);
 
     tmp = all_windows;
@@ -835,7 +835,7 @@ meta_window_place (MetaWindow        *window,
         MetaWindow *w = tmp->data;
 
         if (meta_window_showing_on_its_workspace (w) &&
-            w != window && 
+            w != window &&
             (window->workspace == w->workspace ||
              window->on_all_workspaces || w->on_all_workspaces))
           windows = g_list_prepend (windows, w);
@@ -848,7 +848,7 @@ meta_window_place (MetaWindow        *window,
 
   /* Warning, this is a round trip! */
   xi = meta_screen_get_current_xinerama (window->screen);
-  
+
   /* "Origin" placement algorithm */
   x = xi->rect.x;
   y = xi->rect.y;
@@ -860,7 +860,7 @@ meta_window_place (MetaWindow        *window,
 
   /* Maximize windows if they are too big for their work area (bit of
    * a hack here). Assume undecorated windows probably don't intend to
-   * be maximized.  
+   * be maximized.
    */
   if (window->has_maximize_func && window->decorated &&
       !window->fullscreen)
@@ -870,9 +870,9 @@ meta_window_place (MetaWindow        *window,
 
       meta_window_get_work_area_for_xinerama (window,
                                               xi->number,
-                                              &workarea);      
+                                              &workarea);
       meta_window_get_outer_rect (window, &outer);
-      
+
       /* If the window is bigger than the screen, then automaximize.  Do NOT
        * auto-maximize the directions independently.  See #419810.
        */
@@ -883,7 +883,7 @@ meta_window_place (MetaWindow        *window,
         }
     }
 
-  /* If no placement has been done, revert to cascade to avoid 
+  /* If no placement has been done, revert to cascade to avoid
    * fully overlapping window (e.g. starting multiple terminals)
    * */
   if (!meta_prefs_get_center_new_windows() && (x == xi->rect.x && y == xi->rect.y))
@@ -933,10 +933,10 @@ meta_window_place (MetaWindow        *window,
       if (!found_fit)
         find_most_freespace (window, fgeom, focus_window, x, y, &x, &y);
     }
-  
+
  done:
   g_list_free (windows);
-  
+
  done_no_constraints:
 
   *new_x = x;

--- a/src/core/place.h
+++ b/src/core/place.h
@@ -2,9 +2,9 @@
 
 /* Marco window placement */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA

--- a/src/core/prefs.c
+++ b/src/core/prefs.c
@@ -2,11 +2,11 @@
 
 /* Marco preferences */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington, Copyright (C) 2002 Red Hat Inc.
  * Copyright (C) 2006 Elijah Newren
  * Copyright (C) 2008 Thomas Thurman
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -16,7 +16,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -559,7 +559,7 @@ handle_preference_init_int (void)
 {
   MetaIntPreference *cursor = preferences_int;
 
-  
+
   while (cursor->key!=NULL)
     {
       gint value;
@@ -608,7 +608,7 @@ handle_preference_update_enum (const gchar *key, GSettings *settings)
    */
 
   old_value = * ((gint *) cursor->target);
-  
+
   /* Now look it up... */
   *cursor->target = g_settings_get_enum (settings, key);
 
@@ -642,7 +642,7 @@ handle_preference_update_bool (const gchar *key, GSettings *settings)
    */
 
   old_value = * ((gboolean *) cursor->target);
-  
+
   /* Now look it up... */
 
   *((gboolean *) cursor->target) = g_settings_get_boolean (settings, key);
@@ -738,7 +738,7 @@ handle_preference_update_int (const gchar *key, GSettings *settings)
     }
 
   return TRUE;
-  
+
 }
 
 
@@ -778,7 +778,7 @@ meta_prefs_remove_listener (MetaPrefsChangedFunc func,
 
           return;
         }
-      
+
       tmp = tmp->next;
     }
 
@@ -793,9 +793,9 @@ emit_changed (MetaPreference pref)
 
   meta_topic (META_DEBUG_PREFS, "Notifying listeners that pref %s changed\n",
               meta_preference_to_string (pref));
-  
+
   copy = g_list_copy (listeners);
-  
+
   tmp = copy;
 
   while (tmp != NULL)
@@ -817,24 +817,24 @@ changed_idle_handler (gpointer data)
   GList *copy;
 
   changed_idle = 0;
-  
+
   copy = g_list_copy (changes); /* reentrancy paranoia */
 
   g_list_free (changes);
   changes = NULL;
-  
+
   tmp = copy;
   while (tmp != NULL)
     {
       MetaPreference pref = GPOINTER_TO_INT (tmp->data);
 
       emit_changed (pref);
-      
+
       tmp = tmp->next;
     }
 
   g_list_free (copy);
-  
+
   return FALSE;
 }
 
@@ -842,7 +842,7 @@ static void
 queue_changed (MetaPreference pref)
 {
   meta_topic (META_DEBUG_PREFS, "Queueing change of pref %s\n",
-              meta_preference_to_string (pref));  
+              meta_preference_to_string (pref));
 
   if (g_list_find (changes, GINT_TO_POINTER (pref)) == NULL)
     changes = g_list_prepend (changes, GINT_TO_POINTER (pref));
@@ -867,7 +867,7 @@ meta_prefs_init (void)
 {
   if (settings_general != NULL)
     return;
-  
+
   /* returns references which we hold forever */
   settings_general = g_settings_new (KEY_GENERAL_SCHEMA);
   settings_command = g_settings_new (KEY_COMMAND_SCHEMA);
@@ -930,7 +930,7 @@ change_notify (GSettings *settings,
                gpointer user_data)
 {
   gint i=0;
-  
+
   /* First, search for a handler that might know what to do. */
 
   /* FIXME: When this is all working, since the first item in every
@@ -961,7 +961,7 @@ change_notify (GSettings *settings,
 
       if (update_key_binding (key, str))
         queue_changed (META_PREF_KEYBINDINGS);
-    
+
       g_free(str);
     }
   else if (g_strcmp0 (schema_name, KEY_COMMAND_SCHEMA) == 0)
@@ -971,7 +971,7 @@ change_notify (GSettings *settings,
 
       if (update_command (key, str))
         queue_changed (META_PREF_COMMANDS);
-      
+
       g_free(str);
     }
   else if (g_strcmp0 (schema_name, KEY_WORKSPACE_NAME_SCHEMA))
@@ -981,7 +981,7 @@ change_notify (GSettings *settings,
 
       if (update_workspace_name (key, str))
         queue_changed (META_PREF_WORKSPACE_NAMES);
-      
+
       g_free(str);
     }
   else
@@ -1000,7 +1000,7 @@ cleanup_error (GError **error)
   if (*error)
     {
       meta_warning ("%s\n", (*error)->message);
-      
+
       g_error_free (*error);
       *error = NULL;
     }
@@ -1015,7 +1015,7 @@ static void
 maybe_give_disable_workarounds_warning (void)
 {
   static gboolean first_disable = TRUE;
-    
+
   if (first_disable && disable_workarounds)
     {
       first_disable = FALSE;
@@ -1148,7 +1148,7 @@ mouse_button_mods_handler (MetaPreference pref,
     {
       meta_topic (META_DEBUG_KEYBINDINGS,
                   "Failed to parse new GSettings value\n");
-          
+
       meta_warning (_("\"%s\" found in configuration database is "
                       "not a valid value for mouse button modifier\n"),
                     string_value);
@@ -1160,7 +1160,7 @@ mouse_button_mods_handler (MetaPreference pref,
 static gboolean
 button_layout_equal (const MetaButtonLayout *a,
                      const MetaButtonLayout *b)
-{  
+{
   int i;
 
   i = 0;
@@ -1199,7 +1199,7 @@ button_function_from_string (const char *str)
     return META_BUTTON_FUNCTION_ABOVE;
   else if (strcmp (str, "stick") == 0)
     return META_BUTTON_FUNCTION_STICK;
-  else 
+  else
     /* don't know; give up */
     return META_BUTTON_FUNCTION_LAST;
 }
@@ -1237,11 +1237,11 @@ button_layout_handler (MetaPreference pref,
   MetaButtonLayout new_layout;
   char **sides = NULL;
   int i;
-  
+
   /* We need to ignore unknown button functions, for
    * compat with future versions
    */
-  
+
   if (string_value)
     sides = g_strsplit (string_value, ":", 2);
 
@@ -1258,7 +1258,7 @@ button_layout_handler (MetaPreference pref,
           new_layout.left_buttons_has_spacer[i] = FALSE;
           ++i;
         }
-      
+
       buttons = g_strsplit (sides[0], ",", -1);
       i = 0;
       b = 0;
@@ -1295,13 +1295,13 @@ button_layout_handler (MetaPreference pref,
                               buttons[b]);
                 }
             }
-          
+
           ++b;
         }
 
       new_layout.left_buttons[i] = META_BUTTON_FUNCTION_LAST;
       new_layout.left_buttons_has_spacer[i] = FALSE;
-      
+
       g_strfreev (buttons);
     }
 
@@ -1318,7 +1318,7 @@ button_layout_handler (MetaPreference pref,
           new_layout.right_buttons_has_spacer[i] = FALSE;
           ++i;
         }
-      
+
       buttons = g_strsplit (sides[1], ",", -1);
       i = 0;
       b = 0;
@@ -1354,24 +1354,24 @@ button_layout_handler (MetaPreference pref,
                               buttons[b]);
                 }
             }
-          
+
           ++b;
         }
 
       new_layout.right_buttons[i] = META_BUTTON_FUNCTION_LAST;
       new_layout.right_buttons_has_spacer[i] = FALSE;
-      
+
       g_strfreev (buttons);
     }
 
   g_strfreev (sides);
-  
+
   /* Invert the button layout for RTL languages */
   if (meta_ui_get_direction() == META_UI_DIRECTION_RTL)
   {
     MetaButtonLayout rtl_layout;
     int j;
-    
+
     for (i = 0; new_layout.left_buttons[i] != META_BUTTON_FUNCTION_LAST; i++);
     for (j = 0; j < i; j++)
       {
@@ -1383,7 +1383,7 @@ button_layout_handler (MetaPreference pref,
       }
     rtl_layout.right_buttons[j] = META_BUTTON_FUNCTION_LAST;
     rtl_layout.right_buttons_has_spacer[j] = FALSE;
-      
+
     for (i = 0; new_layout.right_buttons[i] != META_BUTTON_FUNCTION_LAST; i++);
     for (j = 0; j < i; j++)
       {
@@ -1398,7 +1398,7 @@ button_layout_handler (MetaPreference pref,
 
     new_layout = rtl_layout;
   }
-  
+
   if (button_layout_equal (&button_layout, &new_layout))
     {
       /* Same as before, so duck out */
@@ -1435,7 +1435,7 @@ gboolean
 meta_prefs_get_application_based (void)
 {
   return FALSE; /* For now, we never want this to do anything */
-  
+
   return application_based;
 }
 
@@ -1498,7 +1498,7 @@ meta_preference_to_string (MetaPreference pref)
 
     case META_PREF_AUTO_RAISE:
       return "AUTO_RAISE";
-      
+
     case META_PREF_AUTO_RAISE_DELAY:
       return "AUTO_RAISE_DELAY";
 
@@ -1568,7 +1568,7 @@ meta_prefs_set_num_workspaces (int n_workspaces)
     n_workspaces = 1;
   if (n_workspaces > MAX_REASONABLE_WORKSPACES)
     n_workspaces = MAX_REASONABLE_WORKSPACES;
-  
+
   g_settings_set_int (settings_general,
                       KEY_GENERAL_NUM_WORKSPACES,
                       n_workspaces);
@@ -1657,7 +1657,7 @@ update_binding (MetaKeyPref *binding,
   meta_topic (META_DEBUG_KEYBINDINGS,
               "Binding \"%s\" has new GSettings value \"%s\"\n",
               binding->name, value ? value : "none");
-  
+
   keysym = 0;
   keycode = 0;
   mods = 0;
@@ -1681,7 +1681,7 @@ update_binding (MetaKeyPref *binding,
       binding->bindings = g_slist_alloc();
       binding->bindings->data = blank;
     }
-  
+
    combo = binding->bindings->data;
 
    /* Bug 329676: Bindings which can be shifted must not have no modifiers,
@@ -1693,7 +1693,7 @@ update_binding (MetaKeyPref *binding,
       (META_VIRTUAL_SHIFT_MASK == mods || 0 == mods))
     {
       gchar *old_setting;
-      
+
       meta_warning ("Cannot bind \"%s\" to %s: it needs a modifier "
                     "such as Ctrl or Alt.\n",
                     binding->name,
@@ -1735,18 +1735,18 @@ update_binding (MetaKeyPref *binding,
        */
       return TRUE;
     }
-  
+
   changed = FALSE;
   if (keysym != combo->keysym ||
       keycode != combo->keycode ||
       mods != combo->modifiers)
     {
       changed = TRUE;
-      
+
       combo->keysym = keysym;
       combo->keycode = keycode;
       combo->modifiers = mods;
-      
+
       meta_topic (META_DEBUG_KEYBINDINGS,
                   "New keybinding for \"%s\" is keysym = 0x%x keycode = 0x%x mods = 0x%x\n",
                   binding->name, combo->keysym, combo->keycode,
@@ -1757,7 +1757,7 @@ update_binding (MetaKeyPref *binding,
       meta_topic (META_DEBUG_KEYBINDINGS,
                   "Keybinding for \"%s\" is unchanged\n", binding->name);
     }
-  
+
   return changed;
 }
 
@@ -1765,7 +1765,7 @@ static const gchar*
 relative_key (const gchar* key)
 {
   const gchar* end;
-  
+
   end = strrchr (key, '/');
 
   ++end;
@@ -1777,13 +1777,13 @@ relative_key (const gchar* key)
  * notify
  */
 static gboolean
-find_and_update_binding (MetaKeyPref *bindings, 
+find_and_update_binding (MetaKeyPref *bindings,
                          const char  *name,
                          gchar  *value)
 {
   const char *key;
   int i;
-  
+
   if (*name == '/')
     key = relative_key (name);
   else
@@ -1813,7 +1813,7 @@ update_command (const char  *name,
 {
   char *p;
   int i;
-  
+
   p = strrchr (name, '-');
   if (p == NULL)
     {
@@ -1821,7 +1821,7 @@ update_command (const char  *name,
                   "Command %s has no dash?\n", name);
       return FALSE;
     }
-  
+
   ++p;
 
   if (g_ascii_isdigit (*p))
@@ -1846,7 +1846,7 @@ update_command (const char  *name,
           return FALSE;
         }
     }
-  
+
   if (i >= MAX_COMMANDS)
     {
       meta_topic (META_DEBUG_KEYBINDINGS,
@@ -1861,14 +1861,14 @@ update_command (const char  *name,
                   "Command %d is unchanged\n", i);
       return FALSE;
     }
-  
+
   g_free (commands[i]);
   commands[i] = g_strdup (value);
 
   meta_topic (META_DEBUG_KEYBINDINGS,
               "Updated command %d to \"%s\"\n",
               i, commands[i] ? commands[i] : "none");
-  
+
   return TRUE;
 }
 
@@ -1876,7 +1876,7 @@ const char*
 meta_prefs_get_command (int i)
 {
   g_return_val_if_fail (i >= 0 && i < MAX_COMMANDS, NULL);
-  
+
   return commands[i];
 }
 
@@ -1897,7 +1897,7 @@ meta_prefs_get_settings_key_for_command (int i)
       key = g_strdup_printf (KEY_COMMAND_PREFIX"%d", i + 1);
       break;
     }
-  
+
   return key;
 }
 
@@ -1919,7 +1919,7 @@ update_workspace_name (const char  *name,
 {
   char *p;
   int i;
-  
+
   p = strrchr (name, '-');
   if (p == NULL)
     {
@@ -1927,7 +1927,7 @@ update_workspace_name (const char  *name,
                   "Workspace name %s has no dash?\n", name);
       return FALSE;
     }
-  
+
   ++p;
 
   if (!g_ascii_isdigit (*p))
@@ -1936,10 +1936,10 @@ update_workspace_name (const char  *name,
                   "Workspace name %s doesn't end in number?\n", name);
       return FALSE;
     }
-  
+
   i = atoi (p);
   i -= 1; /* count from 0 not 1 */
-  
+
   if (i >= MAX_REASONABLE_WORKSPACES)
     {
       meta_topic (META_DEBUG_PREFS,
@@ -1952,7 +1952,7 @@ update_workspace_name (const char  *name,
       meta_topic (META_DEBUG_PREFS,
                   "Workspace name %d is unchanged\n", i);
       return FALSE;
-    }  
+    }
 
   /* This is a bad hack. We have to treat empty string as
    * "unset" because the root window property can't contain
@@ -1982,11 +1982,11 @@ update_workspace_name (const char  *name,
           workspace_names[i] = d;
         }
     }
-  
+
   meta_topic (META_DEBUG_PREFS,
               "Updated workspace name %d to \"%s\"\n",
               i, workspace_names[i] ? workspace_names[i] : "none");
-  
+
   return TRUE;
 }
 
@@ -2000,7 +2000,7 @@ meta_prefs_get_workspace_name (int i)
   meta_topic (META_DEBUG_PREFS,
               "Getting workspace name for %d: \"%s\"\n",
               i, workspace_names[i]);
-  
+
   return workspace_names[i];
 }
 
@@ -2009,7 +2009,7 @@ meta_prefs_change_workspace_name (int         i,
                                   const char *name)
 {
   char *key;
-  
+
   g_return_if_fail (i >= 0 && i < MAX_REASONABLE_WORKSPACES);
 
   meta_topic (META_DEBUG_PREFS,
@@ -2018,7 +2018,7 @@ meta_prefs_change_workspace_name (int         i,
 
   if (name && *name == '\0')
     name = NULL;
-  
+
   if ((name == NULL && workspace_names[i] == NULL) ||
       (name && workspace_names[i] && strcmp (name, workspace_names[i]) == 0))
     {
@@ -2027,7 +2027,7 @@ meta_prefs_change_workspace_name (int         i,
                   i, name ? name : "none");
       return;
     }
-  
+
   key = settings_key_for_workspace_name (i);
 
   if (name != NULL)
@@ -2046,9 +2046,9 @@ static char*
 settings_key_for_workspace_name (int i)
 {
   char *key;
-  
+
   key = g_strdup_printf (KEY_WORKSPACE_NAME_PREFIX"%d", i + 1);
-  
+
   return key;
 }
 
@@ -2080,7 +2080,7 @@ void
 meta_prefs_get_key_bindings (const MetaKeyPref **bindings,
                                 int                *n_bindings)
 {
-  
+
   *bindings = key_bindings;
   *n_bindings = (int) G_N_ELEMENTS (key_bindings) - 1;
 }
@@ -2143,7 +2143,7 @@ meta_prefs_get_keybinding_action (const char *name)
     {
       if (strcmp (key_bindings[i].name, name) == 0)
         return (MetaKeyBindingAction) i;
-      
+
       --i;
     }
 
@@ -2187,7 +2187,7 @@ meta_prefs_get_window_binding (const char          *name,
           *keysym = *modifiers = 0;
           return;
         }
-      
+
       --i;
     }
 

--- a/src/core/schema-bindings.c
+++ b/src/core/schema-bindings.c
@@ -63,7 +63,7 @@ single_stanza (gboolean is_window, const char *name,
   escaped_description = g_markup_escape_text (description, -1);
   escaped_default_value = default_value==NULL? "disabled":
         g_markup_escape_text (default_value, -1);
-  
+
   fprintf (target_file, "    <schema>\n");
   fprintf (target_file, "      <key>/schemas/apps/marco/%s_keybindings/%s</key>\n",
             keybinding_type, name);
@@ -72,7 +72,7 @@ single_stanza (gboolean is_window, const char *name,
   fprintf (target_file, "      <owner>marco</owner>\n");
   fprintf (target_file, "      <type>string</type>\n");
   fprintf (target_file, "      <default>%s</default>\n", escaped_default_value);
-  
+
   fprintf (target_file, "      <locale name=\"C\">\n");
   fprintf (target_file, "        <short>%s</short>\n", description);
   fprintf (target_file, "        <long>%s</long>\n",
@@ -117,7 +117,7 @@ produce_bindings ()
     {
       if (strstr (buffer, "<!-- GENERATED -->"))
          break;
-         
+
       fprintf (target_file, "%s", buffer);
     }
 
@@ -157,7 +157,7 @@ main (int argc, char **argv)
     {
       g_error ("Syntax: %s <source.in.in> <target.in>\n", argv[0]);
     }
-  
+
   source_filename = argv[1];
   target_filename = argv[2];
 
@@ -187,7 +187,7 @@ main (int argc, char **argv)
 
   g_free (about_keybindings);
   g_free (about_reversible_keybindings);
-  
+
   return 0;
 }
 

--- a/src/core/screen-private.h
+++ b/src/core/screen-private.h
@@ -9,11 +9,11 @@
  * which the rest of the world is allowed to use.)
  */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2003 Rob Adams
  * Copyright (C) 2004-2006 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -23,7 +23,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -80,9 +80,9 @@ struct _MetaScreen
   MetaUI *ui;
   MetaTabPopup *tab_popup;
   MetaTilePreview *tile_preview;
-  
+
   guint tile_preview_timeout_id;
-  
+
   MetaWorkspace *active_workspace;
 
   /* Previous active workspace */
@@ -92,7 +92,7 @@ struct _MetaScreen
    * any actual clients
    */
   Window no_focus_window;
-  
+
   GList *workspaces;
 
   MetaStack *stack;
@@ -104,7 +104,7 @@ struct _MetaScreen
   Window wm_sn_selection_window;
   Atom wm_sn_atom;
   guint32 wm_sn_timestamp;
-  
+
   MetaXineramaScreenInfo *xinerama_infos;
   int n_xinerama_infos;
 
@@ -128,10 +128,10 @@ struct _MetaScreen
   int columns_of_workspaces;
   MetaScreenCorner starting_corner;
   guint vertical_workspaces : 1;
-  
+
   guint keys_grabbed : 1;
   guint all_keys_grabbed : 1;
-  
+
   int closing;
 
   /* gc for XOR on root window */

--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -2,14 +2,14 @@
 
 /* Marco X screen handler */
 
-/* 
+/*
  * Copyright (C) 2001, 2002 Havoc Pennington
  * Copyright (C) 2002, 2003 Red Hat Inc.
  * Some ICCCM manager selection code derived from fvwm2,
  * Copyright (C) 2001 Dominik Vogt, Matthias Clasen, and fvwm2 team
  * Copyright (C) 2003 Rob Adams
  * Copyright (C) 2004-2006 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -19,7 +19,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -75,7 +75,7 @@ set_wm_check_hint (MetaScreen *screen)
   unsigned long data[1];
 
   g_return_val_if_fail (screen->display->leader_window != None, 0);
-  
+
   data[0] = screen->display->leader_window;
 
   XChangeProperty (screen->display->xdisplay, screen->xroot,
@@ -89,7 +89,7 @@ set_wm_check_hint (MetaScreen *screen)
 static void
 unset_wm_check_hint (MetaScreen *screen)
 {
-  XDeleteProperty (screen->display->xdisplay, screen->xroot, 
+  XDeleteProperty (screen->display->xdisplay, screen->xroot,
                    screen->display->atom__NET_SUPPORTING_WM_CHECK);
 }
 
@@ -110,7 +110,7 @@ set_supported_hint (MetaScreen *screen)
                    XA_ATOM,
                    32, PropModeReplace,
                    (guchar*) atoms, G_N_ELEMENTS(atoms));
-  
+
   return Success;
 }
 
@@ -127,12 +127,12 @@ set_wm_icon_size_hint (MetaScreen *screen)
   vals[3] = META_ICON_HEIGHT;
   vals[4] = 0;
   vals[5] = 0;
-  
+
   XChangeProperty (screen->display->xdisplay, screen->xroot,
                    screen->display->atom_WM_ICON_SIZE,
                    XA_CARDINAL,
                    32, PropModeReplace, (guchar*) vals, N_VALS);
-  
+
   return Success;
 #undef N_VALS
 }
@@ -151,29 +151,29 @@ reload_xinerama_infos (MetaScreen *screen)
         MetaWorkspace *space = tmp->data;
 
         meta_workspace_invalidate_work_area (space);
-        
+
         tmp = tmp->next;
       }
   }
 
   display = screen->display;
-  
+
   if (screen->xinerama_infos)
     g_free (screen->xinerama_infos);
-  
+
   screen->xinerama_infos = NULL;
   screen->n_xinerama_infos = 0;
   screen->last_xinerama_index = 0;
 
   screen->display->xinerama_cache_invalidated = TRUE;
-  
+
 #ifdef HAVE_XFREE_XINERAMA
   if (XineramaIsActive (display->xdisplay))
     {
       XineramaScreenInfo *infos;
       int n_infos;
       int i;
-      
+
       n_infos = 0;
       infos = XineramaQueryScreens (display->xdisplay, &n_infos);
 
@@ -185,7 +185,7 @@ reload_xinerama_infos (MetaScreen *screen)
         {
           screen->xinerama_infos = g_new (MetaXineramaScreenInfo, n_infos);
           screen->n_xinerama_infos = n_infos;
-          
+
           i = 0;
           while (i < n_infos)
             {
@@ -202,11 +202,11 @@ reload_xinerama_infos (MetaScreen *screen)
                           screen->xinerama_infos[i].rect.y,
                           screen->xinerama_infos[i].rect.width,
                           screen->xinerama_infos[i].rect.height);
-              
+
               ++i;
             }
         }
-      
+
       meta_XFree (infos);
     }
   else
@@ -237,16 +237,16 @@ reload_xinerama_infos (MetaScreen *screen)
                                 screen->number,
 				monitors, hints,
                                 &n_monitors);
-      /* Yes I know it should be Success but the current implementation 
+      /* Yes I know it should be Success but the current implementation
        * returns the num of monitor
        */
       if (result > 0)
 	{
           g_assert (n_monitors > 0);
-          
+
           screen->xinerama_infos = g_new (MetaXineramaScreenInfo, n_monitors);
           screen->n_xinerama_infos = n_monitors;
-          
+
           i = 0;
           while (i < n_monitors)
             {
@@ -262,8 +262,8 @@ reload_xinerama_infos (MetaScreen *screen)
                           screen->xinerama_infos[i].rect.x,
                           screen->xinerama_infos[i].rect.y,
                           screen->xinerama_infos[i].rect.width,
-                          screen->xinerama_infos[i].rect.height);              
-              
+                          screen->xinerama_infos[i].rect.height);
+
               ++i;
             }
 	}
@@ -279,7 +279,7 @@ reload_xinerama_infos (MetaScreen *screen)
               "Marco compiled without Solaris Xinerama support\n");
 #endif /* HAVE_SOLARIS_XINERAMA */
 
-  
+
   /* If no Xinerama, fill in the single screen info so
    * we can use the field unconditionally
    */
@@ -289,10 +289,10 @@ reload_xinerama_infos (MetaScreen *screen)
         {
           meta_topic (META_DEBUG_XINERAMA,
                       "Pretending a single monitor has two Xinerama screens\n");
-          
+
           screen->xinerama_infos = g_new (MetaXineramaScreenInfo, 2);
           screen->n_xinerama_infos = 2;
-          
+
           screen->xinerama_infos[0].number = 0;
           screen->xinerama_infos[0].rect = screen->rect;
           screen->xinerama_infos[0].rect.width = screen->rect.width / 2;
@@ -306,10 +306,10 @@ reload_xinerama_infos (MetaScreen *screen)
         {
           meta_topic (META_DEBUG_XINERAMA,
                       "No Xinerama screens, using default screen info\n");
-          
+
           screen->xinerama_infos = g_new (MetaXineramaScreenInfo, 1);
           screen->n_xinerama_infos = 1;
-          
+
           screen->xinerama_infos[0].number = 0;
           screen->xinerama_infos[0].rect = screen->rect;
         }
@@ -335,16 +335,16 @@ meta_screen_new (MetaDisplay *display,
   char buf[128];
   guint32 manager_timestamp;
   gulong current_workspace;
-  
+
   replace_current_wm = meta_get_replace_current_wm ();
-  
+
   /* Only display->name, display->xdisplay, and display->error_traps
    * can really be used in this function, since normally screens are
    * created from the MetaDisplay constructor
    */
-  
+
   xdisplay = display->xdisplay;
-  
+
   meta_verbose ("Trying screen %d on display '%s'\n",
                 number, display->name);
 
@@ -361,14 +361,14 @@ meta_screen_new (MetaDisplay *display,
     }
 
   sprintf (buf, "WM_S%d", number);
-  wm_sn_atom = XInternAtom (xdisplay, buf, False);  
-  
+  wm_sn_atom = XInternAtom (xdisplay, buf, False);
+
   current_wm_sn_owner = XGetSelectionOwner (xdisplay, wm_sn_atom);
 
   if (current_wm_sn_owner != None)
     {
       XSetWindowAttributes attrs;
-      
+
       if (!replace_current_wm)
         {
           meta_warning (_("Screen %d on display \"%s\" already has a window manager; try using the --replace option to replace the current window manager.\n"),
@@ -392,7 +392,7 @@ meta_screen_new (MetaDisplay *display,
   new_wm_sn_owner = meta_create_offscreen_window (xdisplay, xroot, NoEventMask);
 
   manager_timestamp = timestamp;
-  
+
   XSetSelectionOwner (xdisplay, wm_sn_atom, new_wm_sn_owner,
                       manager_timestamp);
 
@@ -402,14 +402,14 @@ meta_screen_new (MetaDisplay *display,
                     number, display->name);
 
       XDestroyWindow (xdisplay, new_wm_sn_owner);
-      
+
       return NULL;
     }
-  
+
   {
     /* Send client message indicating that we are now the WM */
     XClientMessageEvent ev;
-    
+
     ev.type = ClientMessage;
     ev.window = xroot;
     ev.message_type = display->atom_MANAGER;
@@ -426,7 +426,7 @@ meta_screen_new (MetaDisplay *display,
       XEvent event;
 
       /* We sort of block infinitely here which is probably lame. */
-      
+
       meta_verbose ("Waiting for old window manager to exit\n");
       do
         {
@@ -435,7 +435,7 @@ meta_screen_new (MetaDisplay *display,
         }
       while (event.type != DestroyNotify);
     }
-  
+
   /* select our root window events */
   meta_error_trap_push_with_return (display);
 
@@ -460,13 +460,13 @@ meta_screen_new (MetaDisplay *display,
                     number, display->name);
 
       XDestroyWindow (xdisplay, new_wm_sn_owner);
-      
+
       return NULL;
     }
-  
+
   screen = g_new (MetaScreen, 1);
   screen->closing = 0;
-  
+
   screen->display = display;
   screen->number = number;
   screen->screen_name = get_screen_name (display, number);
@@ -485,8 +485,8 @@ meta_screen_new (MetaDisplay *display,
   screen->wm_sn_timestamp = manager_timestamp;
 
 #ifdef HAVE_COMPOSITE_EXTENSIONS
-  screen->wm_cm_selection_window = meta_create_offscreen_window (xdisplay, 
-                                                                 xroot, 
+  screen->wm_cm_selection_window = meta_create_offscreen_window (xdisplay,
+                                                                 xroot,
                                                                  NoEventMask);
 #endif
   screen->work_area_idle = 0;
@@ -503,7 +503,7 @@ meta_screen_new (MetaDisplay *display,
     XFontStruct *font_info;
     XGCValues gc_values;
     gulong value_mask = 0;
-    
+
     gc_values.subwindow_mode = IncludeInferiors;
     value_mask |= GCSubwindowMode;
     gc_values.function = GXinvert;
@@ -527,27 +527,27 @@ meta_screen_new (MetaDisplay *display,
                                      value_mask,
                                      &gc_values);
   }
-  
+
   screen->xinerama_infos = NULL;
   screen->n_xinerama_infos = 0;
-  screen->last_xinerama_index = 0;  
-  
+  screen->last_xinerama_index = 0;
+
   reload_xinerama_infos (screen);
-  
+
   meta_screen_set_cursor (screen, META_CURSOR_DEFAULT);
 
-  /* Handle creating a no_focus_window for this screen */  
+  /* Handle creating a no_focus_window for this screen */
   screen->no_focus_window =
     meta_create_offscreen_window (display->xdisplay,
                                   screen->xroot,
                                   FocusChangeMask|KeyPressMask|KeyReleaseMask);
   XMapWindow (display->xdisplay, screen->no_focus_window);
   /* Done with no_focus_window stuff */
-  
+
   set_wm_icon_size_hint (screen);
-  
+
   set_supported_hint (screen);
-  
+
   set_wm_check_hint (screen);
 
   set_desktop_viewport_hint (screen);
@@ -566,13 +566,13 @@ meta_screen_new (MetaDisplay *display,
                   (int) current_workspace);
   else
     meta_verbose ("No _NET_CURRENT_DESKTOP present\n");
-  
+
   /* Screens must have at least one workspace at all times,
    * so create that required workspace.
    */
   meta_workspace_activate (meta_workspace_new (screen), timestamp);
   update_num_workspaces (screen, timestamp);
-  
+
   set_workspace_names (screen);
 
   screen->all_keys_grabbed = FALSE;
@@ -605,17 +605,17 @@ meta_screen_new (MetaDisplay *display,
   /* Switch to the _NET_CURRENT_DESKTOP workspace */
   {
     MetaWorkspace *space;
-    
+
     space = meta_screen_get_workspace_by_index (screen,
                                                 current_workspace);
-    
+
     if (space != NULL)
       meta_workspace_activate (space, timestamp);
   }
 
   meta_verbose ("Added screen %d ('%s') root 0x%lx\n",
                 screen->number, screen->screen_name, screen->xroot);
-  
+
   return screen;
 }
 
@@ -629,7 +629,7 @@ meta_screen_free (MetaScreen *screen,
   display = screen->display;
 
   screen->closing += 1;
-  
+
   meta_display_grab (display);
 
   if (screen->display->compositor)
@@ -637,11 +637,11 @@ meta_screen_free (MetaScreen *screen,
       meta_compositor_unmanage_screen (screen->display->compositor,
 				       screen);
     }
-  
+
   meta_display_unmanage_windows_for_screen (display, screen, timestamp);
-  
+
   meta_prefs_remove_listener (prefs_changed_callback, screen);
-  
+
   meta_screen_ungrab_keys (screen);
 
 #ifdef HAVE_STARTUP_NOTIFICATION
@@ -661,7 +661,7 @@ meta_screen_free (MetaScreen *screen,
       screen->sn_context = NULL;
     }
 #endif
-  
+
   meta_ui_free (screen->ui);
 
   meta_stack_free (screen->stack);
@@ -676,7 +676,7 @@ meta_screen_free (MetaScreen *screen,
 
   XDestroyWindow (screen->display->xdisplay,
                   screen->wm_sn_selection_window);
-  
+
   if (screen->work_area_idle != 0)
     g_source_remove (screen->work_area_idle);
 
@@ -692,7 +692,7 @@ meta_screen_free (MetaScreen *screen,
 
   XFreeGC (screen->display->xdisplay,
            screen->root_xor_gc);
-  
+
   if (screen->xinerama_infos)
     g_free (screen->xinerama_infos);
 
@@ -733,7 +733,7 @@ list_windows (MetaScreen *screen)
       WindowInfo *info = g_new0 (WindowInfo, 1);
 
       meta_error_trap_push_with_return (screen->display);
-      
+
       XGetWindowAttributes (screen->display->xdisplay,
                             children[i], &info->attrs);
 
@@ -764,7 +764,7 @@ meta_screen_manage_all_windows (MetaScreen *screen)
   GList *list;
 
   meta_display_grab (screen->display);
-  
+
   windows = list_windows (screen);
 
   meta_stack_freeze (screen->stack);
@@ -841,12 +841,12 @@ MetaScreen*
 meta_screen_for_x_screen (Screen *xscreen)
 {
   MetaDisplay *display;
-  
+
   display = meta_display_for_x_display (DisplayOfScreen (xscreen));
 
   if (display == NULL)
     return NULL;
-  
+
   return meta_display_screen_for_x_screen (display, xscreen);
 }
 
@@ -855,13 +855,13 @@ prefs_changed_callback (MetaPreference pref,
                         gpointer       data)
 {
   MetaScreen *screen = data;
-  
+
   if (pref == META_PREF_NUM_WORKSPACES)
     {
       /* GSettings doesn't provide timestamps, but luckily update_num_workspaces
        * often doesn't need it...
        */
-      guint32 timestamp = 
+      guint32 timestamp =
         meta_display_get_current_time_roundtrip (screen->display);
       update_num_workspaces (screen, timestamp);
     }
@@ -883,7 +883,7 @@ get_screen_name (MetaDisplay *display,
   char *p;
   char *dname;
   char *scr;
-  
+
   /* DisplayString gives us a sort of canonical display,
    * vs. the user-entered name from XDisplayName()
    */
@@ -898,7 +898,7 @@ get_screen_name (MetaDisplay *display,
       if (p)
         *p = '\0';
     }
-  
+
   scr = g_strdup_printf ("%s.%d", dname, number);
 
   g_free (dname);
@@ -921,7 +921,7 @@ static void
 listify_func (gpointer key, gpointer value, gpointer data)
 {
   GSList **listp;
-  
+
   listp = data;
 
   *listp = g_slist_prepend (*listp, value);
@@ -938,14 +938,14 @@ meta_screen_foreach_window (MetaScreen *screen,
   /* If we end up doing this often, just keeping a list
    * of windows might be sensible.
    */
-  
+
   winlist = NULL;
   g_hash_table_foreach (screen->display->window_ids,
                         listify_func,
                         &winlist);
-  
+
   winlist = g_slist_sort (winlist, ptrcmp);
-  
+
   tmp = winlist;
   while (tmp != NULL)
     {
@@ -960,7 +960,7 @@ meta_screen_foreach_window (MetaScreen *screen,
           if (window->screen == screen)
             (* func) (screen, window, data);
         }
-      
+
       tmp = tmp->next;
     }
   g_slist_free (winlist);
@@ -1007,7 +1007,7 @@ meta_screen_get_workspace_by_index (MetaScreen  *screen,
   /* should be robust, idx is maybe from an app */
   if (idx < 0)
     return NULL;
-  
+
   i = 0;
   tmp = screen->workspaces;
   while (tmp != NULL)
@@ -1100,7 +1100,7 @@ update_num_workspaces (MetaScreen *screen,
   GList *extras;
   MetaWorkspace *last_remaining;
   gboolean need_change_space;
-  
+
   new_num = meta_prefs_get_num_workspaces ();
 
   g_assert (new_num > 0);
@@ -1117,13 +1117,13 @@ update_num_workspaces (MetaScreen *screen,
         extras = g_list_prepend (extras, w);
       else
         last_remaining = w;
-          
+
       ++i;
       tmp = tmp->next;
     }
 
   g_assert (last_remaining);
-  
+
   /* Get rid of the extra workspaces by moving all their windows
    * to last_remaining, then activating last_remaining if
    * one of the removed workspaces was active. This will be a bit
@@ -1136,11 +1136,11 @@ update_num_workspaces (MetaScreen *screen,
     {
       MetaWorkspace *w = tmp->data;
 
-      meta_workspace_relocate_windows (w, last_remaining);      
+      meta_workspace_relocate_windows (w, last_remaining);
 
       if (w == screen->active_workspace)
         need_change_space = TRUE;
-      
+
       tmp = tmp->next;
     }
 
@@ -1155,12 +1155,12 @@ update_num_workspaces (MetaScreen *screen,
 
       g_assert (w->windows == NULL);
       meta_workspace_free (w);
-      
+
       tmp = tmp->next;
     }
-  
+
   g_list_free (extras);
-  
+
   while (i < new_num)
     {
       meta_workspace_new (screen);
@@ -1188,7 +1188,7 @@ meta_screen_set_cursor (MetaScreen *screen,
     return;
 
   screen->current_cursor = cursor;
-  
+
   xcursor = meta_display_create_x_cursor (screen->display, cursor);
   XDefineCursor (screen->display->xdisplay, screen->xroot, xcursor);
   XFlush (screen->display->xdisplay);
@@ -1200,7 +1200,7 @@ meta_screen_update_cursor (MetaScreen *screen)
 {
   Cursor xcursor;
 
-  xcursor = meta_display_create_x_cursor (screen->display, 
+  xcursor = meta_display_create_x_cursor (screen->display,
 					  screen->current_cursor);
   XDefineCursor (screen->display->xdisplay, screen->xroot, xcursor);
   XFlush (screen->display->xdisplay);
@@ -1225,7 +1225,7 @@ get_window_pixbuf (MetaWindow *window,
     return NULL;
 
   pixbuf = meta_ui_get_pixbuf_from_pixmap (pmap);
-  if (pixbuf == NULL) 
+  if (pixbuf == NULL)
     return NULL;
 
   *width = gdk_pixbuf_get_width (pixbuf);
@@ -1270,14 +1270,14 @@ meta_screen_ensure_tab_popup (MetaScreen      *screen,
                                         list_type,
                                         screen,
                                         screen->active_workspace);
-  
+
   len = g_list_length (tab_list);
 
   entries = g_new (MetaTabEntry, len + 1);
   entries[len].key = NULL;
   entries[len].title = NULL;
   entries[len].icon = NULL;
-  
+
   i = 0;
   tmp = tab_list;
   while (i < len)
@@ -1290,13 +1290,13 @@ meta_screen_ensure_tab_popup (MetaScreen      *screen,
 #endif
 
       window = tmp->data;
-      
+
       entries[i].key = (MetaTabEntryKey) window->xwindow;
       entries[i].title = window->title;
 
 #if !GTK_CHECK_VERSION (3, 0, 0)
-      /* Only get the pixbuf if the user does NOT have 
-         compositing-fast-alt-tab-set to true 
+      /* Only get the pixbuf if the user does NOT have
+         compositing-fast-alt-tab-set to true
          in GSettings. There is an obvious lag when the pixbuf is
          retrieved. */
       if (!meta_prefs_get_compositing_fast_alt_tab())
@@ -1321,10 +1321,10 @@ meta_screen_ensure_tab_popup (MetaScreen      *screen,
           gdk_pixbuf_copy_area (win_pixbuf, 0, 0, width, height,
                                 entries[i].icon, 0, 0);
           g_object_unref (win_pixbuf);
-          gdk_pixbuf_composite (window->icon, entries[i].icon, 
+          gdk_pixbuf_composite (window->icon, entries[i].icon,
                                 t_width - icon_width, t_height - icon_height,
                                 icon_width, icon_height,
-                                t_width - icon_width, t_height - icon_height, 
+                                t_width - icon_width, t_height - icon_height,
                                 1.0, 1.0, GDK_INTERP_BILINEAR, 255);
         }
 #else
@@ -1335,12 +1335,12 @@ meta_screen_ensure_tab_popup (MetaScreen      *screen,
       entries[i].blank = FALSE;
       entries[i].hidden = !meta_window_showing_on_its_workspace (window);
       entries[i].demands_attention = window->wm_state_demands_attention;
-      
+
       if (show_type == META_TAB_SHOW_INSTANTLY ||
           !entries[i].hidden                   ||
           !meta_window_get_icon_geometry (window, &r))
         meta_window_get_outer_rect (window, &r);
-      
+
       entries[i].rect = r;
 
       /* Find inside of highlight rectangle to be used when window is
@@ -1381,24 +1381,24 @@ meta_screen_ensure_tab_popup (MetaScreen      *screen,
       else
         entries[i].inner_rect.width = r.width
           - entries[i].inner_rect.x - OUTLINE_WIDTH;
-      
+
       ++i;
       tmp = tmp->next;
     }
 
-  screen->tab_popup = meta_ui_tab_popup_new (entries, 
+  screen->tab_popup = meta_ui_tab_popup_new (entries,
                                              screen->number,
                                              len,
                                              5, /* FIXME */
                                              TRUE);
 
-  for (i = 0; i < len; i++) 
+  for (i = 0; i < len; i++)
     g_object_unref (entries[i].icon);
 
   g_free (entries);
 
   g_list_free (tab_list);
-  
+
   /* don't show tab popup, since proper window isn't selected yet */
 }
 
@@ -1411,7 +1411,7 @@ meta_screen_ensure_workspace_popup (MetaScreen *screen)
   MetaWorkspaceLayout layout;
   int n_workspaces;
   int current_workspace;
-  
+
   if (screen->tab_popup)
     return;
 
@@ -1422,7 +1422,7 @@ meta_screen_ensure_workspace_popup (MetaScreen *screen)
                                      current_workspace, &layout);
 
   len = layout.grid_area;
-  
+
   entries = g_new (MetaTabEntry, len + 1);
   entries[len].key = NULL;
   entries[len].title = NULL;
@@ -1434,15 +1434,15 @@ meta_screen_ensure_workspace_popup (MetaScreen *screen)
       if (layout.grid[i] >= 0)
         {
           MetaWorkspace *workspace;
-          
+
           workspace = meta_screen_get_workspace_by_index (screen,
                                                           layout.grid[i]);
-          
+
           entries[i].key = (MetaTabEntryKey) workspace;
           entries[i].title = meta_workspace_get_name (workspace);
           entries[i].icon = NULL;
           entries[i].blank = FALSE;
-          
+
           g_assert (entries[i].title != NULL);
         }
       else
@@ -1458,11 +1458,11 @@ meta_screen_ensure_workspace_popup (MetaScreen *screen)
       ++i;
     }
 
-  screen->tab_popup = meta_ui_tab_popup_new (entries, 
+  screen->tab_popup = meta_ui_tab_popup_new (entries,
                                              screen->number,
                                              len,
                                              layout.cols,
-                                             FALSE);      
+                                             FALSE);
 
   g_free (entries);
   meta_screen_free_workspace_layout (&layout);
@@ -1532,7 +1532,7 @@ meta_screen_get_mouse_window (MetaScreen  *screen,
   int root_x_return, root_y_return;
   int win_x_return, win_y_return;
   unsigned int mask_return;
-  
+
   if (not_this_one)
     meta_topic (META_DEBUG_FOCUS,
                 "Focusing mouse window excluding %s\n", not_this_one->desc);
@@ -1595,13 +1595,13 @@ meta_screen_get_xinerama_for_window (MetaScreen *screen,
 				     MetaWindow *window)
 {
   MetaRectangle window_rect;
-  
+
   meta_window_get_outer_rect (window, &window_rect);
 
   return meta_screen_get_xinerama_for_rect (screen, &window_rect);
 }
 
-const MetaXineramaScreenInfo* 
+const MetaXineramaScreenInfo*
 meta_screen_get_xinerama_neighbor (MetaScreen         *screen,
                                    int                 which_xinerama,
                                    MetaScreenDirection direction)
@@ -1614,23 +1614,23 @@ meta_screen_get_xinerama_neighbor (MetaScreen         *screen,
     {
       current = screen->xinerama_infos + i;
 
-      if ((direction == META_SCREEN_RIGHT && 
+      if ((direction == META_SCREEN_RIGHT &&
            current->rect.x == input->rect.x + input->rect.width &&
            meta_rectangle_vert_overlap(&current->rect, &input->rect)) ||
-          (direction == META_SCREEN_LEFT && 
+          (direction == META_SCREEN_LEFT &&
            input->rect.x == current->rect.x + current->rect.width &&
            meta_rectangle_vert_overlap(&current->rect, &input->rect)) ||
-          (direction == META_SCREEN_UP && 
+          (direction == META_SCREEN_UP &&
            input->rect.y == current->rect.y + current->rect.height &&
            meta_rectangle_horiz_overlap(&current->rect, &input->rect)) ||
-          (direction == META_SCREEN_DOWN && 
+          (direction == META_SCREEN_DOWN &&
            current->rect.y == input->rect.y + input->rect.height &&
            meta_rectangle_horiz_overlap(&current->rect, &input->rect)))
         {
           return current;
         }
     }
-  
+
   return NULL;
 }
 
@@ -1670,7 +1670,7 @@ meta_screen_get_natural_xinerama_list (MetaScreen *screen,
 
   while (!g_queue_is_empty (xinerama_queue))
     {
-      current = (const MetaXineramaScreenInfo*) 
+      current = (const MetaXineramaScreenInfo*)
         g_queue_pop_head (xinerama_queue);
 
       (*xineramas_list)[cur++] = current->number;
@@ -1734,10 +1734,10 @@ meta_screen_get_current_xinerama (MetaScreen *screen)
 {
   if (screen->n_xinerama_infos == 1)
     return &screen->xinerama_infos[0];
-  
+
   /* Sadly, we have to do it this way. Yuck.
    */
-  
+
   if (screen->display->xinerama_cache_invalidated)
     {
       Window root_return, child_return;
@@ -1745,9 +1745,9 @@ meta_screen_get_current_xinerama (MetaScreen *screen)
       unsigned int mask_return;
       int i;
       MetaRectangle pointer_position;
-      
+
       screen->display->xinerama_cache_invalidated = FALSE;
-      
+
       pointer_position.width = pointer_position.height = 1;
       XQueryPointer (screen->display->xdisplay,
                      screen->xroot,
@@ -1769,7 +1769,7 @@ meta_screen_get_current_xinerama (MetaScreen *screen)
               break;
             }
         }
-      
+
       meta_topic (META_DEBUG_XINERAMA,
                   "Rechecked current Xinerama, now %d\n",
                   screen->last_xinerama_index);
@@ -1791,7 +1791,7 @@ meta_screen_update_workspace_layout (MetaScreen *screen)
 {
   gulong *list;
   int n_items;
-  
+
   list = NULL;
   n_items = 0;
 
@@ -1803,7 +1803,7 @@ meta_screen_update_workspace_layout (MetaScreen *screen)
       if (n_items == 3 || n_items == 4)
         {
           int cols, rows;
-          
+
           switch (list[0])
             {
             case _NET_WM_ORIENTATION_HORZ:
@@ -1830,7 +1830,7 @@ meta_screen_update_workspace_layout (MetaScreen *screen)
                 screen->rows_of_workspaces = rows;
               else
                 screen->rows_of_workspaces = -1;
-              
+
               if (cols > 0)
                 screen->columns_of_workspaces = cols;
               else
@@ -1903,10 +1903,10 @@ set_workspace_names (MetaScreen *screen)
                              strlen (name) + 1);
       else
         g_string_append_len (flattened, "", 1);
-      
+
       ++i;
     }
-  
+
   meta_error_trap_push (screen->display);
   XChangeProperty (screen->display->xdisplay,
                    screen->xroot,
@@ -1915,7 +1915,7 @@ set_workspace_names (MetaScreen *screen)
                    8, PropModeReplace,
 		   (unsigned char *)flattened->str, flattened->len);
   meta_error_trap_pop (screen->display, FALSE);
-  
+
   g_string_free (flattened, TRUE);
 }
 
@@ -1929,7 +1929,7 @@ meta_screen_update_workspace_names (MetaScreen *screen)
   /* this updates names in prefs when the root window property changes,
    * iff the new property contents don't match what's already in prefs
    */
-  
+
   names = NULL;
   n_names = 0;
   if (!meta_prop_get_utf8_list (screen->display,
@@ -1949,10 +1949,10 @@ meta_screen_update_workspace_names (MetaScreen *screen)
                   "Setting workspace %d name to \"%s\" due to _NET_DESKTOP_NAMES change\n",
                   i, names[i] ? names[i] : "null");
       meta_prefs_change_workspace_name (i, names[i]);
-      
+
       ++i;
     }
-  
+
   g_strfreev (names);
 }
 
@@ -1969,7 +1969,7 @@ meta_create_offscreen_window (Display *xdisplay,
    */
   attrs.override_redirect = True;
   attrs.event_mask = valuemask;
-  
+
   return XCreateWindow (xdisplay,
                         parent,
                         -100, -100, 1, 1,
@@ -1988,12 +1988,12 @@ set_work_area_hint (MetaScreen *screen)
   GList *tmp_list;
   unsigned long *data, *tmp;
   MetaRectangle area;
-  
+
   num_workspaces = meta_screen_get_n_workspaces (screen);
   data = g_new (unsigned long, num_workspaces * 4);
   tmp_list = screen->workspaces;
   tmp = data;
-  
+
   while (tmp_list != NULL)
     {
       MetaWorkspace *workspace = tmp_list->data;
@@ -2008,10 +2008,10 @@ set_work_area_hint (MetaScreen *screen)
 
 	  tmp += 4;
         }
-      
+
       tmp_list = tmp_list->next;
     }
-  
+
   meta_error_trap_push (screen->display);
   XChangeProperty (screen->display->xdisplay, screen->xroot,
 		   screen->display->atom__NET_WORKAREA,
@@ -2026,11 +2026,11 @@ set_work_area_idle_func (MetaScreen *screen)
 {
   meta_topic (META_DEBUG_WORKAREA,
               "Running work area idle function\n");
-  
+
   screen->work_area_idle = 0;
-  
+
   set_work_area_hint (screen);
-  
+
   return FALSE;
 }
 
@@ -2082,7 +2082,7 @@ meta_screen_calc_workspace_layout (MetaScreen          *screen,
   int *grid;
   int i, r, c;
   int current_row, current_col;
-  
+
   rows = screen->rows_of_workspaces;
   cols = screen->columns_of_workspaces;
   if (rows <= 0 && cols <= 0)
@@ -2100,58 +2100,58 @@ meta_screen_calc_workspace_layout (MetaScreen          *screen,
     cols = 1;
 
   g_assert (rows != 0 && cols != 0);
-  
+
   grid_area = rows * cols;
-  
+
   meta_verbose ("Getting layout rows = %d cols = %d current = %d "
                 "num_spaces = %d vertical = %s corner = %s\n",
                 rows, cols, current_space, num_workspaces,
                 screen->vertical_workspaces ? "(true)" : "(false)",
                 meta_screen_corner_to_string (screen->starting_corner));
-  
-  /* ok, we want to setup the distances in the workspace array to go     
-   * in each direction. Remember, there are many ways that a workspace   
-   * array can be setup.                                                 
-   * see http://www.freedesktop.org/standards/wm-spec/1.2/html/x109.html 
-   * and look at the _NET_DESKTOP_LAYOUT section for details.            
+
+  /* ok, we want to setup the distances in the workspace array to go
+   * in each direction. Remember, there are many ways that a workspace
+   * array can be setup.
+   * see http://www.freedesktop.org/standards/wm-spec/1.2/html/x109.html
+   * and look at the _NET_DESKTOP_LAYOUT section for details.
    * For instance:
    */
-  /* starting_corner = META_SCREEN_TOPLEFT                         
+  /* starting_corner = META_SCREEN_TOPLEFT
    *  vertical_workspaces = 0                 vertical_workspaces=1
-   *       1234                                    1357            
-   *       5678                                    2468            
-   *                                                               
-   * starting_corner = META_SCREEN_TOPRIGHT                        
+   *       1234                                    1357
+   *       5678                                    2468
+   *
+   * starting_corner = META_SCREEN_TOPRIGHT
    *  vertical_workspaces = 0                 vertical_workspaces=1
-   *       4321                                    7531            
-   *       8765                                    8642            
-   *                                                               
-   * starting_corner = META_SCREEN_BOTTOMLEFT                      
+   *       4321                                    7531
+   *       8765                                    8642
+   *
+   * starting_corner = META_SCREEN_BOTTOMLEFT
    *  vertical_workspaces = 0                 vertical_workspaces=1
-   *       5678                                    2468            
-   *       1234                                    1357            
-   *                                                               
-   * starting_corner = META_SCREEN_BOTTOMRIGHT                     
+   *       5678                                    2468
+   *       1234                                    1357
+   *
+   * starting_corner = META_SCREEN_BOTTOMRIGHT
    *  vertical_workspaces = 0                 vertical_workspaces=1
-   *       8765                                    8642            
-   *       4321                                    7531            
+   *       8765                                    8642
+   *       4321                                    7531
    *
    */
   /* keep in mind that we could have a ragged layout, e.g. the "8"
    * in the above grids could be missing
    */
 
-  
+
   grid = g_new (int, grid_area);
 
   current_row = -1;
   current_col = -1;
   i = 0;
-  
-  switch (screen->starting_corner) 
+
+  switch (screen->starting_corner)
     {
     case META_SCREEN_TOPLEFT:
-      if (screen->vertical_workspaces) 
+      if (screen->vertical_workspaces)
         {
           c = 0;
           while (c < cols)
@@ -2183,7 +2183,7 @@ meta_screen_calc_workspace_layout (MetaScreen          *screen,
         }
       break;
     case META_SCREEN_TOPRIGHT:
-      if (screen->vertical_workspaces) 
+      if (screen->vertical_workspaces)
         {
           c = cols - 1;
           while (c >= 0)
@@ -2215,7 +2215,7 @@ meta_screen_calc_workspace_layout (MetaScreen          *screen,
         }
       break;
     case META_SCREEN_BOTTOMLEFT:
-      if (screen->vertical_workspaces) 
+      if (screen->vertical_workspaces)
         {
           c = 0;
           while (c < cols)
@@ -2247,7 +2247,7 @@ meta_screen_calc_workspace_layout (MetaScreen          *screen,
         }
       break;
     case META_SCREEN_BOTTOMRIGHT:
-      if (screen->vertical_workspaces) 
+      if (screen->vertical_workspaces)
         {
           c = cols - 1;
           while (c >= 0)
@@ -2278,12 +2278,12 @@ meta_screen_calc_workspace_layout (MetaScreen          *screen,
             }
         }
       break;
-    }  
+    }
 
   if (i != grid_area)
     meta_bug ("did not fill in the whole workspace grid in %s (%d filled)\n",
               G_STRFUNC, i);
-  
+
   current_row = 0;
   current_col = 0;
   r = 0;
@@ -2364,13 +2364,13 @@ void
 meta_screen_resize (MetaScreen *screen,
                     int         width,
                     int         height)
-{  
+{
   screen->rect.width = width;
   screen->rect.height = height;
 
   reload_xinerama_infos (screen);
   set_desktop_geometry_hint (screen);
-  
+
   /* Queue a resize on all the windows */
   meta_screen_foreach_window (screen, meta_screen_resize_func, 0);
 }
@@ -2381,7 +2381,7 @@ meta_screen_update_showing_desktop_hint (MetaScreen *screen)
   unsigned long data[1];
 
   data[0] = screen->active_workspace->showing_desktop ? 1 : 0;
-      
+
   meta_error_trap_push (screen->display);
   XChangeProperty (screen->display->xdisplay, screen->xroot,
                    screen->display->atom__NET_SHOWING_DESKTOP,
@@ -2409,7 +2409,7 @@ queue_windows_showing (MetaScreen *screen)
 
       if (w->screen == screen)
         meta_window_queue (w, META_QUEUE_CALC_SHOWING);
-      
+
       tmp = tmp->next;
     }
 
@@ -2424,32 +2424,32 @@ meta_screen_minimize_all_on_active_workspace_except (MetaScreen *screen,
   GList *tmp;
 
   windows = screen->active_workspace->windows;
-  
+
   tmp = windows;
   while (tmp != NULL)
     {
       MetaWindow *w = tmp->data;
-      
+
       if (w->screen == screen  &&
           w->has_minimize_func &&
 	  w != keep)
 	meta_window_minimize (w);
-      
+
       tmp = tmp->next;
     }
 }
 
 void
-meta_screen_show_desktop (MetaScreen *screen, 
+meta_screen_show_desktop (MetaScreen *screen,
                           guint32     timestamp)
 {
   GList *windows;
 
   if (screen->active_workspace->showing_desktop)
     return;
-  
+
   screen->active_workspace->showing_desktop = TRUE;
-  
+
   queue_windows_showing (screen);
 
   /* Focus the most recently used META_WINDOW_DESKTOP window, if there is one;
@@ -2459,18 +2459,18 @@ meta_screen_show_desktop (MetaScreen *screen,
   while (windows != NULL)
     {
       MetaWindow *w = windows->data;
-      
-      if (w->screen == screen  && 
+
+      if (w->screen == screen  &&
           w->type == META_WINDOW_DESKTOP)
         {
           meta_window_focus (w, timestamp);
           break;
         }
-      
+
       windows = windows->next;
     }
 
-  
+
   meta_screen_update_showing_desktop_hint (screen);
 }
 
@@ -2537,11 +2537,11 @@ remove_sequence (MetaScreen        *screen,
   meta_topic (META_DEBUG_STARTUP,
               "Removing sequence %s\n",
               sn_startup_sequence_get_id (sequence));
-  
+
   screen->startup_sequences = g_slist_remove (screen->startup_sequences,
                                               sequence);
   sn_startup_sequence_unref (sequence);
-  
+
   if (screen->startup_sequences == NULL &&
       screen->startup_sequence_timeout != 0)
     {
@@ -2573,7 +2573,7 @@ collect_timed_out_foreach (void *element,
   SnStartupSequence *sequence = element;
   long tv_sec, tv_usec;
   double elapsed;
-  
+
   sn_startup_sequence_get_last_active_time (sequence, &tv_sec, &tv_usec);
 
   elapsed =
@@ -2584,7 +2584,7 @@ collect_timed_out_foreach (void *element,
               "Sequence used %g seconds vs. %g max: %s\n",
               elapsed, (double) STARTUP_TIMEOUT,
               sn_startup_sequence_get_id (sequence));
-  
+
   if (elapsed > STARTUP_TIMEOUT)
     ctod->list = g_slist_prepend (ctod->list, sequence);
 }
@@ -2595,7 +2595,7 @@ startup_sequence_timeout (void *data)
   MetaScreen *screen = data;
   CollectTimedOutData ctod;
   GSList *tmp;
-  
+
   ctod.list = NULL;
   g_get_current_time (&ctod.now);
   g_slist_foreach (screen->startup_sequences,
@@ -2610,14 +2610,14 @@ startup_sequence_timeout (void *data)
       meta_topic (META_DEBUG_STARTUP,
                   "Timed out sequence %s\n",
                   sn_startup_sequence_get_id (sequence));
-      
+
       sn_startup_sequence_complete (sequence);
-      
+
       tmp = tmp->next;
     }
 
   g_slist_free (ctod.list);
-  
+
   if (screen->startup_sequences != NULL)
     {
       return TRUE;
@@ -2636,11 +2636,11 @@ meta_screen_sn_event (SnMonitorEvent *event,
 {
   MetaScreen *screen;
   SnStartupSequence *sequence;
-  
+
   screen = user_data;
 
   sequence = sn_monitor_event_get_startup_sequence (event);
-  
+
   switch (sn_monitor_event_get_type (event))
     {
     case SN_MONITOR_EVENT_INITIATED:
@@ -2648,7 +2648,7 @@ meta_screen_sn_event (SnMonitorEvent *event,
         const char *wmclass;
 
         wmclass = sn_startup_sequence_get_wmclass (sequence);
-        
+
         meta_topic (META_DEBUG_STARTUP,
                     "Received startup initiated for %s wmclass %s\n",
                     sn_startup_sequence_get_id (sequence),
@@ -2698,7 +2698,7 @@ meta_screen_apply_startup_properties (MetaScreen *screen,
   const char *startup_id;
   GSList *tmp;
   SnStartupSequence *sequence;
-  
+
   /* Does the window have a startup ID stored? */
   startup_id = meta_window_get_startup_id (window);
 
@@ -2706,7 +2706,7 @@ meta_screen_apply_startup_properties (MetaScreen *screen,
               "Applying startup props to %s id \"%s\"\n",
               window->desc,
               startup_id ? startup_id : "(none)");
-  
+
   sequence = NULL;
   if (startup_id == NULL)
     {
@@ -2737,11 +2737,11 @@ meta_screen_apply_startup_properties (MetaScreen *screen,
                           "Ending legacy sequence %s due to window %s\n",
                           sn_startup_sequence_get_id (sequence),
                           window->desc);
-              
+
               sn_startup_sequence_complete (sequence);
               break;
             }
-          
+
           tmp = tmp->next;
         }
     }
@@ -2749,7 +2749,7 @@ meta_screen_apply_startup_properties (MetaScreen *screen,
   /* Still no startup ID? Bail. */
   if (startup_id == NULL)
     return FALSE;
-  
+
   /* We might get this far and not know the sequence ID (if the window
    * already had a startup ID stored), so let's look for one if we don't
    * already know it.
@@ -2760,15 +2760,15 @@ meta_screen_apply_startup_properties (MetaScreen *screen,
       while (tmp != NULL)
         {
           const char *id;
-          
+
           id = sn_startup_sequence_get_id (tmp->data);
-          
+
           if (strcmp (id, startup_id) == 0)
             {
               sequence = tmp->data;
               break;
             }
-          
+
           tmp = tmp->next;
         }
     }
@@ -2776,7 +2776,7 @@ meta_screen_apply_startup_properties (MetaScreen *screen,
   if (sequence != NULL)
     {
       gboolean changed_something = FALSE;
-          
+
       meta_topic (META_DEBUG_STARTUP,
                   "Found startup sequence for window %s ID \"%s\"\n",
                   window->desc, startup_id);
@@ -2789,7 +2789,7 @@ meta_screen_apply_startup_properties (MetaScreen *screen,
               meta_topic (META_DEBUG_STARTUP,
                           "Setting initial window workspace to %d based on startup info\n",
                           space);
-              
+
               window->initial_workspace_set = TRUE;
               window->initial_workspace = space;
               changed_something = TRUE;
@@ -2802,7 +2802,7 @@ meta_screen_apply_startup_properties (MetaScreen *screen,
           meta_topic (META_DEBUG_STARTUP,
                       "Setting initial window timestamp to %u based on startup info\n",
                       timestamp);
-              
+
           window->initial_timestamp_set = TRUE;
           window->initial_timestamp = timestamp;
           changed_something = TRUE;
@@ -2816,7 +2816,7 @@ meta_screen_apply_startup_properties (MetaScreen *screen,
                   "Did not find startup sequence for window %s ID \"%s\"\n",
                   window->desc, startup_id);
     }
-  
+
 #endif /* HAVE_STARTUP_NOTIFICATION */
 
   return FALSE;
@@ -2840,7 +2840,7 @@ meta_screen_get_xroot (MetaScreen *screen)
   return screen->xroot;
 }
 
-void 
+void
 meta_screen_get_size (MetaScreen *screen,
                       int        *width,
                       int        *height)
@@ -2875,7 +2875,7 @@ meta_screen_set_cm_selection (MetaScreen *screen)
   g_snprintf (selection, sizeof(selection), "_NET_WM_CM_S%d", screen->number);
   meta_verbose ("Setting selection: %s\n", selection);
   a = XInternAtom (screen->display->xdisplay, selection, FALSE);
-  XSetSelectionOwner (screen->display->xdisplay, a, 
+  XSetSelectionOwner (screen->display->xdisplay, a,
                       screen->wm_cm_selection_window, screen->wm_cm_timestamp);
 }
 

--- a/src/core/session.c
+++ b/src/core/session.c
@@ -2,11 +2,11 @@
 
 /* Marco Session Management */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington (some code in here from
  * libmateui, (C) Tom Tromey, Carsten Schaar)
  * Copyright (C) 2004, 2005 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -16,7 +16,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -76,7 +76,7 @@ meta_window_release_saved_state (const MetaWindowSessionInfo *info)
 
 static void ice_io_error_handler (IceConn connection);
 
-static void new_ice_connection (IceConn connection, IcePointer client_data, 
+static void new_ice_connection (IceConn connection, IcePointer client_data,
 				Bool opening, IcePointer *watch_data);
 
 static void        save_state         (void);
@@ -106,7 +106,7 @@ process_ice_messages (GIOChannel *channel,
 #if 0
       IcePointer context = IceGetConnectionContext (connection);
 #endif
-      
+
       /* We were disconnected; close our connection to the
        * session manager, this will result in the ICE connection
        * being cleaned up, since it is owned by libSM.
@@ -116,7 +116,7 @@ process_ice_messages (GIOChannel *channel,
 
       return FALSE;
     }
-  
+
   return TRUE;
 }
 
@@ -134,22 +134,22 @@ new_ice_connection (IceConn connection, IcePointer client_data, Bool opening,
        * exec'ed children
        */
       GIOChannel *channel;
-      
+
       fcntl (IceConnectionNumber (connection), F_SETFD,
              fcntl (IceConnectionNumber (connection), F_GETFD, 0) | FD_CLOEXEC);
 
       channel = g_io_channel_unix_new (IceConnectionNumber (connection));
-      
+
       input_id = g_io_add_watch (channel,
                                  G_IO_IN | G_IO_ERR,
                                  process_ice_messages,
                                  connection);
 
       g_io_channel_unref (channel);
-      
+
       *watch_data = (IcePointer) GUINT_TO_POINTER (input_id);
     }
-  else 
+  else
     {
       input_id = GPOINTER_TO_UINT ((gpointer) *watch_data);
 
@@ -159,14 +159,14 @@ new_ice_connection (IceConn connection, IcePointer client_data, Bool opening,
 
 static IceIOErrorHandler ice_installed_handler;
 
-/* We call any handler installed before (or after) mate_ice_init but 
+/* We call any handler installed before (or after) mate_ice_init but
    avoid calling the default libICE handler which does an exit() */
 static void
 ice_io_error_handler (IceConn connection)
 {
     if (ice_installed_handler)
       (*ice_installed_handler) (connection);
-}    
+}
 
 static void
 ice_init (void)
@@ -235,7 +235,7 @@ meta_session_init (const char *previous_client_id,
   unsigned long mask;
   SmcCallbacks callbacks;
   char *saved_client_id;
-  
+
   meta_topic (META_DEBUG_SM, "Initializing session with save file '%s'\n",
               previous_save_file ? previous_save_file : "(none)");
 
@@ -254,24 +254,24 @@ meta_session_init (const char *previous_client_id,
     {
       saved_client_id = NULL;
     }
-  
+
   ice_init ();
-  
+
   mask = SmcSaveYourselfProcMask | SmcDieProcMask |
     SmcSaveCompleteProcMask | SmcShutdownCancelledProcMask;
-  
+
   callbacks.save_yourself.callback = save_yourself_callback;
   callbacks.save_yourself.client_data = NULL;
-  
+
   callbacks.die.callback = die_callback;
   callbacks.die.client_data = NULL;
-  
+
   callbacks.save_complete.callback = save_complete_callback;
   callbacks.save_complete.client_data = NULL;
-  
+
   callbacks.shutdown_cancelled.callback = shutdown_cancelled_callback;
   callbacks.shutdown_cancelled.client_data = NULL;
-  
+
   session_connection =
     SmcOpenConnection (NULL, /* use SESSION_MANAGER env */
                        NULL, /* means use existing ICE connection */
@@ -282,10 +282,10 @@ meta_session_init (const char *previous_client_id,
                        (char*) previous_client_id,
                        &client_id,
                        255, buf);
-  
+
   if (session_connection == NULL)
     {
-      meta_topic (META_DEBUG_SM, 
+      meta_topic (META_DEBUG_SM,
                   "Failed to a open connection to a session manager, so window positions will not be saved: %s\n",
                   buf);
 
@@ -302,14 +302,14 @@ meta_session_init (const char *previous_client_id,
     current_state = STATE_IDLE;
   else
     current_state = STATE_REGISTERING;
-  
+
   {
     SmProp prop1, prop2, prop3, prop4, prop5, prop6, *props[6];
     SmPropValue prop1val, prop2val, prop3val, prop4val, prop5val, prop6val;
     char pid[32];
     char hint = SmRestartImmediately;
     char priority = 20; /* low to run before other apps */
-    
+
     prop1.name = SmProgram;
     prop1.type = SmARRAY8;
     prop1.num_vals = 1;
@@ -326,7 +326,7 @@ meta_session_init (const char *previous_client_id,
     prop2.vals = &prop2val;
     prop2val.value = (char*) g_get_user_name ();
     prop2val.length = strlen (prop2val.value);
-	
+
     prop3.name = SmRestartStyleHint;
     prop3.type = SmCARD8;
     prop3.num_vals = 1;
@@ -340,7 +340,7 @@ meta_session_init (const char *previous_client_id,
     prop4.num_vals = 1;
     prop4.vals = &prop4val;
     prop4val.value = pid;
-    prop4val.length = strlen (prop4val.value);    
+    prop4val.length = strlen (prop4val.value);
 
     /* Always start in home directory */
     prop5.name = SmCurrentDirectory;
@@ -356,14 +356,14 @@ meta_session_init (const char *previous_client_id,
     prop6.vals = &prop6val;
     prop6val.value = &priority;
     prop6val.length = 1;
-    
+
     props[0] = &prop1;
     props[1] = &prop2;
     props[2] = &prop3;
     props[3] = &prop4;
     props[4] = &prop5;
     props[5] = &prop6;
-    
+
     SmcSetProperties (session_connection, 6, props);
   }
 
@@ -375,7 +375,7 @@ void
 meta_session_shutdown (void)
 {
   /* Change our restart mode to IfRunning */
-  
+
   SmProp prop1;
   SmPropValue prop1val;
   SmProp *props[1];
@@ -383,16 +383,16 @@ meta_session_shutdown (void)
 
   if (session_connection == NULL)
     return;
-  
+
   prop1.name = SmRestartStyleHint;
   prop1.type = SmCARD8;
   prop1.num_vals = 1;
   prop1.vals = &prop1val;
   prop1val.value = &hint;
   prop1val.length = 1;
-    
+
   props[0] = &prop1;
-  
+
   SmcSetProperties (session_connection, 1, props);
 }
 
@@ -411,11 +411,11 @@ save_yourself_possibly_done (gboolean shutdown,
   meta_topic (META_DEBUG_SM,
               "save possibly done shutdown = %d success = %d\n",
               shutdown, successful);
-  
+
   if (current_state == STATE_SAVING_PHASE_1)
     {
       Status status;
-      
+
       status = SmcRequestSaveYourselfPhase2 (session_connection,
                                              save_phase_2_callback,
                                              GINT_TO_POINTER (shutdown));
@@ -446,17 +446,17 @@ save_yourself_possibly_done (gboolean shutdown,
       meta_topic (META_DEBUG_SM,
                   "Requested interact, status = %d\n", status);
     }
-  
+
   if (current_state == STATE_SAVING_PHASE_1 ||
       current_state == STATE_SAVING_PHASE_2 ||
       current_state == STATE_DONE_WITH_INTERACT ||
       current_state == STATE_SKIPPING_GLOBAL_SAVE)
     {
       meta_topic (META_DEBUG_SM, "Sending SaveYourselfDone\n");
-      
+
       SmcSaveYourselfDone (session_connection,
                            successful);
-      
+
       if (shutdown)
         current_state = STATE_FROZEN;
       else
@@ -464,19 +464,19 @@ save_yourself_possibly_done (gboolean shutdown,
     }
 }
 
-static void 
+static void
 save_phase_2_callback (SmcConn smc_conn, SmPointer client_data)
 {
   gboolean shutdown;
 
   meta_topic (META_DEBUG_SM, "Phase 2 save");
-  
+
   shutdown = GPOINTER_TO_INT (client_data);
-  
+
   current_state = STATE_SAVING_PHASE_2;
 
   save_state ();
-  
+
   save_yourself_possibly_done (shutdown, TRUE);
 }
 
@@ -491,9 +491,9 @@ save_yourself_callback (SmcConn   smc_conn,
   gboolean successful;
 
   meta_topic (META_DEBUG_SM, "SaveYourself received");
-  
+
   successful = TRUE;
-  
+
   /* The first SaveYourself after registering for the first time
    * is a special case (SM specs 7.2).
    */
@@ -503,8 +503,8 @@ save_yourself_callback (SmcConn   smc_conn,
     {
       current_state = STATE_IDLE;
       /* Double check that this is a section 7.2 SaveYourself: */
-      
-      if (save_style == SmSaveLocal && 
+
+      if (save_style == SmSaveLocal &&
 	  interact_style == SmInteractStyleNone &&
 	  !shutdown && !fast)
 	{
@@ -516,7 +516,7 @@ save_yourself_callback (SmcConn   smc_conn,
 #endif
 
   /* ignore Global style saves
-   * 
+   *
    * This interpretaion of the Local/Global/Both styles
    * was discussed extensively on the xdg-list. See:
    *
@@ -530,11 +530,11 @@ save_yourself_callback (SmcConn   smc_conn,
     }
 
   interaction_allowed = interact_style != SmInteractStyleNone;
-  
+
   current_state = STATE_SAVING_PHASE_1;
 
   regenerate_save_file ();
-  
+
   set_clone_restart_commands ();
 
   save_yourself_possibly_done (shutdown, successful);
@@ -560,7 +560,7 @@ static void
 shutdown_cancelled_callback (SmcConn smc_conn, SmPointer client_data)
 {
   meta_topic (META_DEBUG_SM, "Shutdown cancelled received\n");
-  
+
   if (session_connection != NULL &&
       (current_state != STATE_IDLE && current_state != STATE_FROZEN))
     {
@@ -569,14 +569,14 @@ shutdown_cancelled_callback (SmcConn smc_conn, SmPointer client_data)
     }
 }
 
-static void 
+static void
 interact_callback (SmcConn smc_conn, SmPointer client_data)
 {
   /* nothing */
   gboolean shutdown;
 
   meta_topic (META_DEBUG_SM, "Interaction permission received\n");
-  
+
   shutdown = GPOINTER_TO_INT (client_data);
 
   current_state = STATE_DONE_WITH_INTERACT;
@@ -592,14 +592,14 @@ set_clone_restart_commands (void)
   char *discardv[10];
   int i;
   SmProp prop1, prop2, prop3, *props[3];
-  
+
   /* Restart (use same client ID) */
-  
+
   prop1.name = SmRestartCommand;
   prop1.type = SmLISTofARRAY8;
-  
+
   g_return_if_fail (client_id);
-  
+
   i = 0;
   restartv[i] = "marco";
   ++i;
@@ -620,7 +620,7 @@ set_clone_restart_commands (void)
   prop1.num_vals = i;
 
   /* Clone (no client ID) */
-  
+
   i = 0;
   clonev[i] = "marco";
   ++i;
@@ -628,7 +628,7 @@ set_clone_restart_commands (void)
 
   prop2.name = SmCloneCommand;
   prop2.type = SmLISTofARRAY8;
-  
+
   prop2.vals = g_new (SmPropValue, i);
   i = 0;
   while (clonev[i])
@@ -640,7 +640,7 @@ set_clone_restart_commands (void)
   prop2.num_vals = i;
 
   /* Discard */
-  
+
   i = 0;
   discardv[i] = "rm";
   ++i;
@@ -649,10 +649,10 @@ set_clone_restart_commands (void)
   discardv[i] = (char*) full_save_file ();
   ++i;
   discardv[i] = NULL;
-  
+
   prop3.name = SmDiscardCommand;
   prop3.type = SmLISTofARRAY8;
-  
+
   prop3.vals = g_new (SmPropValue, i);
   i = 0;
   while (discardv[i])
@@ -663,11 +663,11 @@ set_clone_restart_commands (void)
     }
   prop3.num_vals = i;
 
-  
+
   props[0] = &prop1;
   props[1] = &prop2;
   props[2] = &prop3;
-  
+
   SmcSetProperties (session_connection, 3, props);
 
   g_free (prop1.vals);
@@ -706,7 +706,7 @@ window_type_to_string (MetaWindowType type)
     }
 
   return "";
-} 
+}
 
 static MetaWindowType
 window_type_from_string (const char *str)
@@ -769,7 +769,7 @@ encode_text_as_utf8_markup (const char *text)
   GString *str;
   const char *p;
   char *escaped;
-  
+
   str = g_string_new ("");
 
   p = text;
@@ -781,7 +781,7 @@ encode_text_as_utf8_markup (const char *text)
 
   escaped = g_markup_escape_text (str->str, str->len);
   g_string_free (str, TRUE);
-  
+
   return escaped;
 }
 
@@ -793,7 +793,7 @@ decode_text_from_utf8 (const char *text)
   const char *p;
 
   str = g_string_new ("");
-  
+
   p = text;
   while (*p)
     {
@@ -815,11 +815,11 @@ save_state (void)
   GSList *windows;
   GSList *tmp;
   int stack_position;
-  
+
   g_assert (client_id);
 
   outfile = NULL;
-  
+
   /*
    * g_get_user_config_dir() is guaranteed to return an existing directory.
    * Eventually, if SM stays with the WM, I'd like to make this
@@ -831,7 +831,7 @@ save_state (void)
   marco_dir = g_strconcat (g_get_user_config_dir (),
                               G_DIR_SEPARATOR_S "marco",
                               NULL);
-  
+
   session_dir = g_strconcat (marco_dir,
                              G_DIR_SEPARATOR_S "sessions",
                              NULL);
@@ -851,7 +851,7 @@ save_state (void)
     }
 
   meta_topic (META_DEBUG_SM, "Saving session to '%s'\n", full_save_file ());
-  
+
   outfile = fopen (full_save_file (), "w");
 
   if (outfile == NULL)
@@ -874,9 +874,9 @@ save_state (void)
    * Note that attributes on <window> are the match info we use to
    * see if the saved state applies to a restored window, and
    * child elements are the saved state to be applied.
-   * 
+   *
    */
-  
+
   fprintf (outfile, "<marco_session id=\"%s\">\n",
            client_id);
 
@@ -905,7 +905,7 @@ save_state (void)
            * in UTF-8 (I think they are in XPCS which is Latin-1?
            * in practice they are always ascii though.)
            */
-              
+
           sm_client_id = encode_text_as_utf8_markup (window->sm_client_id);
           res_class = window->res_class ?
             encode_text_as_utf8_markup (window->res_class) : NULL;
@@ -917,7 +917,7 @@ save_state (void)
             title = g_markup_escape_text (window->title, -1);
           else
             title = NULL;
-              
+
           meta_topic (META_DEBUG_SM, "Saving session managed window %s, client ID '%s'\n",
                       window->desc, window->sm_client_id);
 
@@ -936,7 +936,7 @@ save_state (void)
           g_free (res_name);
           g_free (role);
           g_free (title);
-              
+
           /* Sticky */
           if (window->on_all_workspaces)
             fputs ("    <sticky/>\n", outfile);
@@ -949,13 +949,13 @@ save_state (void)
           if (META_WINDOW_MAXIMIZED (window))
             {
               fprintf (outfile,
-                       "    <maximized saved_x=\"%d\" saved_y=\"%d\" saved_width=\"%d\" saved_height=\"%d\"/>\n", 
+                       "    <maximized saved_x=\"%d\" saved_y=\"%d\" saved_width=\"%d\" saved_height=\"%d\"/>\n",
                        window->saved_rect.x,
                        window->saved_rect.y,
                        window->saved_rect.width,
                        window->saved_rect.height);
             }
-              
+
           /* Workspaces we're on */
           {
             int n;
@@ -968,13 +968,13 @@ save_state (void)
           {
             int x, y, w, h;
             meta_window_get_geometry (window, &x, &y, &w, &h);
-            
+
             fprintf (outfile,
                      "    <geometry x=\"%d\" y=\"%d\" width=\"%d\" height=\"%d\" gravity=\"%s\"/>\n",
                      x, y, w, h,
                      meta_gravity_to_string (window->size_hints.win_gravity));
           }
-              
+
           fputs ("  </window>\n", outfile);
         }
       else
@@ -982,15 +982,15 @@ save_state (void)
           meta_topic (META_DEBUG_SM, "Not saving window '%s', not session managed\n",
                       window->desc);
         }
-          
+
       tmp = tmp->next;
       ++stack_position;
     }
-      
+
   g_slist_free (windows);
 
   fputs ("</marco_session>\n", outfile);
-  
+
  out:
   if (outfile)
     {
@@ -1006,7 +1006,7 @@ save_state (void)
                         full_save_file (), g_strerror (errno));
         }
     }
-  
+
   g_free (marco_dir);
   g_free (session_dir);
 }
@@ -1087,7 +1087,7 @@ load_state (const char *previous_save_file)
                                   G_DIR_SEPARATOR_S,
                                   previous_save_file,
                                   NULL);
-      
+
       if (!g_file_get_contents (session_file,
                                 &text,
                                 &length,
@@ -1107,10 +1107,10 @@ load_state (const char *previous_save_file)
   meta_topic (META_DEBUG_SM, "Parsing saved session file %s\n", session_file);
   g_free (session_file);
   session_file = NULL;
-  
+
   parse_data.info = NULL;
   parse_data.previous_id = NULL;
-  
+
   context = g_markup_parse_context_new (&marco_session_parser,
                                         0, &parse_data, NULL);
 
@@ -1120,8 +1120,8 @@ load_state (const char *previous_save_file)
                                      length,
                                      &error))
     goto error;
-  
-  
+
+
   error = NULL;
   if (!g_markup_parse_context_end_parse (context, &error))
     goto error;
@@ -1131,7 +1131,7 @@ load_state (const char *previous_save_file)
   goto out;
 
  error:
-  
+
   meta_warning (_("Failed to parse saved session file: %s\n"),
                 error->message);
   g_error_free (error);
@@ -1141,9 +1141,9 @@ load_state (const char *previous_save_file)
 
   g_free (parse_data.previous_id);
   parse_data.previous_id = NULL;
-  
+
  out:
-  
+
   g_free (text);
 
   return parse_data.previous_id;
@@ -1165,14 +1165,14 @@ start_element_handler  (GMarkupParseContext *context,
   if (strcmp (element_name, "marco_session") == 0)
     {
       /* Get previous ID */
-      int i;      
+      int i;
 
       i = 0;
       while (attribute_names[i])
         {
           const char *name;
           const char *val;
-          
+
           name = attribute_names[i];
           val = attribute_values[i];
 
@@ -1184,7 +1184,7 @@ start_element_handler  (GMarkupParseContext *context,
                            _("<marco_session> attribute seen but we already have the session ID"));
               return;
             }
-          
+
           if (strcmp (name, "id") == 0)
             {
               pd->previous_id = decode_text_from_utf8 (val);
@@ -1198,14 +1198,14 @@ start_element_handler  (GMarkupParseContext *context,
                            name, "marco_session");
               return;
             }
-          
+
           ++i;
         }
     }
   else if (strcmp (element_name, "window") == 0)
     {
       int i;
-      
+
       if (pd->info)
         {
           g_set_error (error,
@@ -1214,7 +1214,7 @@ start_element_handler  (GMarkupParseContext *context,
                        _("nested <window> tag"));
           return;
         }
-      
+
       pd->info = session_info_new ();
 
       i = 0;
@@ -1222,10 +1222,10 @@ start_element_handler  (GMarkupParseContext *context,
         {
           const char *name;
           const char *val;
-          
+
           name = attribute_names[i];
           val = attribute_values[i];
-          
+
           if (strcmp (name, "id") == 0)
             {
               if (*val)
@@ -1275,7 +1275,7 @@ start_element_handler  (GMarkupParseContext *context,
               pd->info = NULL;
               return;
             }
-          
+
           ++i;
         }
     }
@@ -1289,7 +1289,7 @@ start_element_handler  (GMarkupParseContext *context,
           const char *name;
 
           name = attribute_names[i];
-          
+
           if (strcmp (name, "index") == 0)
             {
               pd->info->workspace_indices =
@@ -1307,7 +1307,7 @@ start_element_handler  (GMarkupParseContext *context,
               pd->info = NULL;
               return;
             }
-          
+
           ++i;
         }
     }
@@ -1387,22 +1387,22 @@ start_element_handler  (GMarkupParseContext *context,
                     pd->info->saved_rect.y,
                     pd->info->saved_rect.width,
                     pd->info->saved_rect.height);
-    }  
+    }
   else if (strcmp (element_name, "geometry") == 0)
     {
       int i;
 
       pd->info->geometry_set = TRUE;
-      
+
       i = 0;
       while (attribute_names[i])
         {
           const char *name;
           const char *val;
-          
+
           name = attribute_names[i];
           val = attribute_values[i];
-          
+
           if (strcmp (name, "x") == 0)
             {
               if (*val)
@@ -1437,7 +1437,7 @@ start_element_handler  (GMarkupParseContext *context,
                            name, "geometry");
               return;
             }
-          
+
           ++i;
         }
 
@@ -1475,12 +1475,12 @@ end_element_handler    (GMarkupParseContext *context,
 
       window_info_list = g_slist_prepend (window_info_list,
                                           pd->info);
-      
+
       meta_topic (META_DEBUG_SM, "Loaded window info from session with class: %s name: %s role: %s\n",
                   pd->info->res_class ? pd->info->res_class : "(none)",
                   pd->info->res_name ? pd->info->res_name : "(none)",
                   pd->info->role ? pd->info->role : "(none)");
-      
+
       pd->info = NULL;
     }
 }
@@ -1516,20 +1516,20 @@ get_possible_matches (MetaWindow *window)
   GSList *retval;
   GSList *tmp;
   gboolean ignore_client_id;
-  
+
   retval = NULL;
 
   ignore_client_id = g_getenv ("MARCO_DEBUG_SM") != NULL;
-  
+
   tmp = window_info_list;
   while (tmp != NULL)
     {
       MetaWindowSessionInfo *info;
 
       info = tmp->data;
-      
+
       if ((ignore_client_id ||
-           both_null_or_matching (info->id, window->sm_client_id)) && 
+           both_null_or_matching (info->id, window->sm_client_id)) &&
           both_null_or_matching (info->res_class, window->res_class) &&
           both_null_or_matching (info->res_name, window->res_name) &&
           both_null_or_matching (info->role, window->role))
@@ -1556,7 +1556,7 @@ get_possible_matches (MetaWindow *window)
                             window->desc,
                             window->res_class ? window->res_class : "(none)",
                             info->res_class ? info->res_class : "(none)");
-              
+
               else if (!both_null_or_matching (info->res_name, window->res_name))
                 meta_topic (META_DEBUG_SM, "Window %s has name %s doesn't match saved name %s, no match\n",
                             window->desc,
@@ -1572,7 +1572,7 @@ get_possible_matches (MetaWindow *window)
                             window->desc, info->id);
             }
         }
-      
+
       tmp = tmp->next;
     }
 
@@ -1586,10 +1586,10 @@ find_best_match (GSList     *infos,
   GSList *tmp;
   const MetaWindowSessionInfo *matching_title;
   const MetaWindowSessionInfo *matching_type;
-  
+
   matching_title = NULL;
   matching_type = NULL;
-  
+
   tmp = infos;
   while (tmp != NULL)
     {
@@ -1604,7 +1604,7 @@ find_best_match (GSList     *infos,
       if (matching_type == NULL &&
           info->type == window->type)
         matching_type = info;
-      
+
       tmp = tmp->next;
     }
 
@@ -1613,7 +1613,7 @@ find_best_match (GSList     *infos,
    * to e.g. break ties by geometry hint similarity,
    * or other window features.
    */
-  
+
   if (matching_title)
     return matching_title;
   else if (matching_type)
@@ -1627,7 +1627,7 @@ meta_window_lookup_saved_state (MetaWindow *window)
 {
   GSList *possibles;
   const MetaWindowSessionInfo *info;
-  
+
   /* Window is not session managed.
    * I haven't yet figured out how to deal with these
    * in a way that doesn't cause broken side effects in
@@ -1651,9 +1651,9 @@ meta_window_lookup_saved_state (MetaWindow *window)
     }
 
   info = find_best_match (possibles, window);
-  
+
   g_slist_free (possibles);
-  
+
   return info;
 }
 
@@ -1678,7 +1678,7 @@ session_info_free (MetaWindowSessionInfo *info)
   g_free (info->role);
 
   g_slist_free (info->workspace_indices);
-  
+
   g_free (info);
 }
 
@@ -1691,7 +1691,7 @@ session_info_new (void)
 
   info->type = META_WINDOW_NORMAL;
   info->gravity = NorthWestGravity;
-  
+
   return info;
 }
 
@@ -1732,7 +1732,7 @@ finish_interact (gboolean shutdown)
   if (current_state == STATE_DONE_WITH_INTERACT) /* paranoia */
     {
       SmcInteractDone (session_connection, False /* don't cancel logout */);
-      
+
       save_yourself_possibly_done (shutdown, TRUE);
     }
 }
@@ -1757,13 +1757,13 @@ warn_about_lame_clients_and_finish_interact (gboolean shutdown)
   GSList *tmp;
   GSList *columns = NULL;
   GPid pid;
-  
+
   windows = meta_display_list_windows (meta_get_display ());
   tmp = windows;
   while (tmp != NULL)
     {
       MetaWindow *window;
-          
+
       window = tmp->data;
 
       /* only complain about normal windows, the others
@@ -1772,12 +1772,12 @@ warn_about_lame_clients_and_finish_interact (gboolean shutdown)
       if (window->sm_client_id == NULL &&
           window->type == META_WINDOW_NORMAL)
         lame = g_slist_prepend (lame, window);
-          
+
       tmp = tmp->next;
     }
-      
+
   g_slist_free (windows);
-  
+
   if (lame == NULL)
     {
       /* No lame apps. */

--- a/src/core/session.h
+++ b/src/core/session.h
@@ -9,9 +9,9 @@
  * requires us to do it here.
  */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -21,7 +21,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -47,11 +47,11 @@ struct _MetaWindowSessionInfo
   MetaWindowType type;
 
   /* Information we restore */
-  
-  GSList *workspace_indices;  
+
+  GSList *workspace_indices;
 
   int stack_position;
-  
+
   /* width/height should be multiplied by resize inc and
    * added to base size; position should be interpreted in
    * light of gravity. This preserves semantics of the

--- a/src/core/stack.c
+++ b/src/core/stack.c
@@ -4,12 +4,12 @@
  * \file stack.c  Which windows cover which other windows
  */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2002, 2003 Red Hat, Inc.
  * Copyright (C) 2004 Rob Adams
  * Copyright (C) 2004, 2005 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -19,7 +19,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -66,7 +66,7 @@ MetaStack*
 meta_stack_new (MetaScreen *screen)
 {
   MetaStack *stack;
-  
+
   stack = g_new (MetaStack, 1);
 
   stack->screen = screen;
@@ -84,7 +84,7 @@ meta_stack_new (MetaScreen *screen)
   stack->need_resort = FALSE;
   stack->need_relayer = FALSE;
   stack->need_constrain = FALSE;
-  
+
   return stack;
 }
 
@@ -99,7 +99,7 @@ meta_stack_free (MetaStack *stack)
 
   if (stack->last_root_children_stacked)
     g_array_free (stack->last_root_children_stacked, TRUE);
-  
+
   g_free (stack);
 }
 
@@ -111,7 +111,7 @@ meta_stack_add (MetaStack  *stack,
 
   if (window->stack_position >= 0)
     meta_bug ("Window %s had stack position already\n", window->desc);
-  
+
   stack->added = g_list_prepend (stack->added, window);
 
   window->stack_position = stack->n_positions;
@@ -119,7 +119,7 @@ meta_stack_add (MetaStack  *stack,
   meta_topic (META_DEBUG_STACK,
               "Window %s has stack_position initialized to %d\n",
               window->desc, window->stack_position);
-  
+
   stack_sync_to_server (stack);
 }
 
@@ -139,7 +139,7 @@ meta_stack_remove (MetaStack  *stack,
   meta_window_set_stack_position_no_sync (window,
                                           stack->n_positions - 1);
   window->stack_position = -1;
-  stack->n_positions -= 1;  
+  stack->n_positions -= 1;
 
   /* We don't know if it's been moved from "added" to "stack" yet */
   stack->added = g_list_remove (stack->added, window);
@@ -154,7 +154,7 @@ meta_stack_remove (MetaStack  *stack,
   if (window->frame)
     stack->removed = g_list_prepend (stack->removed,
                                      GUINT_TO_POINTER (window->frame->xwindow));
-  
+
   stack_sync_to_server (stack);
 }
 
@@ -163,7 +163,7 @@ meta_stack_update_layer (MetaStack  *stack,
                          MetaWindow *window)
 {
   stack->need_relayer = TRUE;
-  
+
   stack_sync_to_server (stack);
 }
 
@@ -172,7 +172,7 @@ meta_stack_update_transient (MetaStack  *stack,
                              MetaWindow *window)
 {
   stack->need_constrain = TRUE;
-  
+
   stack_sync_to_server (stack);
 }
 
@@ -180,10 +180,10 @@ meta_stack_update_transient (MetaStack  *stack,
 void
 meta_stack_raise (MetaStack  *stack,
                   MetaWindow *window)
-{  
+{
   meta_window_set_stack_position_no_sync (window,
                                           stack->n_positions - 1);
-  
+
   stack_sync_to_server (stack);
 }
 
@@ -192,7 +192,7 @@ meta_stack_lower (MetaStack  *stack,
                   MetaWindow *window)
 {
   meta_window_set_stack_position_no_sync (window, 0);
-  
+
   stack_sync_to_server (stack);
 }
 
@@ -206,7 +206,7 @@ void
 meta_stack_thaw (MetaStack *stack)
 {
   g_return_if_fail (stack->freeze_count > 0);
-  
+
   stack->freeze_count -= 1;
   stack_sync_to_server (stack);
 }
@@ -240,7 +240,7 @@ get_standalone_layer (MetaWindow *window)
 {
   MetaStackLayer layer;
   gboolean focused_transient = FALSE;
-  
+
   switch (window->type)
     {
     case META_WINDOW_DESKTOP:
@@ -255,7 +255,7 @@ get_standalone_layer (MetaWindow *window)
         layer = META_LAYER_DOCK;
       break;
 
-    default:       
+    default:
       meta_window_foreach_transient (window,
                                      is_focused_foreach,
                                      &focused_transient);
@@ -291,16 +291,16 @@ get_maximum_layer_in_group (MetaWindow *window)
   GSList *tmp;
   MetaStackLayer max;
   MetaStackLayer layer;
-  
+
   max = META_LAYER_DESKTOP;
-  
+
   group = meta_window_get_group (window);
 
   if (group != NULL)
     members = meta_group_list_windows (group);
   else
     members = NULL;
-  
+
   tmp = members;
   while (tmp != NULL)
     {
@@ -309,12 +309,12 @@ get_maximum_layer_in_group (MetaWindow *window)
       layer = get_standalone_layer (w);
       if (layer > max)
         max = layer;
-      
+
       tmp = tmp->next;
     }
 
   g_slist_free (members);
-  
+
   return max;
 }
 
@@ -322,7 +322,7 @@ static void
 compute_layer (MetaWindow *window)
 {
   window->layer = get_standalone_layer (window);
-  
+
   /* We can only do promotion-due-to-group for dialogs and other
    * transients, or weird stuff happens like the desktop window and
    * caja windows getting in the same layer, or all mate-terminal
@@ -338,11 +338,11 @@ compute_layer (MetaWindow *window)
        * and a dialog transient for the normal window; you don't want the dialog
        * above the dock if it wouldn't normally be.
        */
-      
+
       MetaStackLayer group_max;
-      
+
       group_max = get_maximum_layer_in_group (window);
-      
+
       if (group_max > window->layer)
         {
           meta_topic (META_DEBUG_STACK,
@@ -379,10 +379,10 @@ compare_window_position (void *a,
   else
     return 0; /* not reached */
 }
-  
+
 /*
  * Stacking constraints
- * 
+ *
  * Assume constraints of the form "AB" meaning "window A must be
  * below window B"
  *
@@ -399,14 +399,14 @@ compare_window_position (void *a,
  *  apply BC: ABC
  *
  * but apply constraints in the wrong order and it breaks:
- * 
+ *
  *  start:    BCA
  *  apply BC: BCA
  *  apply AB: CAB
  *
  * We make a directed graph of the constraints by linking
  * from "above windows" to "below windows as follows:
- * 
+ *
  *   AB -> BC -> CD
  *          \
  *           CE
@@ -431,7 +431,7 @@ struct Constraint
 
   /* used to create the graph. */
   GSList *next_nodes;
-  
+
   /* constraint has been applied, used
    * to detect cycles.
    */
@@ -459,7 +459,7 @@ add_constraint (Constraint **constraints,
   Constraint *c;
 
   g_assert (above->screen == below->screen);
-  
+
   /* check if constraint is a duplicate */
   c = constraints[below->stack_position];
   while (c != NULL)
@@ -486,7 +486,7 @@ create_constraints (Constraint **constraints,
                     GList       *windows)
 {
   GList *tmp;
-  
+
   tmp = windows;
   while (tmp != NULL)
     {
@@ -499,7 +499,7 @@ create_constraints (Constraint **constraints,
           tmp = tmp->next;
           continue;
         }
-      
+
       if (WINDOW_TRANSIENT_FOR_WHOLE_GROUP (w))
         {
           GSList *group_windows;
@@ -512,9 +512,9 @@ create_constraints (Constraint **constraints,
             group_windows = meta_group_list_windows (group);
           else
             group_windows = NULL;
-          
+
           tmp2 = group_windows;
-          
+
           while (tmp2 != NULL)
             {
               MetaWindow *group_window = tmp2->data;
@@ -525,7 +525,7 @@ create_constraints (Constraint **constraints,
                   tmp2 = tmp2->next;
                   continue;
                 }
-              
+
 #if 0
               /* old way of doing it */
               if (!(meta_window_is_ancestor_of_transient (w, group_window)) &&
@@ -541,7 +541,7 @@ create_constraints (Constraint **constraints,
                               w->desc, group_window->desc);
                   add_constraint (constraints, w, group_window);
                 }
-              
+
               tmp2 = tmp2->next;
             }
 
@@ -551,7 +551,7 @@ create_constraints (Constraint **constraints,
                !w->transient_parent_is_root_window)
         {
           MetaWindow *parent;
-          
+
           parent =
             meta_display_lookup_x_window (w->display, w->xtransient_for);
 
@@ -563,7 +563,7 @@ create_constraints (Constraint **constraints,
               add_constraint (constraints, w, parent);
             }
         }
-      
+
       tmp = tmp->next;
     }
 }
@@ -582,12 +582,12 @@ graph_constraints (Constraint **constraints,
       /* If we have "A below B" and "B below C" then AB -> BC so we
        * add BC to next_nodes in AB.
        */
-      
+
       c = constraints[i];
       while (c != NULL)
         {
           Constraint *n;
-            
+
           g_assert (c->below->stack_position == i);
 
           /* Constraints where ->above is below are our
@@ -600,10 +600,10 @@ graph_constraints (Constraint **constraints,
                                                n);
               /* c is a previous node of n */
               n->has_prev = TRUE;
-              
+
               n = n->next;
             }
-          
+
           c = c->next;
         }
 
@@ -621,16 +621,16 @@ free_constraints (Constraint **constraints,
   while (i < n_constraints)
     {
       Constraint *c;
-      
+
       c = constraints[i];
       while (c != NULL)
         {
           Constraint *next = c->next;
-          
+
           g_slist_free (c->next_nodes);
 
           g_free (c);
-          
+
           c = next;
         }
 
@@ -641,7 +641,7 @@ free_constraints (Constraint **constraints,
 static void
 ensure_above (MetaWindow *above,
               MetaWindow *below)
-{  
+{
   if (WINDOW_HAS_TRANSIENT_TYPE(above) &&
       above->layer < below->layer)
     {
@@ -669,10 +669,10 @@ traverse_constraint (Constraint *c)
 
   if (c->applied)
     return;
-  
+
   ensure_above (c->above, c->below);
   c->applied = TRUE;
-  
+
   tmp = c->next_nodes;
   while (tmp != NULL)
     {
@@ -696,13 +696,13 @@ apply_constraints (Constraint **constraints,
   while (i < n_constraints)
     {
       Constraint *c;
-      
+
       c = constraints[i];
       while (c != NULL)
         {
           if (!c->has_prev)
             heads = g_slist_prepend (heads, c);
-          
+
           c = c->next;
         }
 
@@ -716,7 +716,7 @@ apply_constraints (Constraint **constraints,
       Constraint *c = tmp->data;
 
       traverse_constraint (c);
-      
+
       tmp = tmp->next;
     }
 
@@ -735,7 +735,7 @@ stack_do_window_deletions (MetaStack *stack)
    */
   GList *tmp;
   int i;
-    
+
   tmp = stack->removed;
   while (tmp != NULL)
     {
@@ -749,7 +749,7 @@ stack_do_window_deletions (MetaStack *stack)
       while (i > 0)
         {
           --i;
-          
+
           /* there's no guarantee we'll actually find windows to
            * remove, e.g. the same xwindow could have been
            * added/removed before we ever synced, and we put
@@ -786,34 +786,34 @@ stack_do_window_additions (MetaStack *stack)
       meta_topic (META_DEBUG_STACK,
                   "Adding %d windows to sorted list\n",
                   n_added);
-      
+
       old_size = stack->windows->len;
       g_array_set_size (stack->windows, old_size + n_added);
-      
+
       end = &g_array_index (stack->windows, Window, old_size);
 
       /* stack->added has the most recent additions at the
        * front of the list, so we need to reverse it
        */
       stack->added = g_list_reverse (stack->added);
-      
+
       i = 0;
       tmp = stack->added;
       while (tmp != NULL)
         {
           MetaWindow *w;
-          
+
           w = tmp->data;
-          
+
           end[i] = w->xwindow;
 
           /* add to the main list */
           stack->sorted = g_list_prepend (stack->sorted, w);
-          
+
           ++i;
           tmp = tmp->next;
         }
-      
+
       stack->need_resort = TRUE; /* may not be needed as we add to top */
       stack->need_constrain = TRUE;
       stack->need_relayer = TRUE;
@@ -830,13 +830,13 @@ static void
 stack_do_relayer (MetaStack *stack)
 {
   GList *tmp;
-    
+
   if (!stack->need_relayer)
       return;
-    
+
   meta_topic (META_DEBUG_STACK,
               "Recomputing layers\n");
-      
+
   tmp = stack->sorted;
 
   while (tmp != NULL)
@@ -854,7 +854,7 @@ stack_do_relayer (MetaStack *stack)
           meta_topic (META_DEBUG_STACK,
                       "Window %s moved from layer %u to %u\n",
                       w->desc, old_layer, w->layer);
-              
+
           stack->need_resort = TRUE;
           stack->need_constrain = TRUE;
           /* don't need to constrain as constraining
@@ -862,7 +862,7 @@ stack_do_relayer (MetaStack *stack)
            * not layer
            */
         }
-          
+
       tmp = tmp->next;
     }
 
@@ -879,7 +879,7 @@ stack_do_constrain (MetaStack *stack)
   Constraint **constraints;
 
   /* It'd be nice if this were all faster, probably */
-  
+
   if (!stack->need_constrain)
     return;
 
@@ -894,10 +894,10 @@ stack_do_constrain (MetaStack *stack)
   graph_constraints (constraints, stack->n_positions);
 
   apply_constraints (constraints, stack->n_positions);
-  
+
   free_constraints (constraints, stack->n_positions);
   g_free (constraints);
-  
+
   stack->need_constrain = FALSE;
 }
 
@@ -909,10 +909,10 @@ stack_do_resort (MetaStack *stack)
 {
   if (!stack->need_resort)
     return;
-  
+
   meta_topic (META_DEBUG_STACK,
               "Sorting stack list\n");
-      
+
   stack->sorted = g_list_sort (stack->sorted,
                                (GCompareFunc) compare_window_position);
 
@@ -963,9 +963,9 @@ raise_window_relative_to_managed_windows (MetaScreen *screen,
    * we don't, since we know we won't manage any new windows
    * or restack any windows before using the XQueryTree results.
    */
-  
+
   meta_error_trap_push_with_return (screen->display);
-  
+
   XQueryTree (screen->display->xdisplay,
               screen->xroot,
               &ignored1, &ignored2, &children, &n_children);
@@ -1001,7 +1001,7 @@ raise_window_relative_to_managed_windows (MetaScreen *screen,
                                              children[i]) != NULL)
         {
           XWindowChanges changes;
-          
+
           /* children[i] is the topmost managed child */
           meta_topic (META_DEBUG_STACK,
                       "Moving 0x%lx above topmost managed child window 0x%lx\n",
@@ -1033,7 +1033,7 @@ raise_window_relative_to_managed_windows (MetaScreen *screen,
                     xwindow);
       meta_error_trap_pop (screen->display, FALSE);
     }
-  
+
   if (children)
     XFree (children);
 }
@@ -1051,15 +1051,15 @@ stack_sync_to_server (MetaStack *stack)
   GArray *stacked;
   GArray *root_children_stacked;
   GList *tmp;
-  
+
   /* Bail out if frozen */
   if (stack->freeze_count > 0)
     return;
-  
-  meta_topic (META_DEBUG_STACK, "Syncing window stack to server\n");  
+
+  meta_topic (META_DEBUG_STACK, "Syncing window stack to server\n");
 
   stack_ensure_sorted (stack);
-  
+
   /* Create stacked xwindow arrays.
    * Painfully, "stacked" is in bottom-to-top order for the
    * _NET hints, and "root_children_stacked" is in top-to-bottom
@@ -1070,25 +1070,25 @@ stack_sync_to_server (MetaStack *stack)
 
   meta_topic (META_DEBUG_STACK, "Top to bottom: ");
   meta_push_no_msg_prefix ();
-  
+
   tmp = stack->sorted;
   while (tmp != NULL)
     {
       MetaWindow *w;
-      
+
       w = tmp->data;
-      
+
       /* remember, stacked is in reverse order (bottom to top) */
       g_array_prepend_val (stacked, w->xwindow);
-      
+
       /* build XRestackWindows() array from top to bottom */
       if (w->frame)
         g_array_append_val (root_children_stacked, w->frame->xwindow);
       else
         g_array_append_val (root_children_stacked, w->xwindow);
-      
+
       meta_topic (META_DEBUG_STACK, "%u:%d - %s ", w->layer, w->stack_position, w->desc);
-          
+
       tmp = tmp->next;
     }
 
@@ -1099,12 +1099,12 @@ stack_sync_to_server (MetaStack *stack)
   if (stacked->len != stack->windows->len)
     meta_bug ("%u windows stacked, %u windows exist in stack\n",
               stacked->len, stack->windows->len);
-  
+
   /* Sync to server */
 
   meta_topic (META_DEBUG_STACK, "Restacking %u windows\n",
               root_children_stacked->len);
-  
+
   meta_error_trap_push (stack->screen->display);
 
   if (stack->last_root_children_stacked == NULL)
@@ -1136,7 +1136,7 @@ stack_sync_to_server (MetaStack *stack)
       const Window *old_end = old_stack + old_len;
       const Window *new_end = new_stack + new_len;
       Window last_window = None;
-      
+
       while (oldp != old_end &&
              newp != new_end)
         {
@@ -1171,7 +1171,7 @@ stack_sync_to_server (MetaStack *stack)
                    * *newp, then we fail to restack *newp; but on
                    * unmanaging last_window, we'll fix it up.
                    */
-                  
+
                   XWindowChanges changes;
 
                   changes.sibling = last_window;
@@ -1179,7 +1179,7 @@ stack_sync_to_server (MetaStack *stack)
 
                   meta_topic (META_DEBUG_STACK, "Placing window 0x%lx below 0x%lx\n",
                               *newp, last_window);
-                  
+
                   XConfigureWindow (stack->screen->display->xdisplay,
                                     *newp,
                                     CWSibling | CWStackMode,
@@ -1212,7 +1212,7 @@ stack_sync_to_server (MetaStack *stack)
    * get removed from the stacking list when we unmanage it
    * and we'll fix stacking at that time.
    */
-  
+
   /* Sync _NET_CLIENT_LIST and _NET_CLIENT_LIST_STACKING */
 
   XChangeProperty (stack->screen->display->xdisplay,
@@ -1235,7 +1235,7 @@ stack_sync_to_server (MetaStack *stack)
   if (stack->last_root_children_stacked)
     g_array_free (stack->last_root_children_stacked, TRUE);
   stack->last_root_children_stacked = root_children_stacked;
-  
+
   /* That was scary... */
 }
 
@@ -1271,9 +1271,9 @@ meta_stack_get_above (MetaStack      *stack,
 {
   GList *link;
   MetaWindow *above;
-  
+
   stack_ensure_sorted (stack);
-  
+
   link = g_list_find (stack->sorted, window);
   if (link == NULL)
     return NULL;
@@ -1296,7 +1296,7 @@ meta_stack_get_below (MetaStack      *stack,
 {
   GList *link;
   MetaWindow *below;
-  
+
   stack_ensure_sorted (stack);
 
   link = g_list_find (stack->sorted, window);
@@ -1305,7 +1305,7 @@ meta_stack_get_below (MetaStack      *stack,
     return NULL;
   if (link->next == NULL)
     return NULL;
-  
+
   below = link->next->data;
 
   if (only_within_layer &&
@@ -1347,7 +1347,7 @@ get_default_focus_window (MetaStack     *stack,
   MetaWindow *topmost_overall;
   MetaGroup *not_this_one_group;
   GList *link;
-  
+
   topmost_dock = NULL;
   transient_parent = NULL;
   topmost_in_group = NULL;
@@ -1361,7 +1361,7 @@ get_default_focus_window (MetaStack     *stack,
 
   /* top of this layer is at the front of the list */
   link = stack->sorted;
-      
+
   while (link)
     {
       MetaWindow *window = link->data;
@@ -1449,22 +1449,22 @@ meta_stack_list_windows (MetaStack     *stack,
 {
   GList *workspace_windows = NULL;
   GList *link;
-  
+
   stack_ensure_sorted (stack); /* do adds/removes */
-  
+
   link = stack->sorted;
-  
+
   while (link)
     {
       MetaWindow *window = link->data;
-      
+
       if (window &&
           (workspace == NULL || meta_window_located_on_workspace (window, workspace)))
         {
           workspace_windows = g_list_prepend (workspace_windows,
                                               window);
         }
-      
+
       link = link->next;
     }
 
@@ -1481,7 +1481,7 @@ meta_stack_windows_cmp  (MetaStack  *stack,
   /* -1 means a below b */
 
   stack_ensure_sorted (stack); /* update constraints, layers */
-  
+
   if (window_a->layer < window_b->layer)
     return -1;
   else if (window_a->layer > window_b->layer)
@@ -1531,7 +1531,7 @@ compare_pointers (gconstpointer a,
     return 1;
   else if (a < b)
     return -1;
-  else 
+  else
     return 0;
 }
 
@@ -1569,7 +1569,7 @@ meta_stack_set_positions (MetaStack *stack,
 
   /* Make sure any adds or removes aren't in limbo -- is this needed? */
   stack_ensure_sorted (stack);
-  
+
   if (!lists_contain_same_windows (windows, stack->sorted))
     {
       meta_warning ("This list of windows has somehow changed; not resetting "
@@ -1582,7 +1582,7 @@ meta_stack_set_positions (MetaStack *stack,
 
   stack->need_resort = TRUE;
   stack->need_constrain = TRUE;
-   
+
   i = 0;
   tmp = windows;
   while (tmp != NULL)
@@ -1591,7 +1591,7 @@ meta_stack_set_positions (MetaStack *stack,
       w->stack_position = i++;
       tmp = tmp->next;
     }
-  
+
   meta_topic (META_DEBUG_STACK,
               "Reset the stack positions of (nearly) all windows\n");
 
@@ -1604,7 +1604,7 @@ meta_window_set_stack_position_no_sync (MetaWindow *window,
 {
   int low, high, delta;
   GList *tmp;
-  
+
   g_return_if_fail (window->screen->stack != NULL);
   g_return_if_fail (window->stack_position >= 0);
   g_return_if_fail (position >= 0);
@@ -1619,7 +1619,7 @@ meta_window_set_stack_position_no_sync (MetaWindow *window,
 
   window->screen->stack->need_resort = TRUE;
   window->screen->stack->need_constrain = TRUE;
-  
+
   if (position < window->stack_position)
     {
       low = position;
@@ -1644,7 +1644,7 @@ meta_window_set_stack_position_no_sync (MetaWindow *window,
 
       tmp = tmp->next;
     }
-  
+
   window->stack_position = position;
 
   meta_topic (META_DEBUG_STACK,

--- a/src/core/stack.h
+++ b/src/core/stack.h
@@ -4,7 +4,7 @@
  * \file stack.h  Which windows cover which other windows
  *
  * There are two factors that determine window position.
- * 
+ *
  * One is window->stack_position, which is a unique integer
  * indicating how windows are ordered with respect to one
  * another. The ordering here transcends layers; it isn't changed
@@ -12,16 +12,16 @@
  * windows from one layer to another, while preserving the relative
  * order of the moved windows. Also, it allows us to restore
  * the stacking order from a saved session.
- * 
+ *
  * However when actually stacking windows on the screen, the
  * layer overrides the stack_position; windows are first sorted
  * by layer, then by stack_position within each layer.
  */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2005 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -31,7 +31,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -99,7 +99,7 @@ struct _MetaStack
    * The order of the elements in this list is not important.
    */
   GList *removed;
-  
+
   /**
    * If this is zero, the local stack oughtn't to be brought up to date with
    * the X server's stack, because it is in the middle of being updated.
@@ -299,7 +299,7 @@ MetaWindow* meta_stack_get_below  (MetaStack  *stack,
  * \param not_this_one  Window to ignore because it's being unfocussed or
  *                      going away.
  * \return The window matching all these constraints or NULL if none does.
- * 
+ *
  * \bug Never called!
   */
 MetaWindow* meta_stack_get_default_focus_window          (MetaStack     *stack,

--- a/src/core/testasyncgetprop.c
+++ b/src/core/testasyncgetprop.c
@@ -100,14 +100,14 @@ x_error_handler (Display     *xdisplay,
   if (error_trap_depth == 0)
     {
       print_backtrace ();
-      
+
       fprintf (stderr, "Unexpected X error: %s serial %ld error_code %d request_code %d minor_code %d)\n",
                buf,
                error->serial,
                error->error_code,
                error->request_code,
                error->minor_code);
-      
+
       exit (1);
     }
 
@@ -128,7 +128,7 @@ error_trap_pop (Display   *xdisplay)
       fprintf (stderr, "Error trap underflow!\n");
       exit (1);
     }
-  
+
   XSync (xdisplay, False); /* get all errors out of the queue */
   --error_trap_depth;
 }
@@ -198,11 +198,11 @@ try_get_reply (Display           *xdisplay,
       struct timeval current_time;
 
       gettimeofday (&current_time, NULL);
-      
+
       printf (" %gms (we have a reply for property %ld)\n",
               ELAPSED (program_start_time, current_time),
               ag_task_get_property (task));
-      
+
       data = NULL;
 
       name = atom_name (xdisplay,
@@ -210,7 +210,7 @@ try_get_reply (Display           *xdisplay,
       printf (" %s on 0x%lx:\n", name,
               ag_task_get_window (task));
       free (name);
-      
+
       result = ag_task_get_reply_and_free (task,
                                            &actual_type,
                                            &actual_format,
@@ -228,12 +228,12 @@ try_get_reply (Display           *xdisplay,
           name = atom_name (xdisplay, actual_type);
           printf ("  actual_type = %s\n", name);
           free (name);
-          
+
           printf ("  actual_format = %d\n", actual_format);
-          
+
           printf ("  n_items = %lu\n", n_items);
           printf ("  bytes_after = %lu\n", bytes_after);
-          
+
           printf ("  data = \"%s\"\n", data ? (char*) data : "NULL");
         }
 
@@ -258,13 +258,13 @@ main (int argc, char **argv)
   char *end;
   Atom *props;
   struct timeval current_time;
-  
+
   if (argc < 2)
     {
       fprintf (stderr, "specify window ID\n");
       return 1;
     }
-  
+
   window_str = argv[1];
 
   end = NULL;
@@ -286,7 +286,7 @@ main (int argc, char **argv)
     XSynchronize (xdisplay, True);
 
   XSetErrorHandler (x_error_handler);
-  
+
   n_props = 0;
   props = XListProperties (xdisplay, window, &n_props);
   if (n_props == 0 || props == NULL)
@@ -296,7 +296,7 @@ main (int argc, char **argv)
     }
 
   gettimeofday (&program_start_time, NULL);
-  
+
   i = 0;
   while (i < n_props)
     {
@@ -313,7 +313,7 @@ main (int argc, char **argv)
           fprintf (stderr, "Failed to send request\n");
           return 1;
         }
-      
+
       ++i;
     }
 
@@ -321,24 +321,24 @@ main (int argc, char **argv)
   props = NULL;
 
   n_left = n_props;
-  
+
   while (TRUE)
     {
       XEvent xevent;
       int connection;
       fd_set set;
       AgGetPropertyTask *task;
-      
+
       /* Mop up event queue */
       while (XPending (xdisplay) > 0)
-        {                  
+        {
           XNextEvent (xdisplay, &xevent);
           gettimeofday (&current_time, NULL);
           printf (" %gms (processing event type %d)\n",
                   ELAPSED (program_start_time, current_time),
                   xevent.xany.type);
         }
-      
+
       while ((task = ag_get_next_completed_task (xdisplay)))
         {
           try_get_reply (xdisplay, task);
@@ -364,7 +364,7 @@ main (int argc, char **argv)
     }
 
   run_speed_comparison (xdisplay, window);
-  
+
   return 0;
 }
 
@@ -379,7 +379,7 @@ run_speed_comparison (Display *xdisplay,
   int n_props;
   struct timeval start, end;
   int n_left;
-  
+
   /* We just use atom values (0 to n_props) % 200, many are probably
    * BadAtom, that's fine, but the %200 keeps most of them valid. The
    * async case is about twice as advantageous when using valid atoms
@@ -388,9 +388,9 @@ run_speed_comparison (Display *xdisplay,
    */
   n_props = 4000;
   printf ("Timing with %d property requests\n", n_props);
-  
+
   gettimeofday (&start, NULL);
-  
+
   i = 0;
   while (i < n_props)
     {
@@ -403,23 +403,23 @@ run_speed_comparison (Display *xdisplay,
           fprintf (stderr, "Failed to send request\n");
           exit (1);
         }
-      
+
       ++i;
     }
 
   n_left = n_props;
-  
+
   while (TRUE)
     {
       int connection;
       fd_set set;
       XEvent xevent;
       AgGetPropertyTask *task;
-      
+
       /* Mop up event queue */
       while (XPending (xdisplay) > 0)
         XNextEvent (xdisplay, &xevent);
-      
+
       while ((task = ag_get_next_completed_task (xdisplay)))
         {
           int UNUSED_VARIABLE result;
@@ -430,7 +430,7 @@ run_speed_comparison (Display *xdisplay,
           unsigned char *data;
 
           assert (ag_task_have_reply (task));
-          
+
           data = NULL;
           result = ag_task_get_reply_and_free (task,
                                                &actual_type,
@@ -438,13 +438,13 @@ run_speed_comparison (Display *xdisplay,
                                                &n_items,
                                                &bytes_after,
                                                &data);
-          
+
           if (data)
             XFree (data);
-          
+
           n_left -= 1;
         }
-      
+
       if (n_left == 0)
         break;
 
@@ -456,16 +456,16 @@ run_speed_comparison (Display *xdisplay,
 
       select (connection + 1, &set, NULL, NULL, NULL);
     }
-  
+
   gettimeofday (&end, NULL);
-  
+
   printf ("Async time: %gms\n",
           ELAPSED (start, end));
-  
+
   gettimeofday (&start, NULL);
 
   error_trap_push (xdisplay);
-  
+
   i = 0;
   while (i < n_props)
     {
@@ -474,7 +474,7 @@ run_speed_comparison (Display *xdisplay,
       unsigned long n_items;
       unsigned long bytes_after;
       unsigned char *data;
-      
+
       data = NULL;
       if (XGetWindowProperty (xdisplay, window,
                               (Atom) i % 200,
@@ -490,14 +490,14 @@ run_speed_comparison (Display *xdisplay,
           if (data)
             XFree (data);
         }
-      
+
       ++i;
     }
 
   error_trap_pop (xdisplay);
-  
+
   gettimeofday (&end, NULL);
-  
+
   printf ("Sync time:  %gms\n",
           ELAPSED (start, end));
 }

--- a/src/core/testboxes.c
+++ b/src/core/testboxes.c
@@ -2,9 +2,9 @@
 
 /* Marco box operation testing program */
 
-/* 
+/*
  * Copyright (C) 2005 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -365,7 +365,7 @@ test_merge_regions ()
    * uniformly distributed location of center of struts (within screen)
    * merge all regions that are possible
    * print stats on problem setup
-   *   number of (non-completely-occluded?) struts 
+   *   number of (non-completely-occluded?) struts
    *   percentage of screen covered
    *   length of resulting non-minimal spanning set
    *   length of resulting minimal spanning set
@@ -510,11 +510,11 @@ test_merge_regions ()
       compare = compare->next;
     }
 
-  printf ("  Num rectangles contained in others          : %d\n", 
+  printf ("  Num rectangles contained in others          : %d\n",
           num_contains);
-  printf ("  Num rectangles partially contained in others: %d\n", 
+  printf ("  Num rectangles partially contained in others: %d\n",
           num_part_contains);
-  printf ("  Num rectangles adjacent to others           : %d\n", 
+  printf ("  Num rectangles adjacent to others           : %d\n",
           num_adjacent);
   printf ("  Num rectangles merged with others           : %d\n",
           num_merged);
@@ -585,9 +585,9 @@ test_regions_okay ()
   GList* region;
   GList* tmp;
 
-  /*************************************************************/  
+  /*************************************************************/
   /* Make sure test region 0 has the right spanning rectangles */
-  /*************************************************************/  
+  /*************************************************************/
   region = get_screen_region (0);
   tmp = NULL;
   tmp = g_list_prepend (tmp, new_meta_rect (0, 0, 1600, 1200));
@@ -595,9 +595,9 @@ test_regions_okay ()
   meta_rectangle_free_list_and_elements (tmp);
   meta_rectangle_free_list_and_elements (region);
 
-  /*************************************************************/  
+  /*************************************************************/
   /* Make sure test region 1 has the right spanning rectangles */
-  /*************************************************************/  
+  /*************************************************************/
   region = get_screen_region (1);
   tmp = NULL;
   tmp = g_list_prepend (tmp, new_meta_rect (0, 20,  400, 1180));
@@ -608,7 +608,7 @@ test_regions_okay ()
 
   /*************************************************************/
   /* Make sure test region 2 has the right spanning rectangles */
-  /*************************************************************/  
+  /*************************************************************/
   region = get_screen_region (2);
   tmp = NULL;
   tmp = g_list_prepend (tmp, new_meta_rect (   0,   20,  300, 1180));
@@ -622,7 +622,7 @@ test_regions_okay ()
 
   /*************************************************************/
   /* Make sure test region 3 has the right spanning rectangles */
-  /*************************************************************/  
+  /*************************************************************/
   region = get_screen_region (3);
   tmp = NULL;
   tmp = g_list_prepend (tmp, new_meta_rect ( 380,  675,  420,  525)); /* 220500 */
@@ -648,7 +648,7 @@ test_regions_okay ()
 
   /*************************************************************/
   /* Make sure test region 4 has the right spanning rectangles */
-  /*************************************************************/  
+  /*************************************************************/
   region = get_screen_region (4);
   tmp = NULL;
   tmp = g_list_prepend (tmp, new_meta_rect ( 800,   20,  800, 1180));
@@ -658,7 +658,7 @@ test_regions_okay ()
 
   /*************************************************************/
   /* Make sure test region 5 has the right spanning rectangles */
-  /*************************************************************/  
+  /*************************************************************/
   printf ("The next test intentionally causes a warning, "
           "but it can be ignored.\n");
   region = get_screen_region (5);
@@ -1022,9 +1022,9 @@ test_find_onscreen_edges ()
   int top    = META_DIRECTION_TOP;
   int bottom = META_DIRECTION_BOTTOM;
 
-  /*************************************************/  
+  /*************************************************/
   /* Make sure test region 0 has the correct edges */
-  /*************************************************/  
+  /*************************************************/
   edges = get_screen_edges (0);
   tmp = NULL;
   tmp = g_list_prepend (tmp, new_screen_edge (   0, 1200, 1600, 0, bottom));
@@ -1035,9 +1035,9 @@ test_find_onscreen_edges ()
   meta_rectangle_free_list_and_elements (tmp);
   meta_rectangle_free_list_and_elements (edges);
 
-  /*************************************************/  
+  /*************************************************/
   /* Make sure test region 1 has the correct edges */
-  /*************************************************/  
+  /*************************************************/
   edges = get_screen_edges (1);
   tmp = NULL;
   tmp = g_list_prepend (tmp, new_screen_edge (   0, 1200,  400, 0, bottom));
@@ -1050,9 +1050,9 @@ test_find_onscreen_edges ()
   meta_rectangle_free_list_and_elements (tmp);
   meta_rectangle_free_list_and_elements (edges);
 
-  /*************************************************/  
+  /*************************************************/
   /* Make sure test region 2 has the correct edges */
-  /*************************************************/  
+  /*************************************************/
   edges = get_screen_edges (2);
   tmp = NULL;
   tmp = g_list_prepend (tmp, new_screen_edge (1200, 1200,  400, 0, bottom));
@@ -1071,9 +1071,9 @@ test_find_onscreen_edges ()
   meta_rectangle_free_list_and_elements (tmp);
   meta_rectangle_free_list_and_elements (edges);
 
-  /*************************************************/  
+  /*************************************************/
   /* Make sure test region 3 has the correct edges */
-  /*************************************************/  
+  /*************************************************/
   edges = get_screen_edges (3);
   tmp = NULL;
   tmp = g_list_prepend (tmp, new_screen_edge (1200, 1200,  400, 0, bottom));
@@ -1098,7 +1098,7 @@ test_find_onscreen_edges ()
   char big_buffer1[(EDGE_LENGTH+2)*FUDGE], big_buffer2[(EDGE_LENGTH+2)*FUDGE];
   meta_rectangle_edge_list_to_string (edges, "\n ", big_buffer1);
   meta_rectangle_edge_list_to_string (tmp,   "\n ", big_buffer2);
-  printf("Generated edge list:\n %s\nComparison edges list:\n %s\n", 
+  printf("Generated edge list:\n %s\nComparison edges list:\n %s\n",
          big_buffer1, big_buffer2);
 #endif
 
@@ -1106,9 +1106,9 @@ test_find_onscreen_edges ()
   meta_rectangle_free_list_and_elements (tmp);
   meta_rectangle_free_list_and_elements (edges);
 
-  /*************************************************/  
+  /*************************************************/
   /* Make sure test region 4 has the correct edges */
-  /*************************************************/  
+  /*************************************************/
   edges = get_screen_edges (4);
   tmp = NULL;
   tmp = g_list_prepend (tmp, new_screen_edge ( 800, 1200, 800,  0, bottom));
@@ -1119,18 +1119,18 @@ test_find_onscreen_edges ()
   meta_rectangle_free_list_and_elements (tmp);
   meta_rectangle_free_list_and_elements (edges);
 
-  /*************************************************/  
+  /*************************************************/
   /* Make sure test region 5 has the correct edges */
-  /*************************************************/  
+  /*************************************************/
   edges = get_screen_edges (5);
   tmp = NULL;
   verify_edge_lists_are_equal (edges, tmp);
   meta_rectangle_free_list_and_elements (tmp);
   meta_rectangle_free_list_and_elements (edges);
 
-  /*************************************************/  
+  /*************************************************/
   /* Make sure test region 6 has the correct edges */
-  /*************************************************/  
+  /*************************************************/
   edges = get_screen_edges (6);
   tmp = NULL;
   tmp = g_list_prepend (tmp, new_screen_edge (   0, 1200, 1600,  0, bottom));
@@ -1155,18 +1155,18 @@ test_find_nonintersected_xinerama_edges ()
   int top    = META_DIRECTION_TOP;
   int bottom = META_DIRECTION_BOTTOM;
 
-  /*************************************************************************/  
+  /*************************************************************************/
   /* Make sure test xinerama set 0 for with region 0 has the correct edges */
-  /*************************************************************************/  
+  /*************************************************************************/
   edges = get_xinerama_edges (0, 0);
   tmp = NULL;
   verify_edge_lists_are_equal (edges, tmp);
   meta_rectangle_free_list_and_elements (tmp);
   meta_rectangle_free_list_and_elements (edges);
 
-  /*************************************************************************/  
+  /*************************************************************************/
   /* Make sure test xinerama set 2 for with region 1 has the correct edges */
-  /*************************************************************************/  
+  /*************************************************************************/
   edges = get_xinerama_edges (2, 1);
   tmp = NULL;
   tmp = g_list_prepend (tmp, new_xinerama_edge (   0,  600, 1600, 0, bottom));
@@ -1175,9 +1175,9 @@ test_find_nonintersected_xinerama_edges ()
   meta_rectangle_free_list_and_elements (tmp);
   meta_rectangle_free_list_and_elements (edges);
 
-  /*************************************************************************/  
+  /*************************************************************************/
   /* Make sure test xinerama set 1 for with region 2 has the correct edges */
-  /*************************************************************************/  
+  /*************************************************************************/
   edges = get_xinerama_edges (1, 2);
   tmp = NULL;
   tmp = g_list_prepend (tmp, new_xinerama_edge ( 800,   20, 0, 1080, right));
@@ -1187,16 +1187,16 @@ test_find_nonintersected_xinerama_edges ()
   char big_buffer1[(EDGE_LENGTH+2)*FUDGE], big_buffer2[(EDGE_LENGTH+2)*FUDGE];
   meta_rectangle_edge_list_to_string (edges, "\n ", big_buffer1);
   meta_rectangle_edge_list_to_string (tmp,   "\n ", big_buffer2);
-  printf("Generated edge list:\n %s\nComparison edges list:\n %s\n", 
+  printf("Generated edge list:\n %s\nComparison edges list:\n %s\n",
          big_buffer1, big_buffer2);
 #endif
   verify_edge_lists_are_equal (edges, tmp);
   meta_rectangle_free_list_and_elements (tmp);
   meta_rectangle_free_list_and_elements (edges);
 
-  /*************************************************************************/  
+  /*************************************************************************/
   /* Make sure test xinerama set 3 for with region 3 has the correct edges */
-  /*************************************************************************/  
+  /*************************************************************************/
   edges = get_xinerama_edges (3, 3);
   tmp = NULL;
   tmp = g_list_prepend (tmp, new_xinerama_edge ( 900,  600,  700, 0, bottom));
@@ -1209,9 +1209,9 @@ test_find_nonintersected_xinerama_edges ()
   meta_rectangle_free_list_and_elements (tmp);
   meta_rectangle_free_list_and_elements (edges);
 
-  /*************************************************************************/  
+  /*************************************************************************/
   /* Make sure test xinerama set 3 for with region 4 has the correct edges */
-  /*************************************************************************/  
+  /*************************************************************************/
   edges = get_xinerama_edges (3, 4);
   tmp = NULL;
   tmp = g_list_prepend (tmp, new_xinerama_edge ( 800,  600,  800, 0, bottom));
@@ -1221,9 +1221,9 @@ test_find_nonintersected_xinerama_edges ()
   meta_rectangle_free_list_and_elements (tmp);
   meta_rectangle_free_list_and_elements (edges);
 
-  /*************************************************************************/  
+  /*************************************************************************/
   /* Make sure test xinerama set 3 for with region 5has the correct edges */
-  /*************************************************************************/  
+  /*************************************************************************/
   edges = get_xinerama_edges (3, 5);
   tmp = NULL;
   verify_edge_lists_are_equal (edges, tmp);

--- a/src/core/util.c
+++ b/src/core/util.c
@@ -2,10 +2,10 @@
 
 /* Marco utilities */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2005 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -15,7 +15,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -46,11 +46,11 @@ meta_print_backtrace (void)
   int bt_size;
   int i;
   char **syms;
-  
+
   bt_size = backtrace (bt, 500);
 
   syms = backtrace_symbols (bt, bt_size);
-  
+
   i = 0;
   while (i < bt_size)
     {
@@ -85,7 +85,7 @@ ensure_logfile (void)
       char *tmpl;
       int fd;
       GError *err;
-      
+
       tmpl = g_strdup_printf ("marco-%d-debug-log-XXXXXX",
                               (int) getpid ());
 
@@ -95,7 +95,7 @@ ensure_logfile (void)
                             &err);
 
       g_free (tmpl);
-      
+
       if (err != NULL)
         {
           meta_warning (_("Failed to open debug log: %s\n"),
@@ -103,9 +103,9 @@ ensure_logfile (void)
           g_error_free (err);
           return;
         }
-      
+
       logfile = fdopen (fd, "w");
-      
+
       if (logfile == NULL)
         {
           meta_warning (_("Failed to fdopen() log file %s: %s\n"),
@@ -116,7 +116,7 @@ ensure_logfile (void)
         {
           g_printerr (_("Opened log file %s\n"), filename);
         }
-      
+
       g_free (filename);
     }
 }
@@ -134,11 +134,11 @@ meta_set_verbose (gboolean setting)
 #ifndef WITH_VERBOSE_MODE
   if (setting)
     meta_fatal (_("Marco was compiled without support for verbose mode\n"));
-#else 
+#else
   if (setting)
     ensure_logfile ();
 #endif
-  
+
   is_verbose = setting;
 }
 
@@ -191,7 +191,7 @@ utf8_fputs (const char *str,
 {
   char *l;
   int retval;
-  
+
   l = g_locale_from_utf8 (str, -1, NULL, NULL, NULL);
 
   if (l == NULL)
@@ -220,24 +220,24 @@ meta_debug_spew_real (const char *format, ...)
   va_list args;
   gchar *str;
   FILE *out;
-  
+
   g_return_if_fail (format != NULL);
 
   if (!is_debugging)
     return;
-  
+
   va_start (args, format);
   str = g_strdup_vprintf (format, args);
   va_end (args);
 
   out = logfile ? logfile : stderr;
-  
+
   if (no_prefix == 0)
     utf8_fputs (_("Window manager: "), out);
   utf8_fputs (str, out);
 
   fflush (out);
-  
+
   g_free (str);
 }
 #endif /* WITH_VERBOSE_MODE */
@@ -254,19 +254,19 @@ meta_verbose_real (const char *format, ...)
 
   if (!is_verbose)
     return;
-  
+
   va_start (args, format);
   str = g_strdup_vprintf (format, args);
   va_end (args);
 
   out = logfile ? logfile : stderr;
-  
+
   if (no_prefix == 0)
     utf8_fputs ("Window manager: ", out);
   utf8_fputs (str, out);
 
   fflush (out);
-  
+
   g_free (str);
 }
 #endif /* WITH_VERBOSE_MODE */
@@ -341,8 +341,8 @@ meta_topic_real (MetaDebugTopic topic,
 
   if (!is_verbose)
     return;
-  
-  va_start (args, format);  
+
+  va_start (args, format);
   str = g_strdup_vprintf (format, args);
   va_end (args);
 
@@ -356,11 +356,11 @@ meta_topic_real (MetaDebugTopic topic,
       ++sync_count;
       fprintf (out, "%d: ", sync_count);
     }
-  
+
   utf8_fputs (str, out);
-  
+
   fflush (out);
-  
+
   g_free (str);
 }
 #endif /* WITH_VERBOSE_MODE */
@@ -373,7 +373,7 @@ meta_bug (const char *format, ...)
   FILE *out;
 
   g_return_if_fail (format != NULL);
-  
+
   va_start (args, format);
   str = g_strdup_vprintf (format, args);
   va_end (args);
@@ -389,11 +389,11 @@ meta_bug (const char *format, ...)
   utf8_fputs (str, out);
 
   fflush (out);
-  
+
   g_free (str);
 
   meta_print_backtrace ();
-  
+
   /* stop us in a debugger */
   abort ();
 }
@@ -404,9 +404,9 @@ meta_warning (const char *format, ...)
   va_list args;
   gchar *str;
   FILE *out;
-  
+
   g_return_if_fail (format != NULL);
-  
+
   va_start (args, format);
   str = g_strdup_vprintf (format, args);
   va_end (args);
@@ -422,7 +422,7 @@ meta_warning (const char *format, ...)
   utf8_fputs (str, out);
 
   fflush (out);
-  
+
   g_free (str);
 }
 
@@ -432,9 +432,9 @@ meta_fatal (const char *format, ...)
   va_list args;
   gchar *str;
   FILE *out;
-  
+
   g_return_if_fail (format != NULL);
-  
+
   va_start (args, format);
   str = g_strdup_vprintf (format, args);
   va_end (args);
@@ -450,7 +450,7 @@ meta_fatal (const char *format, ...)
   utf8_fputs (str, out);
 
   fflush (out);
-  
+
   g_free (str);
 
   meta_exit (META_EXIT_ERROR);
@@ -473,7 +473,7 @@ meta_pop_no_msg_prefix (void)
 void
 meta_exit (MetaExitCode code)
 {
-  
+
   exit (code);
 }
 
@@ -570,7 +570,7 @@ meta_show_dialog (const char *type,
   argvl[i++] = _("Marco");
   argvl[i++] = "--text";
   argvl[i++] = message;
-  
+
   if (timeout)
     {
       argvl[i++] = "--timeout";
@@ -588,7 +588,7 @@ meta_show_dialog (const char *type,
       argvl[i++] = "--cancel-label";
       argvl[i++] = cancel_text;
     }
-  
+
   tmp = columns;
   while (tmp)
     {
@@ -603,7 +603,7 @@ meta_show_dialog (const char *type,
       argvl[i++] = tmp->data;
       tmp = tmp->next;
     }
-    
+
   argvl[i] = NULL;
 
   if (transient_for)

--- a/src/core/window-private.h
+++ b/src/core/window-private.h
@@ -9,12 +9,12 @@
  * which the rest of the world is allowed to use.)
  */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2002 Red Hat, Inc.
  * Copyright (C) 2003, 2004 Rob Adams
  * Copyright (C) 2004-2006 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -24,7 +24,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -110,10 +110,10 @@ struct _MetaWindow
   MetaIconCache icon_cache;
   Pixmap wm_hints_pixmap;
   Pixmap wm_hints_mask;
-  
+
   MetaWindowType type;
   Atom type_atom;
-  
+
   /* NOTE these five are not in UTF-8, we just treat them as random
    * binary data
    */
@@ -125,17 +125,17 @@ struct _MetaWindow
   char *startup_id;
 
   int net_wm_pid;
-  
+
   Window xtransient_for;
   Window xgroup_leader;
   Window xclient_leader;
 
   /* Initial workspace property */
-  int initial_workspace;  
-  
+  int initial_workspace;
+
   /* Initial timestamp property */
-  guint32 initial_timestamp;  
-  
+  guint32 initial_timestamp;
+
   /* Whether we're maximized */
   guint maximized_horizontally : 1;
   guint maximized_vertically : 1;
@@ -164,7 +164,7 @@ struct _MetaWindow
    * these monitors.  If not, this is the single monitor which the window's
    * origin is on. */
   long fullscreen_monitors[4];
-  
+
   /* Whether we're trying to constrain the window to be fully onscreen */
   guint require_fully_onscreen : 1;
 
@@ -189,7 +189,7 @@ struct _MetaWindow
    * see also unmaps_pending
    */
   guint mapped : 1;
-  
+
   /* Iconic is the state in WM_STATE; happens for workspaces/shading
    * in addition to minimize
    */
@@ -201,20 +201,20 @@ struct _MetaWindow
 
   /* whether an initial workspace was explicitly set */
   guint initial_workspace_set : 1;
-  
+
   /* whether an initial timestamp was explicitly set */
   guint initial_timestamp_set : 1;
-  
+
   /* whether net_wm_user_time has been set yet */
   guint net_wm_user_time_set : 1;
-  
+
   /* These are the flags from WM_PROTOCOLS */
   guint take_focus : 1;
   guint delete_window : 1;
   guint net_wm_ping : 1;
   /* Globally active / No input */
   guint input : 1;
-  
+
   /* MWM hints about features of window */
   guint mwm_decorated : 1;
   guint mwm_border_only : 1;
@@ -223,7 +223,7 @@ struct _MetaWindow
   guint mwm_has_maximize_func : 1;
   guint mwm_has_move_func : 1;
   guint mwm_has_resize_func : 1;
-  
+
   /* Computed features of window */
   guint decorated : 1;
   guint border_only : 1;
@@ -235,7 +235,7 @@ struct _MetaWindow
   guint has_move_func : 1;
   guint has_resize_func : 1;
   guint has_fullscreen_func : 1;
-  
+
   /* Weird "_NET_WM_STATE_MODAL" flag */
   guint wm_state_modal : 1;
 
@@ -253,12 +253,12 @@ struct _MetaWindow
 
   /* EWHH demands attention flag */
   guint wm_state_demands_attention : 1;
-  
+
   /* this flag tracks receipt of focus_in focus_out and
    * determines whether we draw the focus
    */
   guint has_focus : 1;
-  
+
   /* Have we placed this window? */
   guint placed : 1;
 
@@ -276,15 +276,15 @@ struct _MetaWindow
 
   /* Are we in meta_window_new()? */
   guint constructing : 1;
-  
+
   /* Are we in the various queues? (Bitfield: see META_WINDOW_IS_IN_QUEUE) */
   guint is_in_queues : NUMBER_OF_QUEUES;
- 
+
   /* Used by keybindings.c */
   guint keys_grabbed : 1;     /* normal keybindings grabbed */
   guint grab_on_frame : 1;    /* grabs are on the frame */
   guint all_keys_grabbed : 1; /* AnyKey grabbed */
-  
+
   /* Set if the reason for unmanaging the window is that
    * it was withdrawn
    */
@@ -309,7 +309,7 @@ struct _MetaWindow
 
   /* icon props have changed */
   guint need_reread_icon : 1;
-  
+
   /* if TRUE, window was maximized at start of current grab op */
   guint shaken_loose : 1;
 
@@ -328,7 +328,7 @@ struct _MetaWindow
   guint sync_request_serial;
   GTimeVal sync_request_time;
 #endif
-  
+
   /* Number of UnmapNotify that are caused by us, if
    * we get UnmapNotify with none pending then the client
    * is withdrawing the window.
@@ -341,11 +341,11 @@ struct _MetaWindow
 
   /* window that gets updated net_wm_user_time values */
   Window user_time_window;
-  
+
   /* The size we set the window to last (i.e. what we believe
    * to be its actual size on the server). The x, y are
    * the actual server-side x,y so are relative to the frame
-   * (meaning that they just hold the frame width and height) 
+   * (meaning that they just hold the frame width and height)
    * or the root window (meaning they specify the location
    * of the top left of the inner window) as appropriate.
    */
@@ -370,7 +370,7 @@ struct _MetaWindow
    * Position always in root coords, unlike window->rect.
    */
   MetaRectangle user_rect;
-  
+
   /* Requested geometry */
   int border_width;
   /* x/y/w/h here get filled with ConfigureRequest values */
@@ -379,7 +379,7 @@ struct _MetaWindow
   /* Managed by stack.c */
   MetaStackLayer layer;
   int stack_position; /* see comment in stack.h */
-  
+
   /* Current dialog open for this window */
   int dialog_pid;
 
@@ -442,7 +442,7 @@ void        meta_window_activate           (MetaWindow  *window,
                                             guint32      current_time);
 void        meta_window_activate_with_workspace  (MetaWindow    *window,
                                                   guint32        current_time,
-                                                  MetaWorkspace *workspace);   
+                                                  MetaWorkspace *workspace);
 void        meta_window_make_fullscreen_internal (MetaWindow    *window);
 void        meta_window_make_fullscreen    (MetaWindow  *window);
 void        meta_window_unmake_fullscreen  (MetaWindow  *window);

--- a/src/core/window-props.c
+++ b/src/core/window-props.c
@@ -14,11 +14,11 @@
  * together.
  */
 
-/* 
+/*
  * Copyright (C) 2001, 2002, 2003 Red Hat, Inc.
  * Copyright (C) 2004, 2005 Elijah Newren
  * Copyright (C) 2009 Thomas Thurman
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -28,7 +28,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -120,14 +120,14 @@ meta_window_reload_properties_from_xwindow (MetaWindow *window,
 
   g_return_if_fail (properties != NULL);
   g_return_if_fail (n_properties > 0);
-  
+
   values = g_new0 (MetaPropValue, n_properties);
 
   for (i=0; i<n_properties; i++)
     {
       MetaWindowPropHooks *hooks = find_hooks (window->display,
                                                properties[i]);
-    
+
       if (!hooks || hooks->type == META_PROP_VALUE_INVALID)
         {
           values[i].type = META_PROP_VALUE_INVALID;
@@ -139,7 +139,7 @@ meta_window_reload_properties_from_xwindow (MetaWindow *window,
           values[i].atom = properties[i];
         }
     }
-  
+
   meta_prop_get_values (window->display, xwindow,
                         values, n_properties);
 
@@ -153,7 +153,7 @@ meta_window_reload_properties_from_xwindow (MetaWindow *window,
     }
 
   meta_prop_free_values (values, n_properties);
-  
+
   g_free (values);
 }
 
@@ -164,7 +164,7 @@ reload_wm_client_machine (MetaWindow    *window,
 {
   g_free (window->wm_client_machine);
   window->wm_client_machine = NULL;
-  
+
   if (value->type != META_PROP_VALUE_INVALID)
     window->wm_client_machine = g_strdup (value->v.str);
 
@@ -247,7 +247,7 @@ reload_net_wm_pid (MetaWindow    *window,
   if (value->type != META_PROP_VALUE_INVALID)
     {
       gulong cardinal = (int) value->v.cardinal;
-      
+
       if (cardinal <= 0)
         meta_warning (_("Application set a bogus _NET_WM_PID %lu\n"),
                       cardinal);
@@ -342,7 +342,7 @@ owner_of_process (pid_t process, uid_t *result)
 {
 #ifdef HAVE_GTOP
   glibtop_proc_uid process_details;
-      
+
   glibtop_get_proc_uid (&process_details, process);
 
   *result = process_details.uid;
@@ -373,12 +373,12 @@ set_title_text (MetaWindow  *window,
 {
   char hostname[HOST_NAME_MAX + 1];
   gboolean modified = FALSE;
-  
+
   if (!target)
     return FALSE;
-  
+
   g_free (*target);
-  
+
   if (!title)
     *target = g_strdup ("");
   else if (g_utf8_strlen (title, MAX_TITLE_LENGTH + 1) > MAX_TITLE_LENGTH)
@@ -412,7 +412,7 @@ set_title_text (MetaWindow  *window,
       /* Assume a window with unknown ownership is ours (call it usufruct!) */
       gboolean window_owner_is_us =
               !window_owner_known || window_owner==getuid ();
-      
+
       if (window_owner_is_us)
         {
           /* we own it, so fall back to the simple case */
@@ -439,7 +439,7 @@ set_title_text (MetaWindow  *window,
                 {
                   found_name = pwd->pw_name;
                 }
-            
+
               if (found_name)
                 /* Translators: the title of a window owned by another user
                  * on this machine */
@@ -454,7 +454,7 @@ set_title_text (MetaWindow  *window,
             }
           /* either way we changed it */
           modified = TRUE;
-              
+
         }
     }
   else
@@ -483,7 +483,7 @@ set_window_title (MetaWindow *window,
                   const char *title)
 {
   char *str;
- 
+
   gboolean modified =
     set_title_text (window,
                     window->using_net_wm_visible_name,
@@ -491,7 +491,7 @@ set_window_title (MetaWindow *window,
                     window->display->atom__NET_WM_VISIBLE_NAME,
                     &window->title);
   window->using_net_wm_visible_name = modified;
-  
+
   /* strndup is a hack since GNU libc has broken %.10s */
   str = g_strndup (window->title, 10);
   g_free (window->desc);
@@ -537,7 +537,7 @@ reload_wm_name (MetaWindow    *window,
                     value->v.str);
       return;
     }
-  
+
   if (value->type != META_PROP_VALUE_INVALID)
     {
       set_window_title (window, value->v.str);
@@ -597,11 +597,11 @@ reload_wm_icon_name (MetaWindow    *window,
                     value->v.str);
       return;
     }
-  
+
   if (value->type != META_PROP_VALUE_INVALID)
     {
       set_icon_title (window, value->v.str);
-      
+
       meta_verbose ("Using WM_ICON_NAME for new title of %s: \"%s\"\n",
                     window->desc, window->title);
     }
@@ -789,7 +789,7 @@ reload_mwm_hints (MetaWindow    *window,
     meta_verbose ("Functions flag unset\n");
 
   meta_window_recalc_features (window);
-  
+
   /* We do all this anyhow at the end of meta_window_new() */
   if (!window->constructing)
     {
@@ -797,7 +797,7 @@ reload_mwm_hints (MetaWindow    *window,
         meta_window_ensure_frame (window);
       else
         meta_window_destroy_frame (window);
-      
+
       meta_window_queue (window,
                          META_QUEUE_MOVE_RESIZE |
                          /* because ensure/destroy frame may unmap: */
@@ -819,7 +819,7 @@ reload_wm_class (MetaWindow    *window,
   window->res_name = NULL;
 
   if (value->type != META_PROP_VALUE_INVALID)
-    { 
+    {
       if (value->v.class_hint.res_name)
         window->res_name = g_strdup (value->v.class_hint.res_name);
 
@@ -855,32 +855,32 @@ reload_net_startup_id (MetaWindow    *window,
 {
   guint32 timestamp = window->net_wm_user_time;
   MetaWorkspace *workspace = NULL;
-  
+
   g_free (window->startup_id);
-  
+
   if (value->type != META_PROP_VALUE_INVALID)
     window->startup_id = g_strdup (value->v.str);
   else
     window->startup_id = NULL;
-    
+
   /* Update timestamp and workspace on a running window */
   if (!window->constructing)
   {
-    window->initial_timestamp_set = 0;  
+    window->initial_timestamp_set = 0;
     window->initial_workspace_set = 0;
-    
+
     if (meta_screen_apply_startup_properties (window->screen, window))
       {
-  
+
         if (window->initial_timestamp_set)
           timestamp = window->initial_timestamp;
         if (window->initial_workspace_set)
           workspace = meta_screen_get_workspace_by_index (window->screen, window->initial_workspace);
-    
+
         meta_window_activate_with_workspace (window, timestamp, workspace);
       }
   }
-  
+
   meta_verbose ("New _NET_STARTUP_ID \"%s\" for %s\n",
                 window->startup_id ? window->startup_id : "unset",
                 window->desc);
@@ -960,7 +960,7 @@ spew_size_hints_differences (const XSizeHints *old,
   if (FLAG_CHANGED (old, new, PWinGravity))
     meta_topic (META_DEBUG_GEOMETRY, "XSizeHints: PWinGravity now %s  (%d -> %d)\n",
                 FLAG_TOGGLED_ON (old, new, PWinGravity) ? "set" : "unset",
-                old->win_gravity, new->win_gravity);  
+                old->win_gravity, new->win_gravity);
 }
 
 void
@@ -1313,15 +1313,15 @@ reload_normal_hints (MetaWindow    *window,
   if (value->type != META_PROP_VALUE_INVALID)
     {
       XSizeHints old_hints;
-  
+
       meta_topic (META_DEBUG_GEOMETRY, "Updating WM_NORMAL_HINTS for %s\n", window->desc);
 
       old_hints = window->size_hints;
-  
+
       meta_set_normal_hints (window, value->v.size_hints.hints);
-      
+
       spew_size_hints_differences (&old_hints, &window->size_hints);
-      
+
       meta_window_recalc_features (window);
 
       if (!initial)
@@ -1335,12 +1335,12 @@ reload_wm_protocols (MetaWindow    *window,
                      gboolean       initial)
 {
   int i;
-  
+
   window->take_focus = FALSE;
   window->delete_window = FALSE;
   window->net_wm_ping = FALSE;
-  
-  if (value->type == META_PROP_VALUE_INVALID)    
+
+  if (value->type == META_PROP_VALUE_INVALID)
     return;
 
   i = 0;
@@ -1357,7 +1357,7 @@ reload_wm_protocols (MetaWindow    *window,
         window->net_wm_ping = TRUE;
       ++i;
     }
-  
+
   meta_verbose ("New _NET_STARTUP_ID \"%s\" for %s\n",
                 window->startup_id ? window->startup_id : "unset",
                 window->desc);
@@ -1369,20 +1369,20 @@ reload_wm_hints (MetaWindow    *window,
                  gboolean       initial)
 {
   Window old_group_leader;
-  
+
   old_group_leader = window->xgroup_leader;
-  
+
   /* Fill in defaults */
   window->input = TRUE;
   window->initially_iconic = FALSE;
   window->xgroup_leader = None;
   window->wm_hints_pixmap = None;
   window->wm_hints_mask = None;
-  
+
   if (value->type != META_PROP_VALUE_INVALID)
     {
       const XWMHints *hints = value->v.wm_hints;
-      
+
       if (hints->flags & InputHint)
         window->input = hints->input;
 
@@ -1397,7 +1397,7 @@ reload_wm_hints (MetaWindow    *window,
 
       if (hints->flags & IconMaskHint)
         window->wm_hints_mask = hints->icon_mask;
-      
+
       meta_verbose ("Read WM_HINTS input: %d iconic: %d group leader: 0x%lx pixmap: 0x%lx mask: 0x%lx\n",
                     window->input, window->initially_iconic,
                     window->xgroup_leader,
@@ -1409,7 +1409,7 @@ reload_wm_hints (MetaWindow    *window,
     {
       meta_verbose ("Window %s changed its group leader to 0x%lx\n",
                     window->desc, window->xgroup_leader);
-      
+
       meta_window_group_leader_changed (window);
     }
 
@@ -1426,13 +1426,13 @@ reload_transient_for (MetaWindow    *window,
                       gboolean       initial)
 {
   window->xtransient_for = None;
-  
+
   if (value->type != META_PROP_VALUE_INVALID)
     window->xtransient_for = value->v.xwindow;
 
   /* Make sure transient_for is valid */
   if (window->xtransient_for != None &&
-      meta_display_lookup_x_window (window->display, 
+      meta_display_lookup_x_window (window->display,
                                     window->xtransient_for) == NULL)
     {
       meta_warning (_("Invalid WM_TRANSIENT_FOR window 0x%lx specified "

--- a/src/core/window-props.h
+++ b/src/core/window-props.h
@@ -10,9 +10,9 @@
  * round trip to the server.
  */
 
-/* 
+/*
  * Copyright (C) 2001, 2002 Red Hat, Inc.
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -22,7 +22,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA

--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -2,11 +2,11 @@
 
 /* Marco Workspaces */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2003 Rob Adams
  * Copyright (C) 2004, 2005 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -16,7 +16,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -79,7 +79,7 @@ meta_workspace_new (MetaScreen *screen)
   workspace->all_struts = NULL;
 
   workspace->showing_desktop = FALSE;
-  
+
   return workspace;
 }
 
@@ -100,7 +100,7 @@ workspace_free_struts (MetaWorkspace *workspace)
 {
   if (workspace->all_struts == NULL)
     return;
-    
+
   g_slist_foreach (workspace->all_struts, free_this, NULL);
   g_slist_free (workspace->all_struts);
   workspace->all_struts = NULL;
@@ -118,7 +118,7 @@ meta_workspace_free (MetaWorkspace *workspace)
   /* Here we assume all the windows are already on another workspace
    * as well, so they won't be "orphaned"
    */
-  
+
   tmp = workspace->windows;
   while (tmp != NULL)
     {
@@ -136,10 +136,10 @@ meta_workspace_free (MetaWorkspace *workspace)
   g_assert (workspace->windows == NULL);
 
   screen = workspace->screen;
-  
+
   workspace->screen->workspaces =
     g_list_remove (workspace->screen->workspaces, workspace);
-  
+
   g_free (workspace->work_area_xinerama);
 
   g_list_free (workspace->mru_list);
@@ -175,11 +175,11 @@ meta_workspace_add_window (MetaWorkspace *workspace,
                            MetaWindow    *window)
 {
   g_return_if_fail (window->workspace == NULL);
-  
+
   /* If the window is on all workspaces, we want to add it to all mru
    * lists, otherwise just add it to this workspaces mru list
    */
-  if (window->on_all_workspaces) 
+  if (window->on_all_workspaces)
     {
       if (window->workspace == NULL)
         {
@@ -204,7 +204,7 @@ meta_workspace_add_window (MetaWorkspace *workspace,
   window->workspace = workspace;
 
   meta_window_set_current_workspace_hint (window);
-  
+
   if (window->struts)
     {
       meta_topic (META_DEBUG_WORKAREA,
@@ -229,10 +229,10 @@ meta_workspace_remove_window (MetaWorkspace *workspace,
   window->workspace = NULL;
 
   /* If the window is on all workspaces, we don't want to remove it
-   * from the MRU list unless this causes it to be removed from all 
+   * from the MRU list unless this causes it to be removed from all
    * workspaces
    */
-  if (window->on_all_workspaces) 
+  if (window->on_all_workspaces)
     {
       GList* tmp = window->screen->workspaces;
       while (tmp)
@@ -250,7 +250,7 @@ meta_workspace_remove_window (MetaWorkspace *workspace,
     }
 
   meta_window_set_current_workspace_hint (window);
-  
+
   if (window->struts)
     {
       meta_topic (META_DEBUG_WORKAREA,
@@ -271,12 +271,12 @@ meta_workspace_relocate_windows (MetaWorkspace *workspace,
 {
   GList *tmp;
   GList *copy;
-  
+
   g_return_if_fail (workspace != new_home);
 
   /* can't modify list we're iterating over */
   copy = g_list_copy (workspace->windows);
-  
+
   tmp = copy;
   while (tmp != NULL)
     {
@@ -284,12 +284,12 @@ meta_workspace_relocate_windows (MetaWorkspace *workspace,
 
       meta_workspace_remove_window (workspace, window);
       meta_workspace_add_window (new_home, window);
-      
+
       tmp = tmp->next;
     }
 
   g_list_free (copy);
-  
+
   g_assert (workspace->windows == NULL);
 }
 
@@ -372,10 +372,10 @@ meta_workspace_activate_with_focus (MetaWorkspace *workspace,
 {
   MetaWorkspace *old;
   MetaWindow *move_window;
-  
+
   meta_verbose ("Activating workspace %d\n",
                 meta_workspace_index (workspace));
-  
+
   if (workspace->screen->active_workspace == workspace)
     return;
 
@@ -406,7 +406,7 @@ meta_workspace_activate_with_focus (MetaWorkspace *workspace,
   if (workspace->screen->display->grab_op == META_GRAB_OP_MOVING ||
       workspace->screen->display->grab_op == META_GRAB_OP_KEYBOARD_MOVING)
     move_window = workspace->screen->display->grab_window;
-      
+
   if (move_window != NULL)
     {
       if (move_window->on_all_workspaces)
@@ -479,7 +479,7 @@ meta_workspace_list_windows (MetaWorkspace *workspace)
   GSList *display_windows;
   GSList *tmp;
   GList *workspace_windows;
-  
+
   display_windows = meta_display_list_windows (workspace->screen->display);
 
   workspace_windows = NULL;
@@ -513,11 +513,11 @@ set_active_space_hint (MetaScreen *screen)
    */
   if (screen->closing > 0)
     return;
-  
+
   data[0] = meta_workspace_index (screen->active_workspace);
 
   meta_verbose ("Setting _NET_CURRENT_DESKTOP to %lu\n", data[0]);
-  
+
   meta_error_trap_push (screen->display);
   XChangeProperty (screen->display->xdisplay, screen->xroot,
                    screen->display->atom__NET_CURRENT_DESKTOP,
@@ -532,7 +532,7 @@ meta_workspace_invalidate_work_area (MetaWorkspace *workspace)
   GList *tmp;
   GList *windows;
   int i;
-  
+
   if (workspace->work_areas_invalid)
     {
       meta_topic (META_DEBUG_WORKAREA,
@@ -547,7 +547,7 @@ meta_workspace_invalidate_work_area (MetaWorkspace *workspace)
 
   g_free (workspace->work_area_xinerama);
   workspace->work_area_xinerama = NULL;
-      
+
   workspace_free_struts (workspace);
 
   for (i = 0; i < workspace->screen->n_xinerama_infos; i++)
@@ -560,7 +560,7 @@ meta_workspace_invalidate_work_area (MetaWorkspace *workspace)
   workspace->screen_region = NULL;
   workspace->screen_edges = NULL;
   workspace->xinerama_edges = NULL;
-  
+
   workspace->work_areas_invalid = TRUE;
 
   /* redo the size/position constraints on all windows */
@@ -571,7 +571,7 @@ meta_workspace_invalidate_work_area (MetaWorkspace *workspace)
       MetaWindow *w = tmp->data;
 
       meta_window_queue (w, META_QUEUE_MOVE_RESIZE);
-      
+
       tmp = tmp->next;
     }
 
@@ -597,7 +597,7 @@ ensure_work_areas_validated (MetaWorkspace *workspace)
   g_assert (workspace->screen_edges == NULL);
   g_assert (workspace->xinerama_edges == NULL);
 
-  /* STEP 1: Get the list of struts */  
+  /* STEP 1: Get the list of struts */
   windows = meta_workspace_list_windows (workspace);
   for (tmp = windows; tmp != NULL; tmp = tmp->next)
     {
@@ -615,7 +615,7 @@ ensure_work_areas_validated (MetaWorkspace *workspace)
 
   /* STEP 2: Get the maximal/spanning rects for the onscreen and
    *         on-single-xinerama regions
-   */  
+   */
   g_assert (workspace->xinerama_region == NULL);
   g_assert (workspace->screen_region   == NULL);
 
@@ -687,7 +687,7 @@ ensure_work_areas_validated (MetaWorkspace *workspace)
               workspace->work_area_screen.x,
               workspace->work_area_screen.y,
               workspace->work_area_screen.width,
-              workspace->work_area_screen.height);    
+              workspace->work_area_screen.height);
 
   /* Now find the work areas for each xinerama */
   g_free (workspace->work_area_xinerama);
@@ -722,7 +722,7 @@ ensure_work_areas_validated (MetaWorkspace *workspace)
 
   /* STEP 4: Make sure the screen_region is nonempty (separate from step 2
    *         since it relies on step 3).
-   */  
+   */
   if (workspace->screen_region == NULL)
     {
       MetaRectangle *nonempty_region;
@@ -758,7 +758,7 @@ meta_workspace_get_work_area_for_xinerama (MetaWorkspace *workspace,
 
   ensure_work_areas_validated (workspace);
   g_assert (which_xinerama < workspace->screen->n_xinerama_infos);
-  
+
   *area = workspace->work_area_xinerama[which_xinerama];
 }
 
@@ -767,7 +767,7 @@ meta_workspace_get_work_area_all_xineramas (MetaWorkspace *workspace,
                                             MetaRectangle *area)
 {
   ensure_work_areas_validated (workspace);
-  
+
   *area = workspace->work_area_screen;
 }
 
@@ -987,7 +987,7 @@ meta_workspace_focus_default_window (MetaWorkspace *workspace,
             }
 
           if (workspace->screen->display->autoraise_window != window &&
-              meta_prefs_get_auto_raise ()) 
+              meta_prefs_get_auto_raise ())
             {
               meta_display_queue_autoraise_callback (workspace->screen->display,
                                                      window);
@@ -1036,7 +1036,7 @@ focus_ancestor_or_mru_window (MetaWorkspace *workspace,
     meta_topic (META_DEBUG_FOCUS,
                 "Focusing MRU window\n");
 
-  /* First, check to see if we need to focus an ancestor of a window */  
+  /* First, check to see if we need to focus an ancestor of a window */
   if (not_this_one)
     {
       MetaWindow *ancestor;
@@ -1045,9 +1045,9 @@ focus_ancestor_or_mru_window (MetaWorkspace *workspace,
       if (ancestor != NULL)
         {
           meta_topic (META_DEBUG_FOCUS,
-                      "Focusing %s, ancestor of %s\n", 
+                      "Focusing %s, ancestor of %s\n",
                       ancestor->desc, not_this_one->desc);
-      
+
           meta_window_focus (ancestor, timestamp);
 
           /* Also raise the window if in click-to-focus */
@@ -1059,7 +1059,7 @@ focus_ancestor_or_mru_window (MetaWorkspace *workspace,
     }
 
   /* No ancestor, look for the MRU window */
-  tmp = workspace->mru_list;  
+  tmp = workspace->mru_list;
 
   while (tmp)
     {
@@ -1093,7 +1093,7 @@ focus_ancestor_or_mru_window (MetaWorkspace *workspace,
     {
       meta_topic (META_DEBUG_FOCUS,
                   "Focusing workspace MRU window %s\n", window->desc);
-      
+
       meta_window_focus (window, timestamp);
 
       /* Also raise the window if in click-to-focus */

--- a/src/core/workspace.h
+++ b/src/core/workspace.h
@@ -10,10 +10,10 @@
  * are unmapped.
  */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2004, 2005 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -23,7 +23,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -50,7 +50,7 @@ typedef enum
 struct _MetaWorkspace
 {
   MetaScreen *screen;
-  
+
   GList *windows;
   GList *mru_list;
 

--- a/src/core/xprops.c
+++ b/src/core/xprops.c
@@ -2,7 +2,7 @@
 
 /* Marco X property convenience routines */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2002 Red Hat Inc.
  *
@@ -10,7 +10,7 @@
  *   Copyright 1987, 1988, 1998  The Open Group
  *   Copyright 1988 by Wyse Technology, Inc., San Jose, Ca,
  *   Copyright 1987 by Digital Equipment Corporation, Maynard, Massachusetts,
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -20,7 +20,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -33,20 +33,20 @@ Copyright 1987 by Digital Equipment Corporation, Maynard, Massachusetts,
 
                         All Rights Reserved
 
-Permission to use, copy, modify, and distribute this software and its 
-documentation for any purpose and without fee is hereby granted, 
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose and without fee is hereby granted,
 provided that the above copyright notice appear in all copies and that
-both that copyright notice and this permission notice appear in 
+both that copyright notice and this permission notice appear in
 supporting documentation, and that the name Digital not be
 used in advertising or publicity pertaining to distribution of the
-software without specific, written prior permission.  
+software without specific, written prior permission.
 
-DIGITAL AND WYSE DISCLAIM ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, 
-INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO 
-EVENT SHALL DIGITAL OR WYSE BE LIABLE FOR ANY SPECIAL, INDIRECT OR 
-CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF 
-USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR 
-OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR 
+DIGITAL AND WYSE DISCLAIM ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO
+EVENT SHALL DIGITAL OR WYSE BE LIABLE FOR ANY SPECIAL, INDIRECT OR
+CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
+USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
 ******************************************************************/
@@ -116,12 +116,12 @@ validate_or_free_results (GetPropertyResults *results,
   const char *res_class;
   const char *res_name;
   MetaWindow *w;
-  
+
   if (expected_format == results->format &&
       expected_type == results->type &&
       (!must_have_items || results->n_items > 0))
-    return TRUE;  
-  
+    return TRUE;
+
   meta_error_trap_push (results->display);
   type_name = XGetAtomName (results->display->xdisplay, results->type);
   expected_name = XGetAtomName (results->display->xdisplay, expected_type);
@@ -142,7 +142,7 @@ validate_or_free_results (GetPropertyResults *results,
       res_class = NULL;
       res_name = NULL;
     }
-  
+
   if (title == NULL)
     title = "unknown";
 
@@ -151,7 +151,7 @@ validate_or_free_results (GetPropertyResults *results,
 
   if (res_name == NULL)
     res_name = "unknown";
-  
+
   meta_warning (_("Window 0x%lx has property %s\nthat was expected to have type %s format %d\nand actually has type %s format %d n_items %d.\nThis is most likely an application bug, not a window manager bug.\nThe window has title=\"%s\" class=\"%s\" name=\"%s\"\n"),
                 results->xwindow,
                 prop_name ? prop_name : "(bad atom)",
@@ -173,7 +173,7 @@ validate_or_free_results (GetPropertyResults *results,
       XFree (results->prop);
       results->prop = NULL;
     }
-  
+
   return FALSE;
 }
 
@@ -192,7 +192,7 @@ get_property (MetaDisplay        *display,
   results->type = None;
   results->bytes_after = 0;
   results->format = 0;
-  
+
   meta_error_trap_push_with_return (display);
   if (XGetWindowProperty (display->xdisplay, xwindow, xatom,
                           0, G_MAXLONG,
@@ -224,12 +224,12 @@ atom_list_from_results (GetPropertyResults *results,
                         int                *n_atoms_p)
 {
   if (!validate_or_free_results (results, 32, XA_ATOM, FALSE))
-    return FALSE;  
+    return FALSE;
 
   *atoms_p = (Atom*) results->prop;
   *n_atoms_p = results->n_items;
-  results->prop = NULL;  
-  
+  results->prop = NULL;
+
   return TRUE;
 }
 
@@ -258,12 +258,12 @@ cardinal_list_from_results (GetPropertyResults *results,
                             int                *n_cardinals_p)
 {
   if (!validate_or_free_results (results, 32, XA_CARDINAL, FALSE))
-    return FALSE;  
+    return FALSE;
 
   *cardinals_p = (gulong*) results->prop;
   *n_cardinals_p = results->n_items;
   results->prop = NULL;
-  
+
   return TRUE;
 }
 
@@ -292,8 +292,8 @@ motif_hints_from_results (GetPropertyResults *results,
 {
   int real_size, max_size;
 #define MAX_ITEMS sizeof (MotifWmHints)/sizeof (gulong)
-  
-  *hints_p = NULL;  
+
+  *hints_p = NULL;
 
   if (results->type == None || results->n_items <= 0)
     {
@@ -329,7 +329,7 @@ motif_hints_from_results (GetPropertyResults *results,
       XFree (results->prop);
       results->prop = NULL;
     }
-  
+
   return TRUE;
 }
 
@@ -340,7 +340,7 @@ meta_prop_get_motif_hints (MetaDisplay   *display,
                            MotifWmHints **hints_p)
 {
   GetPropertyResults results;
-  
+
   *hints_p = NULL;
 
   if (!get_property (display, xwindow, xatom, AnyPropertyType,
@@ -355,13 +355,13 @@ latin1_string_from_results (GetPropertyResults *results,
                             char              **str_p)
 {
   *str_p = NULL;
-  
+
   if (!validate_or_free_results (results, 8, XA_STRING, FALSE))
     return FALSE;
 
   *str_p = (char*) results->prop;
   results->prop = NULL;
-  
+
   return TRUE;
 }
 
@@ -378,7 +378,7 @@ meta_prop_get_latin1_string (MetaDisplay *display,
   if (!get_property (display, xwindow, xatom, XA_STRING,
                      &results))
     return FALSE;
-  
+
   return latin1_string_from_results (&results, str_p);
 }
 
@@ -387,7 +387,7 @@ utf8_string_from_results (GetPropertyResults *results,
                           char              **str_p)
 {
   *str_p = NULL;
-  
+
   if (!validate_or_free_results (results, 8,
                                  results->display->atom_UTF8_STRING, FALSE))
     return FALSE;
@@ -403,13 +403,13 @@ utf8_string_from_results (GetPropertyResults *results,
       meta_XFree (name);
       XFree (results->prop);
       results->prop = NULL;
-      
+
       return FALSE;
     }
-  
+
   *str_p = (char*) results->prop;
   results->prop = NULL;
-  
+
   return TRUE;
 }
 
@@ -441,14 +441,14 @@ utf8_list_from_results (GetPropertyResults *results,
   int n_strings;
   char **retval;
   const char *p;
-  
+
   *str_p = NULL;
   *n_str_p = 0;
 
   if (!validate_or_free_results (results, 8,
                                  results->display->atom_UTF8_STRING, FALSE))
     return FALSE;
-  
+
   /* I'm not sure this is right, but I'm guessing the
    * property is nul-separated
    */
@@ -463,11 +463,11 @@ utf8_list_from_results (GetPropertyResults *results,
 
   if (results->prop[results->n_items - 1] != '\0')
     ++n_strings;
- 
+
   /* we're guaranteed that results->prop has a nul on the end
    * by XGetWindowProperty
    */
-  
+
   retval = g_new0 (char*, n_strings + 1);
 
   p = (char *)results->prop;
@@ -486,17 +486,17 @@ utf8_list_from_results (GetPropertyResults *results,
           meta_XFree (name);
           meta_XFree (results->prop);
           results->prop = NULL;
-          
+
           g_strfreev (retval);
           return FALSE;
         }
 
       retval[i] = g_strdup (p);
-      
+
       p = p + strlen (p) + 1;
       ++i;
     }
-  
+
   *str_p = retval;
   *n_str_p = i;
 
@@ -533,9 +533,9 @@ meta_prop_set_utf8_string_hint (MetaDisplay *display,
                                 const char *val)
 {
   meta_error_trap_push (display);
-  XChangeProperty (display->xdisplay, 
+  XChangeProperty (display->xdisplay,
                    xwindow, atom,
-                   display->atom_UTF8_STRING, 
+                   display->atom_UTF8_STRING,
                    8, PropModeReplace, (guchar*) val, strlen (val));
   meta_error_trap_pop (display, FALSE);
 }
@@ -545,12 +545,12 @@ window_from_results (GetPropertyResults *results,
                      Window             *window_p)
 {
   if (!validate_or_free_results (results, 32, XA_WINDOW, TRUE))
-    return FALSE;  
+    return FALSE;
 
   *window_p = *(Window*) results->prop;
   XFree (results->prop);
-  results->prop = NULL;  
-  
+  results->prop = NULL;
+
   return TRUE;
 }
 
@@ -562,12 +562,12 @@ counter_from_results (GetPropertyResults *results,
   if (!validate_or_free_results (results, 32,
                                  XA_CARDINAL,
                                  TRUE))
-    return FALSE;  
+    return FALSE;
 
   *counter_p = *(XSyncCounter*) results->prop;
   XFree (results->prop);
   results->prop = NULL;
-  
+
   return TRUE;
 }
 #endif
@@ -581,7 +581,7 @@ meta_prop_get_window (MetaDisplay *display,
   GetPropertyResults results;
 
   *window_p = None;
-  
+
   if (!get_property (display, xwindow, xatom, XA_WINDOW,
                      &results))
     return FALSE;
@@ -605,12 +605,12 @@ cardinal_with_atom_type_from_results (GetPropertyResults *results,
                                       gulong             *cardinal_p)
 {
   if (!validate_or_free_results (results, 32, prop_type, TRUE))
-    return FALSE;  
+    return FALSE;
 
   *cardinal_p = *(gulong*) results->prop;
   XFree (results->prop);
-  results->prop = NULL;  
-  
+  results->prop = NULL;
+
   return TRUE;
 }
 
@@ -639,19 +639,19 @@ text_property_from_results (GetPropertyResults *results,
   XTextProperty tp;
 
   *utf8_str_p = NULL;
-  
+
   tp.value = results->prop;
   results->prop = NULL;
   tp.encoding = results->type;
   tp.format = results->format;
-  tp.nitems = results->n_items;  
-  
+  tp.nitems = results->n_items;
+
   *utf8_str_p = meta_text_property_to_utf8 (results->display->xdisplay,
                                             &tp);
-  
+
   if (tp.value != NULL)
     XFree (tp.value);
-  
+
   return *utf8_str_p != NULL;
 }
 
@@ -662,7 +662,7 @@ meta_prop_get_text_property (MetaDisplay   *display,
                              char         **utf8_str_p)
 {
   GetPropertyResults results;
-  
+
   if (!get_property (display, xwindow, xatom, AnyPropertyType,
                      &results))
     return FALSE;
@@ -701,13 +701,13 @@ wm_hints_from_results (GetPropertyResults *results,
 {
   XWMHints *hints;
   xPropWMHints *raw;
-  
-  *hints_p = NULL;
-  
-  if (!validate_or_free_results (results, 32, XA_WM_HINTS, TRUE))
-    return FALSE;  
 
-  /* pre-R3 bogusly truncated window_group, don't fail on them */  
+  *hints_p = NULL;
+
+  if (!validate_or_free_results (results, 32, XA_WM_HINTS, TRUE))
+    return FALSE;
+
+  /* pre-R3 bogusly truncated window_group, don't fail on them */
   if (results->n_items < (NumPropWMHintsElements - 1))
     {
       meta_verbose ("WM_HINTS property too short: %d should be %d\n",
@@ -719,11 +719,11 @@ wm_hints_from_results (GetPropertyResults *results,
         }
       return FALSE;
     }
-  
+
   hints = ag_Xmalloc0 (sizeof (XWMHints));
 
   raw = (xPropWMHints*) results->prop;
-  
+
   hints->flags = raw->flags;
   hints->input = (raw->input ? True : False);
   hints->initial_state = cvtINT32toInt (raw->initialState);
@@ -757,7 +757,7 @@ meta_prop_get_wm_hints (MetaDisplay   *display,
   GetPropertyResults results;
 
   *hints_p = NULL;
-  
+
   if (!get_property (display, xwindow, xatom, XA_WM_HINTS,
                      &results))
     return FALSE;
@@ -770,13 +770,13 @@ class_hint_from_results (GetPropertyResults *results,
                          XClassHint         *class_hint)
 {
   int len_name, len_class;
-  
+
   class_hint->res_class = NULL;
   class_hint->res_name = NULL;
-  
+
   if (!validate_or_free_results (results, 8, XA_STRING, FALSE))
     return FALSE;
-  
+
   len_name = strlen ((char *) results->prop);
   if (! (class_hint->res_name = ag_Xmalloc (len_name+1)))
     {
@@ -784,14 +784,14 @@ class_hint_from_results (GetPropertyResults *results,
       results->prop = NULL;
       return FALSE;
     }
-  
+
   strcpy (class_hint->res_name, (char *)results->prop);
 
   if (len_name == (int) results->n_items)
     len_name--;
-  
+
   len_class = strlen ((char *)results->prop + len_name + 1);
-  
+
   if (! (class_hint->res_class = ag_Xmalloc(len_class+1)))
     {
       XFree(class_hint->res_name);
@@ -800,12 +800,12 @@ class_hint_from_results (GetPropertyResults *results,
       results->prop = NULL;
       return FALSE;
     }
-  
+
   strcpy (class_hint->res_class, (char *)results->prop + len_name + 1);
 
   XFree (results->prop);
   results->prop = NULL;
-  
+
   return TRUE;
 }
 
@@ -816,10 +816,10 @@ meta_prop_get_class_hint (MetaDisplay   *display,
                           XClassHint    *class_hint)
 {
   GetPropertyResults results;
-  
+
   class_hint->res_class = NULL;
   class_hint->res_name = NULL;
-  
+
   if (!get_property (display, xwindow, xatom, XA_STRING,
                      &results))
     return FALSE;
@@ -834,10 +834,10 @@ size_hints_from_results (GetPropertyResults *results,
 {
   xPropSizeHints *raw;
   XSizeHints *hints;
-  
+
   *hints_p = NULL;
   *flags_p = 0;
-  
+
   if (!validate_or_free_results (results, 32, XA_WM_SIZE_HINTS, FALSE))
     return FALSE;
 
@@ -847,7 +847,7 @@ size_hints_from_results (GetPropertyResults *results,
   raw = (xPropSizeHints*) results->prop;
 
   hints = ag_Xmalloc (sizeof (XSizeHints));
-  
+
   /* XSizeHints misdeclares these as int instead of long */
   hints->flags = raw->flags;
   hints->x = cvtINT32toInt (raw->x);
@@ -875,12 +875,12 @@ size_hints_from_results (GetPropertyResults *results,
     }
 
   hints->flags &= (*flags_p);	/* get rid of unwanted bits */
-  
+
   XFree (results->prop);
   results->prop = NULL;
 
   *hints_p = hints;
-  
+
   return TRUE;
 }
 
@@ -895,7 +895,7 @@ meta_prop_get_size_hints (MetaDisplay   *display,
 
   *hints_p = NULL;
   *flags_p = 0;
-  
+
   if (!get_property (display, xwindow, xatom, XA_WM_SIZE_HINTS,
                      &results))
     return FALSE;
@@ -920,7 +920,7 @@ latin1_to_utf8 (const char *text)
 {
   GString *str;
   const char *p;
-  
+
   str = g_string_new ("");
 
   p = text;
@@ -944,10 +944,10 @@ meta_prop_get_values (MetaDisplay   *display,
 
   meta_verbose ("Requesting %d properties of 0x%lx at once\n",
                 n_values, xwindow);
-  
+
   if (n_values == 0)
     return;
-  
+
   tasks = g_new0 (AgGetPropertyTask*, n_values);
 
   /* Start up tasks. The "values" array can have values
@@ -1009,22 +1009,22 @@ meta_prop_get_values (MetaDisplay   *display,
       if (values[i].atom != None)
         tasks[i] = get_task (display, xwindow,
                              values[i].atom, values[i].required_type);
-      
+
       ++i;
-    }  
-  
+    }
+
   /* Get replies for all our tasks */
   meta_topic (META_DEBUG_SYNC, "Syncing to get %d GetProperty replies in %s\n",
               n_values, G_STRFUNC);
   XSync (display->xdisplay, False);
-  
+
   /* Collect results, should arrive in order requested */
   i = 0;
   while (i < n_values)
     {
       AgGetPropertyTask *task;
       GetPropertyResults results;
-      
+
       if (tasks[i] == NULL)
         {
           /* Probably values[i].type was None, or ag_task_create()
@@ -1033,7 +1033,7 @@ meta_prop_get_values (MetaDisplay   *display,
           values[i].type = META_PROP_VALUE_INVALID;
           goto next;
         }
-      
+
       task = ag_get_next_completed_task (display->xdisplay);
       g_assert (task != NULL);
       g_assert (ag_task_have_reply (task));
@@ -1046,7 +1046,7 @@ meta_prop_get_values (MetaDisplay   *display,
       results.type = None;
       results.bytes_after = 0;
       results.format = 0;
-      
+
       if (ag_task_get_reply_and_free (task,
                                       &results.type, &results.format,
                                       &results.n_items,
@@ -1179,7 +1179,7 @@ free_value (MetaPropValue *value)
 {
   switch (value->type)
     {
-    case META_PROP_VALUE_INVALID:          
+    case META_PROP_VALUE_INVALID:
       break;
     case META_PROP_VALUE_UTF8:
     case META_PROP_VALUE_STRING:
@@ -1188,10 +1188,10 @@ free_value (MetaPropValue *value)
       break;
     case META_PROP_VALUE_MOTIF_HINTS:
       meta_XFree (value->v.motif_hints);
-      break;          
+      break;
     case META_PROP_VALUE_CARDINAL:
       break;
-    case META_PROP_VALUE_WINDOW:          
+    case META_PROP_VALUE_WINDOW:
       break;
     case META_PROP_VALUE_ATOM_LIST:
       meta_XFree (value->v.atom_list.atoms);

--- a/src/include/all-keybindings.h
+++ b/src/include/all-keybindings.h
@@ -1,8 +1,8 @@
 /* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
 
-/* 
+/*
  * Copyright (C) 2008 Thomas Thurman
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -12,7 +12,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -143,7 +143,7 @@ keybind (cycle-panels, handle_cycle, META_TAB_LIST_DOCKS, BINDING_REVERSES)
 keybind (cycle-panels-backward, handle_cycle, META_TAB_LIST_DOCKS, REVERSES_AND_REVERSED)
 
 /***********************************/
-     
+
 keybind (show-desktop, handle_show_desktop, 0, 0)
 keybind (panel-main-menu, handle_panel, META_KEYBINDING_ACTION_PANEL_MAIN_MENU, 0)
 keybind (panel-run-dialog, handle_panel, META_KEYBINDING_ACTION_PANEL_RUN_DIALOG, 0)
@@ -201,7 +201,7 @@ keybind (set-spew-mark, handle_set_spew_mark, 0, 0)
 /* These take a window as an extra parameter; they have no effect
  * if no window is active.
  */
- 
+
 keybind (activate-window-menu, handle_activate_window_menu, 0, BINDING_PER_WINDOW)
 keybind (toggle-fullscreen, handle_toggle_fullscreen, 0, BINDING_PER_WINDOW)
 keybind (toggle-maximized, handle_toggle_maximized, 0, BINDING_PER_WINDOW)

--- a/src/include/boxes.h
+++ b/src/include/boxes.h
@@ -2,9 +2,9 @@
 
 /* Simple box operations */
 
-/* 
+/*
  * Copyright (C) 2005, 2006 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -75,7 +75,7 @@ struct _MetaEdge
  *   region_to_string: (RECT_LENGTH+strlen(separator_string)) *
  *                     g_list_length (region)
  *   edge_to_string:   EDGE_LENGTH
- *   edge_list_to_...: (EDGE_LENGTH+strlen(separator_string)) * 
+ *   edge_list_to_...: (EDGE_LENGTH+strlen(separator_string)) *
  *                     g_list_length (edge_list)
  */
 #define RECT_LENGTH 27
@@ -253,7 +253,7 @@ void meta_rectangle_find_linepoint_closest_to_point (double x1,    double y1,
 /* Return whether an edge overlaps or is adjacent to the rectangle in the
  * nonzero-width dimension of the edge.
  */
-gboolean meta_rectangle_edge_aligns (const MetaRectangle *rect, 
+gboolean meta_rectangle_edge_aligns (const MetaRectangle *rect,
                                      const MetaEdge      *edge);
 
 /* Compare two edges, so that sorting functions can put a list of edges in

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -2,10 +2,10 @@
 
 /* Marco common types shared by core.h and ui.h */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2005 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -15,7 +15,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -124,12 +124,12 @@ typedef enum
   META_GRAB_OP_KEYBOARD_ESCAPING_DOCK,
 
   META_GRAB_OP_KEYBOARD_ESCAPING_GROUP,
-  
+
   /* Alt+F6 */
   META_GRAB_OP_KEYBOARD_TABBING_GROUP,
-  
+
   META_GRAB_OP_KEYBOARD_WORKSPACE_SWITCHING,
-  
+
   /* Frame button ops */
   META_GRAB_OP_CLICKING_MINIMIZE,
   META_GRAB_OP_CLICKING_MAXIMIZE,
@@ -215,7 +215,7 @@ typedef enum
    */
   META_VIRTUAL_SHIFT_MASK    = 1 << 5,
   META_VIRTUAL_CONTROL_MASK  = 1 << 6,
-  META_VIRTUAL_ALT_MASK      = 1 << 7,  
+  META_VIRTUAL_ALT_MASK      = 1 << 7,
   META_VIRTUAL_META_MASK     = 1 << 8,
   META_VIRTUAL_SUPER_MASK    = 1 << 9,
   META_VIRTUAL_HYPER_MASK    = 1 << 10,

--- a/src/include/core.h
+++ b/src/include/core.h
@@ -2,10 +2,10 @@
 
 /* Marco interface used by GTK+ UI to talk to core */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2005 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -15,7 +15,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA

--- a/src/include/errors.h
+++ b/src/include/errors.h
@@ -2,9 +2,9 @@
 
 /* Marco X error handling */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -37,7 +37,7 @@ void      meta_errors_init     (void);
 void	  meta_errors_register_foreign_display (Display      *foreign_dpy,
 						ErrorHandler  handler,
 						gpointer      data);
-						
+
 void      meta_error_trap_push (MetaDisplay *display);
 void      meta_error_trap_pop  (MetaDisplay *display,
                                 gboolean     last_request_was_roundtrip);

--- a/src/include/main.h
+++ b/src/include/main.h
@@ -2,9 +2,9 @@
 
 /* Marco main */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA

--- a/src/include/prefs.h
+++ b/src/include/prefs.h
@@ -2,10 +2,10 @@
 
 /* Marco preferences */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2006 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -15,7 +15,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA

--- a/src/include/resizepopup.h
+++ b/src/include/resizepopup.h
@@ -2,9 +2,9 @@
 
 /* Marco resizing-terminal-window feedback */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA

--- a/src/include/tabpopup.h
+++ b/src/include/tabpopup.h
@@ -2,10 +2,10 @@
 
 /* Marco tab popup window */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2005 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -15,7 +15,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -38,7 +38,7 @@ typedef void *MetaTabEntryKey;
 
 struct _MetaTabEntry
 {
-  MetaTabEntryKey  key;  
+  MetaTabEntryKey  key;
   const char      *title;
   GdkPixbuf       *icon;
   MetaRectangle    rect;

--- a/src/include/ui.h
+++ b/src/include/ui.h
@@ -2,9 +2,9 @@
 
 /* Marco interface for talking to GTK+ UI module */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA

--- a/src/include/util.h
+++ b/src/include/util.h
@@ -2,10 +2,10 @@
 
 /* Marco utilities */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2005 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -15,7 +15,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA

--- a/src/include/xprops.h
+++ b/src/include/xprops.h
@@ -2,9 +2,9 @@
 
 /* Marco X property convenience routines */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -166,7 +166,7 @@ typedef struct
   MetaPropValueType type;
   Atom atom;
   Atom required_type; /* autofilled if None */
-  
+
   union
   {
     char *str;
@@ -178,13 +178,13 @@ typedef struct
 #ifdef HAVE_XSYNC
     XSyncCounter xcounter;
 #endif
-    
+
     struct
     {
       XSizeHints   *hints;
       unsigned long flags;
     } size_hints;
-    
+
     struct
     {
       gulong *cardinals;
@@ -202,7 +202,7 @@ typedef struct
       Atom *atoms;
       int   n_atoms;
     } atom_list;
-    
+
   } v;
 
 } MetaPropValue;

--- a/src/tools/marco-grayscale.c
+++ b/src/tools/marco-grayscale.c
@@ -1,8 +1,8 @@
 /* Hack for grayscaling an image */
 
-/* 
+/*
  * Copyright (C) 2002 Red Hat Inc.
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -12,7 +12,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -36,15 +36,15 @@ grayscale_pixbuf (GdkPixbuf *pixbuf)
   int row;
   int n_rows;
   int width;
-  
+
   gray = gdk_pixbuf_copy (pixbuf);
   rowstride = gdk_pixbuf_get_rowstride (gray);
   pixstride = gdk_pixbuf_get_has_alpha (gray) ? 4 : 3;
-  
+
   pixels = gdk_pixbuf_get_pixels (gray);
   n_rows = gdk_pixbuf_get_height (gray);
   width = gdk_pixbuf_get_width (gray);
-  
+
   row = 0;
   while (row < n_rows)
     {
@@ -58,13 +58,13 @@ grayscale_pixbuf (GdkPixbuf *pixbuf)
           p[0] = (guchar) v;
           p[1] = (guchar) v;
           p[2] = (guchar) v;
-          
+
           p += pixstride;
         }
-      
+
       ++row;
     }
-  
+
   return gray;
 }
 
@@ -74,7 +74,7 @@ main (int argc, char **argv)
   GdkPixbuf *pixbuf;
   GdkPixbuf *gray;
   GError *err;
-  
+
   if (argc != 2)
     {
       g_printerr ("specify a single image on the command line\n");
@@ -82,7 +82,7 @@ main (int argc, char **argv)
     }
 
   g_type_init ();
-  
+
   err = NULL;
   pixbuf = gdk_pixbuf_new_from_file (argv[1], &err);
   if (err != NULL)
@@ -93,7 +93,7 @@ main (int argc, char **argv)
     }
 
   gray = grayscale_pixbuf (pixbuf);
-  
+
   err = NULL;
   gdk_pixbuf_save (gray, "grayscale.png", "png", &err, NULL);
   if (err != NULL)
@@ -104,6 +104,6 @@ main (int argc, char **argv)
     }
 
   g_print ("wrote grayscale.png\n");
-  
+
   return 0;
 }

--- a/src/tools/marco-mag.c
+++ b/src/tools/marco-mag.c
@@ -1,8 +1,8 @@
 /* Hack for use instead of xmag */
 
-/* 
+/*
  * Copyright (C) 2002 Red Hat Inc.
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -12,7 +12,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -55,10 +55,10 @@ get_pixbuf (void)
   g_print ("Size %d x %d\n",
            last_grab_width, last_grab_height);
 #endif
-  
+
 
   #if GTK_CHECK_VERSION(3, 0, 0)
-  screenshot = gdk_pixbuf_get_from_window(gdk_get_default_root_window(), last_grab_x, last_grab_y, last_grab_width, last_grab_height); 
+  screenshot = gdk_pixbuf_get_from_window(gdk_get_default_root_window(), last_grab_x, last_grab_y, last_grab_width, last_grab_height);
   #else
   screenshot = gdk_pixbuf_get_from_drawable (NULL, gdk_get_default_root_window (),
                                              NULL,
@@ -89,14 +89,14 @@ regrab_idle (GtkWidget *image)
   GtkAllocation allocation;
 
   gtk_widget_get_allocation (image, &allocation);
-  
+
   if (allocation.width != last_grab_allocation.width ||
       allocation.height != last_grab_allocation.height)
     {
       last_grab_width = rint (allocation.width / width_factor);
       last_grab_height = rint (allocation.height / height_factor);
       last_grab_allocation = allocation;
-      
+
       magnified = get_pixbuf ();
 
       gtk_image_set_from_pixbuf (GTK_IMAGE (image), magnified);
@@ -105,7 +105,7 @@ regrab_idle (GtkWidget *image)
     }
 
   regrab_idle_id = 0;
-  
+
   return FALSE;
 }
 
@@ -125,7 +125,7 @@ grab_area_at_mouse (GtkWidget *invisible,
   GdkPixbuf *magnified;
   int width, height;
   GtkWidget *widget;
-  
+
   width = last_grab_width;
   height = last_grab_height;
 
@@ -133,9 +133,9 @@ grab_area_at_mouse (GtkWidget *invisible,
   last_grab_y = y_root;
   last_grab_width = width;
   last_grab_height = height;
-  
+
   magnified = get_pixbuf ();
-  
+
   display_window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
   gtk_window_set_default_size (GTK_WINDOW (display_window),
                                last_grab_width, last_grab_height);
@@ -151,7 +151,7 @@ grab_area_at_mouse (GtkWidget *invisible,
                     G_CALLBACK (gtk_main_quit), NULL);
 
   g_signal_connect_after (G_OBJECT (widget), "size_allocate", G_CALLBACK (image_resized), NULL);
-  
+
   gtk_widget_show_all (display_window);
 }
 
@@ -168,7 +168,7 @@ mouse_motion (GtkWidget      *invisible,
 	      GdkEventMotion *event,
 	      gpointer        data)
 {
-  
+
 }
 
 static gboolean
@@ -182,7 +182,7 @@ mouse_release (GtkWidget      *invisible,
   grab_area_at_mouse (invisible, event->x_root, event->y_root);
 
   shutdown_grab ();
-  
+
   g_signal_handlers_disconnect_by_func (invisible, mouse_motion, NULL);
   g_signal_handlers_disconnect_by_func (invisible, mouse_release, NULL);
 
@@ -199,14 +199,14 @@ static gboolean
 key_press (GtkWidget   *invisible,
            GdkEventKey *event,
            gpointer     data)
-{  
+{
   if (event->keyval == GDK_Escape)
     {
       shutdown_grab ();
 
       g_signal_handlers_disconnect_by_func (invisible, mouse_press, NULL);
       g_signal_handlers_disconnect_by_func (invisible, key_press, NULL);
-      
+
       return TRUE;
     }
 
@@ -217,7 +217,7 @@ static gboolean
 mouse_press (GtkWidget      *invisible,
 	     GdkEventButton *event,
 	     gpointer        data)
-{  
+{
   if (event->type == GDK_BUTTON_PRESS &&
       event->button == 1)
     {
@@ -242,7 +242,7 @@ begin_area_grab (void)
 
       gtk_widget_add_events (grab_widget,
                              GDK_BUTTON_RELEASE_MASK | GDK_BUTTON_PRESS_MASK | GDK_POINTER_MOTION_MASK);
-      
+
       gtk_widget_show (grab_widget);
     }
 
@@ -253,7 +253,7 @@ begin_area_grab (void)
       g_warning ("Failed to grab keyboard to do eyedropper");
       return;
     }
-  
+
   if (gdk_pointer_grab (gtk_widget_get_window (grab_widget),
                         FALSE,
                         GDK_BUTTON_RELEASE_MASK | GDK_BUTTON_PRESS_MASK | GDK_POINTER_MOTION_MASK,
@@ -267,7 +267,7 @@ begin_area_grab (void)
     }
 
   gtk_grab_add (grab_widget);
-  
+
   g_signal_connect (grab_widget, "button_press_event",
                     G_CALLBACK (mouse_press), NULL);
   g_signal_connect (grab_widget, "key_press_event",
@@ -280,8 +280,8 @@ main (int argc, char **argv)
   gtk_init (&argc, &argv);
 
   begin_area_grab ();
-  
+
   gtk_main ();
-  
+
   return 0;
 }

--- a/src/tools/marco-message.c
+++ b/src/tools/marco-message.c
@@ -156,7 +156,7 @@ int
 main (int argc, char **argv)
 {
   bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
-  
+
   gtk_init (&argc, &argv);
 
   if (argc < 2)
@@ -175,13 +175,13 @@ main (int argc, char **argv)
 #ifndef WITH_VERBOSE_MODE
       g_printerr (_("Marco was compiled without support for verbose mode\n"));
       return 1;
-#else      
+#else
       send_toggle_verbose ();
 #endif
     }
   else
     usage ();
-  
+
   return 0;
 }
 

--- a/src/tools/marco-window-demo.c
+++ b/src/tools/marco-window-demo.c
@@ -1,8 +1,8 @@
 /* Marco window types/properties demo app */
 
-/* 
+/*
  * Copyright (C) 2002 Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -12,7 +12,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -40,7 +40,7 @@ set_gdk_window_struts (GdkWindow *window,
                        int        bottom)
 {
   long vals[12];
-  
+
   vals[0] = left;
   vals[1] = right;
   vals[2] = top;
@@ -77,7 +77,7 @@ on_realize_set_struts (GtkWindow *window,
   right = GPOINTER_TO_INT (g_object_get_data (G_OBJECT (window), "meta-strut-right"));
   top = GPOINTER_TO_INT (g_object_get_data (G_OBJECT (window), "meta-strut-top"));
   bottom = GPOINTER_TO_INT (g_object_get_data (G_OBJECT (window), "meta-strut-bottom"));
-  
+
   set_gdk_window_struts (gtk_widget_get_window (GTK_WIDGET (window)),
                          left, right, top, bottom);
 }
@@ -97,11 +97,11 @@ set_gtk_window_struts (GtkWidget  *window,
                      GINT_TO_POINTER (top));
   g_object_set_data (G_OBJECT (window), "meta-strut-bottom",
                      GINT_TO_POINTER (bottom));
-  
+
   g_signal_handlers_disconnect_by_func (G_OBJECT (window),
                                         on_realize_set_struts,
                                         NULL);
-                                
+
   g_signal_connect_after (G_OBJECT (window),
                           "realize",
                           G_CALLBACK (on_realize_set_struts),
@@ -117,15 +117,15 @@ set_gdk_window_type (GdkWindow  *window,
                      const char *type)
 {
   Atom atoms[2] = { None, None };
-  
+
   atoms[0] = XInternAtom (GDK_WINDOW_XDISPLAY (window),
                           type, False);
-  
+
   XChangeProperty (GDK_WINDOW_XDISPLAY (window),
                    GDK_WINDOW_XWINDOW (window),
                    XInternAtom (GDK_WINDOW_XDISPLAY (window), "_NET_WM_WINDOW_TYPE", False),
                    XA_ATOM, 32, PropModeReplace,
-                   (guchar *)atoms, 
+                   (guchar *)atoms,
                    1);
 }
 
@@ -140,7 +140,7 @@ on_realize_set_type (GtkWindow *window,
   type = g_object_get_data (G_OBJECT (window), "meta-window-type");
 
   g_return_if_fail (type != NULL);
-  
+
   set_gdk_window_type (gtk_widget_get_window (GTK_WIDGET (window)),
                        type);
 }
@@ -154,7 +154,7 @@ set_gtk_window_type (GtkWindow  *window,
   g_signal_handlers_disconnect_by_func (G_OBJECT (window),
                                         on_realize_set_type,
                                         NULL);
-                                
+
   g_signal_connect_after (G_OBJECT (window),
                           "realize",
                           G_CALLBACK (on_realize_set_type),
@@ -176,7 +176,7 @@ on_realize_set_border_only (GtkWindow *window,
                             gpointer   data)
 {
   g_return_if_fail (gtk_widget_get_realized (GTK_WIDGET (window)));
-  
+
   set_gdk_window_border_only (gtk_widget_get_window (GTK_WIDGET (window)));
 }
 
@@ -186,7 +186,7 @@ set_gtk_window_border_only (GtkWindow  *window)
   g_signal_handlers_disconnect_by_func (G_OBJECT (window),
                                         on_realize_set_border_only,
                                         NULL);
-                                
+
   g_signal_connect_after (G_OBJECT (window),
                           "realize",
                           G_CALLBACK (on_realize_set_border_only),
@@ -202,7 +202,7 @@ main (int argc, char **argv)
   GList *list;
   GdkPixbuf *pixbuf;
   GError *err;
-  
+
   gtk_init (&argc, &argv);
 
   err = NULL;
@@ -211,7 +211,7 @@ main (int argc, char **argv)
   if (pixbuf)
     {
       list = g_list_prepend (NULL, pixbuf);
-      
+
       gtk_window_set_default_icon_list (list);
       g_list_free (list);
       g_object_unref (G_OBJECT (pixbuf));
@@ -221,11 +221,11 @@ main (int argc, char **argv)
       g_printerr ("Could not load icon: %s\n", err->message);
       g_error_free (err);
     }
-  
+
   do_appwindow ();
 
   gtk_main ();
-  
+
   return 0;
 }
 
@@ -240,7 +240,7 @@ make_dialog (GtkWidget *parent,
 {
   GtkWidget *dialog;
   char *str;
-  
+
   dialog = gtk_message_dialog_new (parent ? GTK_WINDOW (parent) : NULL,
                                    GTK_DIALOG_DESTROY_WITH_PARENT,
                                    GTK_MESSAGE_INFO,
@@ -252,11 +252,11 @@ make_dialog (GtkWidget *parent,
   str = g_strdup_printf ("%d dialog", depth);
   gtk_window_set_title (GTK_WINDOW (dialog), str);
   g_free (str);
-  
+
   gtk_dialog_add_button (GTK_DIALOG (dialog),
                          "Open child dialog",
                          GTK_RESPONSE_ACCEPT);
-  
+
   /* Close dialog on user response */
   g_signal_connect (G_OBJECT (dialog),
                     "response",
@@ -265,7 +265,7 @@ make_dialog (GtkWidget *parent,
 
   g_object_set_data (G_OBJECT (dialog), "depth",
                      GINT_TO_POINTER (depth));
-  
+
   gtk_widget_show (dialog);
 }
 
@@ -302,7 +302,7 @@ modal_dialog_cb (gpointer             callback_data,
                  GtkWidget           *widget)
 {
   GtkWidget *dialog;
-  
+
   dialog = gtk_message_dialog_new (GTK_WINDOW (callback_data),
                                    GTK_DIALOG_DESTROY_WITH_PARENT,
                                    GTK_MESSAGE_INFO,
@@ -310,7 +310,7 @@ modal_dialog_cb (gpointer             callback_data,
                                    "Here is a MODAL dialog");
 
   set_gtk_window_type (GTK_WINDOW (dialog), "_NET_WM_WINDOW_TYPE_MODAL_DIALOG");
-  
+
   gtk_dialog_run (GTK_DIALOG (dialog));
 
   gtk_widget_destroy (dialog);
@@ -332,13 +332,13 @@ utility_cb (gpointer             callback_data,
   GtkWidget *window;
   GtkWidget *vbox;
   GtkWidget *button;
-  
+
   window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
   set_gtk_window_type (GTK_WINDOW (window), "_NET_WM_WINDOW_TYPE_UTILITY");
   gtk_window_set_title (GTK_WINDOW (window), "Utility");
-  
+
   gtk_window_set_transient_for (GTK_WINDOW (window), GTK_WINDOW (callback_data));
-  
+
   vbox = gtk_vbox_new (FALSE, 0);
 
   gtk_container_add (GTK_CONTAINER (window), vbox);
@@ -354,7 +354,7 @@ utility_cb (gpointer             callback_data,
 
   button = gtk_button_new_with_mnemonic ("_D button");
   gtk_box_pack_start (GTK_BOX (vbox), button, FALSE, FALSE, 0);
-  
+
   gtk_widget_show_all (window);
 }
 
@@ -366,20 +366,20 @@ toolbar_cb (gpointer             callback_data,
   GtkWidget *window;
   GtkWidget *vbox;
   GtkWidget *label;
-  
+
   window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
   set_gtk_window_type (GTK_WINDOW (window), "_NET_WM_WINDOW_TYPE_TOOLBAR");
   gtk_window_set_title (GTK_WINDOW (window), "Toolbar");
-  
+
   gtk_window_set_transient_for (GTK_WINDOW (window), GTK_WINDOW (callback_data));
-  
+
   vbox = gtk_vbox_new (FALSE, 0);
 
   gtk_container_add (GTK_CONTAINER (window), vbox);
 
   label = gtk_label_new ("FIXME this needs a resize grip, etc.");
   gtk_box_pack_start (GTK_BOX (vbox), label, FALSE, FALSE, 0);
-  
+
   gtk_widget_show_all (window);
 }
 
@@ -391,20 +391,20 @@ menu_cb (gpointer             callback_data,
   GtkWidget *window;
   GtkWidget *vbox;
   GtkWidget *label;
-  
+
   window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
   set_gtk_window_type (GTK_WINDOW (window), "_NET_WM_WINDOW_TYPE_MENU");
   gtk_window_set_title (GTK_WINDOW (window), "Menu");
-  
+
   gtk_window_set_transient_for (GTK_WINDOW (window), GTK_WINDOW (callback_data));
-  
+
   vbox = gtk_vbox_new (FALSE, 0);
 
   gtk_container_add (GTK_CONTAINER (window), vbox);
 
   label = gtk_label_new ("FIXME this isn't a menu.");
   gtk_box_pack_start (GTK_BOX (vbox), label, FALSE, FALSE, 0);
-  
+
   gtk_widget_show_all (window);
 }
 
@@ -416,17 +416,17 @@ override_redirect_cb (gpointer             callback_data,
   GtkWidget *window;
   GtkWidget *vbox;
   GtkWidget *label;
-  
+
   window = gtk_window_new (GTK_WINDOW_POPUP);
   gtk_window_set_title (GTK_WINDOW (window), "Override Redirect");
-  
+
   vbox = gtk_vbox_new (FALSE, 0);
 
   gtk_container_add (GTK_CONTAINER (window), vbox);
 
   label = gtk_label_new ("This is an override\nredirect window\nand should not be managed");
   gtk_box_pack_start (GTK_BOX (vbox), label, FALSE, FALSE, 0);
-  
+
   gtk_widget_show_all (window);
 }
 
@@ -438,20 +438,20 @@ border_only_cb (gpointer             callback_data,
   GtkWidget *window;
   GtkWidget *vbox;
   GtkWidget *label;
-  
+
   window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
   set_gtk_window_border_only (GTK_WINDOW (window));
   gtk_window_set_title (GTK_WINDOW (window), "Border only");
-  
+
   gtk_window_set_transient_for (GTK_WINDOW (window), GTK_WINDOW (callback_data));
-  
+
   vbox = gtk_vbox_new (FALSE, 0);
 
   gtk_container_add (GTK_CONTAINER (window), vbox);
 
   label = gtk_label_new ("This window is supposed to have a border but no titlebar.");
   gtk_box_pack_start (GTK_BOX (vbox), label, FALSE, FALSE, 0);
-  
+
   gtk_widget_show_all (window);
 }
 
@@ -464,17 +464,17 @@ changing_icon_cb (gpointer             callback_data,
   GtkWidget *window;
   GtkWidget *vbox;
   GtkWidget *label;
-  
+
   window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
   gtk_window_set_title (GTK_WINDOW (window), "Changing Icon");
-  
+
   vbox = gtk_vbox_new (FALSE, 0);
 
   gtk_container_add (GTK_CONTAINER (window), vbox);
 
   label = gtk_label_new ("This window has an icon that changes over time");
   gtk_box_pack_start (GTK_BOX (vbox), label, FALSE, FALSE, 0);
-  
+
   gtk_widget_show_all (window);
 }
 #endif
@@ -504,7 +504,7 @@ focus_out_event_cb (GtkWidget *window,
   widget = GTK_WIDGET (data);
 
   gtk_label_set_text (GTK_LABEL (widget), "Not focused");
-  
+
   return TRUE;
 }
 
@@ -512,7 +512,7 @@ static GtkWidget*
 focus_label (GtkWidget *window)
 {
   GtkWidget *label;
-  
+
   label = gtk_label_new ("Not focused");
 
   g_signal_connect (G_OBJECT (window), "focus_in_event",
@@ -520,7 +520,7 @@ focus_label (GtkWidget *window)
 
   g_signal_connect (G_OBJECT (window), "focus_out_event",
                     G_CALLBACK (focus_out_event_cb), label);
-  
+
   return label;
 }
 
@@ -532,20 +532,20 @@ splashscreen_cb (gpointer             callback_data,
   GtkWidget *window;
   GtkWidget *image;
   GtkWidget *vbox;
-  
+
   window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
   set_gtk_window_type (GTK_WINDOW (window), "_NET_WM_WINDOW_TYPE_SPLASHSCREEN");
   gtk_window_set_title (GTK_WINDOW (window), "Splashscreen");
-  
+
   vbox = gtk_vbox_new (FALSE, 0);
-  
+
   image = gtk_image_new_from_stock (GTK_STOCK_DIALOG_INFO, GTK_ICON_SIZE_DIALOG);
   gtk_box_pack_start (GTK_BOX (vbox), image, FALSE, FALSE, 0);
 
-  gtk_box_pack_start (GTK_BOX (vbox), focus_label (window), FALSE, FALSE, 0);  
-  
+  gtk_box_pack_start (GTK_BOX (vbox), focus_label (window), FALSE, FALSE, 0);
+
   gtk_container_add (GTK_CONTAINER (window), vbox);
-  
+
   gtk_widget_show_all (window);
 }
 
@@ -572,7 +572,7 @@ make_dock (int type)
   switch (type)
     {
     case DOCK_LEFT:
-    case DOCK_RIGHT:      
+    case DOCK_RIGHT:
       box = gtk_vbox_new (FALSE, 0);
       break;
     case DOCK_TOP:
@@ -585,18 +585,18 @@ make_dock (int type)
 
   window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
   set_gtk_window_type (GTK_WINDOW (window), "_NET_WM_WINDOW_TYPE_DOCK");
-  
+
   image = gtk_image_new_from_stock (GTK_STOCK_DIALOG_INFO, GTK_ICON_SIZE_DIALOG);
-  gtk_box_pack_start (GTK_BOX (box), image, FALSE, FALSE, 0);  
-  
-  gtk_box_pack_start (GTK_BOX (box), focus_label (window), FALSE, FALSE, 0);  
+  gtk_box_pack_start (GTK_BOX (box), image, FALSE, FALSE, 0);
+
+  gtk_box_pack_start (GTK_BOX (box), focus_label (window), FALSE, FALSE, 0);
 
   button = gtk_button_new_with_label ("Close");
   gtk_box_pack_start (GTK_BOX (box), button, FALSE, FALSE, 0);
 
   g_signal_connect_swapped (G_OBJECT (button), "clicked",
                             G_CALLBACK (gtk_widget_destroy), window);
-  
+
   gtk_container_add (GTK_CONTAINER (window), box);
 
 #define DOCK_SIZE 48
@@ -608,7 +608,7 @@ make_dock (int type)
       set_gtk_window_struts (window, DOCK_SIZE, 0, 0, 0);
       gtk_window_set_title (GTK_WINDOW (window), "LeftDock");
       break;
-    case DOCK_RIGHT:      
+    case DOCK_RIGHT:
       gtk_widget_set_size_request (window, DOCK_SIZE, 400);
       gtk_window_move (GTK_WINDOW (window), gdk_screen_width () - DOCK_SIZE, 200);
       set_gtk_window_struts (window, 0, DOCK_SIZE, 0, 0);
@@ -629,7 +629,7 @@ make_dock (int type)
     case DOCK_ALL:
       break;
     }
-  
+
   gtk_widget_show_all (window);
 }
 
@@ -678,24 +678,24 @@ desktop_cb (gpointer             callback_data,
   GtkWidget *window;
   GtkWidget *label;
   GdkColor desktop_color;
-  
+
   window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
   set_gtk_window_type (GTK_WINDOW (window), "_NET_WM_WINDOW_TYPE_DESKTOP");
   gtk_window_set_title (GTK_WINDOW (window), "Desktop");
   gtk_widget_set_size_request (window,
                                gdk_screen_width (), gdk_screen_height ());
   gtk_window_move (GTK_WINDOW (window), 0, 0);
-  
+
   desktop_color.red = 0x5144;
   desktop_color.green = 0x75D6;
   desktop_color.blue = 0xA699;
 
   gtk_widget_modify_bg (window, GTK_STATE_NORMAL, &desktop_color);
-  
+
   label = focus_label (window);
-  
+
   gtk_container_add (GTK_CONTAINER (window), label);
-  
+
   gtk_widget_show_all (window);
 }
 
@@ -724,7 +724,7 @@ static gchar ui_definition[] =
 	</menubar>\
 </ui>";
 
-static GtkActionEntry entries[] = 
+static GtkActionEntry entries[] =
 {
 	/*
 	struct GtkActionEntry {
@@ -811,7 +811,7 @@ toggle_aspect_ratio (GtkWidget *button,
 				   GTK_WIDGET (data),
 				   &geom,
 				   GDK_HINT_ASPECT);
-				   
+
 }
 
 static void
@@ -830,7 +830,7 @@ clicked_toolbar_cb (GtkWidget *button,
                     gpointer   data)
 {
   GtkWidget *dialog;
-  
+
   dialog = gtk_message_dialog_new (GTK_WINDOW (data),
                                    GTK_DIALOG_DESTROY_WITH_PARENT,
                                    GTK_MESSAGE_INFO,
@@ -842,7 +842,7 @@ clicked_toolbar_cb (GtkWidget *button,
                     "response",
                     G_CALLBACK (gtk_widget_destroy),
                     NULL);
-  
+
   gtk_widget_show (dialog);
 }
 
@@ -854,7 +854,7 @@ update_statusbar (GtkTextBuffer *buffer,
   gint row, col;
   gint count;
   GtkTextIter iter;
-  
+
   gtk_statusbar_pop (statusbar, 0); /* clear any previous message, underflow is allowed */
 
   count = gtk_text_buffer_get_char_count (buffer);
@@ -909,11 +909,11 @@ do_appwindow (void)
   GtkActionGroup *action_group;
   GtkUIManager *ui_manager;
   #else
-  GtkAccelGroup *accel_group;      
+  GtkAccelGroup *accel_group;
   GtkItemFactory *item_factory;
   #endif
 
-      
+
   /* Create the toplevel window
    */
 
@@ -923,12 +923,12 @@ do_appwindow (void)
 
   window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
   gtk_window_set_title (GTK_WINDOW (window), "Application Window");
-  
+
   g_signal_connect (G_OBJECT (window), "destroy",
                     G_CALLBACK (destroy_cb), NULL);
-      
+
   table = gtk_table_new (1, 4, FALSE);
-      
+
   gtk_container_add (GTK_CONTAINER (window), table);
 
   #if GTK_CHECK_VERSION(3, 0, 0)
@@ -950,14 +950,14 @@ do_appwindow (void)
   gtk_window_add_accel_group (GTK_WINDOW (window), gtk_ui_manager_get_accel_group (ui_manager));
 
   #else
-      
+
   /* Create the menubar
    */
-      
+
   accel_group = gtk_accel_group_new ();
   gtk_window_add_accel_group (GTK_WINDOW (window), accel_group);
   g_object_unref (accel_group);
-      
+
   item_factory = gtk_item_factory_new (GTK_TYPE_MENU_BAR, "<main>", accel_group);
 
   /* Set up item factory to go away with the window */
@@ -994,7 +994,7 @@ do_appwindow (void)
 
   gtk_scrolled_window_set_shadow_type (GTK_SCROLLED_WINDOW (sw),
                                        GTK_SHADOW_IN);
-      
+
   gtk_table_attach (GTK_TABLE (table),
                     sw,
                     /* X direction */       /* Y direction */
@@ -1004,11 +1004,11 @@ do_appwindow (void)
 
   gtk_window_set_default_size (GTK_WINDOW (window),
                                200, 200);
-      
+
   contents = gtk_text_view_new ();
   gtk_text_view_set_wrap_mode (GTK_TEXT_VIEW (contents),
                                PANGO_WRAP_WORD);
-      
+
   gtk_container_add (GTK_CONTAINER (sw),
                      contents);
 
@@ -1026,8 +1026,8 @@ do_appwindow (void)
   gtk_toolbar_insert(GTK_TOOLBAR(toolbar),
 		     newButton,
 		     -1); /*-1 means append to end of toolbar*/
-  
-			    
+
+
   GtkToolItem *lockButton = gtk_tool_button_new_from_stock(GTK_STOCK_OPEN);
   gtk_tool_item_set_tooltip_text(lockButton,
 				 "This is a demo button that locks up the demo");
@@ -1038,7 +1038,7 @@ do_appwindow (void)
   gtk_toolbar_insert(GTK_TOOLBAR(toolbar),
 		     lockButton,
 		     -1); /*-1 means append to end of toolbar*/
-  
+
 
   GtkToolItem *decoButton = gtk_tool_button_new_from_stock(GTK_STOCK_OPEN);
   gtk_tool_item_set_tooltip_text(decoButton,
@@ -1076,7 +1076,7 @@ do_appwindow (void)
   handlebox = gtk_handle_box_new ();
 
   gtk_container_add (GTK_CONTAINER (handlebox), toolbar);
-      
+
   gtk_table_attach (GTK_TABLE (table),
                     handlebox,
                     /* X direction */       /* Y direction */
@@ -1103,7 +1103,7 @@ do_appwindow (void)
                             "Be sure to tear off the menu and toolbar, those are also "
                             "a special kind of window.",
                             -1);
-      
+
   g_signal_connect_object (buffer,
                            "changed",
                            G_CALLBACK (update_statusbar),
@@ -1115,7 +1115,7 @@ do_appwindow (void)
                            G_CALLBACK (mark_set_callback),
                            statusbar,
                            0);
-      
+
   update_statusbar (buffer, GTK_STATUSBAR (statusbar));
 
   gtk_widget_show_all (window);

--- a/src/ui/draw-workspace.c
+++ b/src/ui/draw-workspace.c
@@ -6,9 +6,9 @@
  * libwnck or marco, since it's used in both of them
  */
 
-/* 
+/*
  * Copyright (C) 2002 Red Hat Inc.
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -18,7 +18,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -37,23 +37,23 @@ get_window_rect (const WnckWindowDisplayInfo *win,
 {
   double width_ratio, height_ratio;
   int x, y, width, height;
-  
+
   width_ratio = (double) workspace_rect->width / (double) screen_width;
   height_ratio = (double) workspace_rect->height / (double) screen_height;
-  
+
   x = win->x;
   y = win->y;
   width = win->width;
   height = win->height;
-  
+
   x *= width_ratio;
   y *= height_ratio;
   width *= width_ratio;
   height *= height_ratio;
-  
+
   x += workspace_rect->x;
   y += workspace_rect->y;
-  
+
   if (width < 3)
     width = 3;
   if (height < 3)
@@ -90,7 +90,7 @@ draw_window (GtkWidget                   *widget,
 
   #if GTK_CHECK_VERSION(3, 0, 0)
   cairo_save(cr);
-  #else  
+  #else
   cr = gdk_cairo_create (drawable);
   #endif
 
@@ -116,9 +116,9 @@ draw_window (GtkWidget                   *widget,
   icon = win->icon;
 
   icon_w = icon_h = 0;
-          
+
   if (icon)
-    {              
+    {
       icon_w = gdk_pixbuf_get_width (icon);
       icon_h = gdk_pixbuf_get_height (icon);
 
@@ -134,7 +134,7 @@ draw_window (GtkWidget                   *widget,
             {
               icon_w = gdk_pixbuf_get_width (icon);
               icon_h = gdk_pixbuf_get_height (icon);
-        
+
               /* Give up. */
               if (icon_w > (winrect->width - 2) ||
                   icon_h > (winrect->height - 2))
@@ -147,7 +147,7 @@ draw_window (GtkWidget                   *widget,
     {
       icon_x = winrect->x + (winrect->width - icon_w) / 2;
       icon_y = winrect->y + (winrect->height - icon_h) / 2;
-      
+
       cairo_save (cr);
       gdk_cairo_set_source_pixbuf (cr, icon, icon_x, icon_y);
       cairo_rectangle (cr, icon_x, icon_y, icon_w, icon_h);
@@ -155,7 +155,7 @@ draw_window (GtkWidget                   *widget,
       cairo_paint (cr);
       cairo_restore (cr);
     }
-          
+
   if (is_active)
     color = &style->fg[state];
   else
@@ -170,7 +170,7 @@ draw_window (GtkWidget                   *widget,
                    winrect->x + 0.5, winrect->y + 0.5,
                    MAX (0, winrect->width - 1), MAX (0, winrect->height - 1));
   cairo_stroke (cr);
-  
+
   #if GTK_CHECK_VERSION(3, 0, 0)
   cairo_restore(cr);
   #else
@@ -210,7 +210,7 @@ wnck_draw_workspace (GtkWidget                   *widget,
 
   if (is_active)
     state = GTK_STATE_SELECTED;
-  else if (workspace_background) 
+  else if (workspace_background)
     state = GTK_STATE_PRELIGHT;
   else
     state = GTK_STATE_NORMAL;
@@ -220,7 +220,7 @@ wnck_draw_workspace (GtkWidget                   *widget,
   #else
   cr = gdk_cairo_create (drawable);
   #endif
-  
+
   if (workspace_background)
     {
       gdk_cairo_set_source_pixbuf (cr, workspace_background, x, y);
@@ -236,16 +236,16 @@ wnck_draw_workspace (GtkWidget                   *widget,
   #if !GTK_CHECK_VERSION(3, 0, 0)
   cairo_destroy (cr);
   #endif
-  
+
   i = 0;
   while (i < n_windows)
     {
       const WnckWindowDisplayInfo *win = &windows[i];
       GdkRectangle winrect;
-      
+
       get_window_rect (win, screen_width,
                        screen_height, &workspace_rect, &winrect);
-      
+
       draw_window (widget,
                    #if GTK_CHECK_VERSION(3, 0, 0)
                    cr,
@@ -255,7 +255,7 @@ wnck_draw_workspace (GtkWidget                   *widget,
                    win,
                    &winrect,
                    state);
-      
+
       ++i;
     }
 

--- a/src/ui/draw-workspace.h
+++ b/src/ui/draw-workspace.h
@@ -6,9 +6,9 @@
  * libwnck or marco, since it's used in both of them
  */
 
-/* 
+/*
  * Copyright (C) 2002 Red Hat Inc.
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -18,7 +18,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -42,7 +42,7 @@ typedef struct
   int height;
 
   guint is_active : 1;
-  
+
 } WnckWindowDisplayInfo;
 
 void wnck_draw_workspace (GtkWidget                   *widget,

--- a/src/ui/fixedtip.c
+++ b/src/ui/fixedtip.c
@@ -2,9 +2,9 @@
 
 /* Marco fixed tooltip routine */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -75,7 +75,7 @@ static gint
 expose_handler (GtkTooltips *tooltips)
 {
   gtk_paint_flat_box (gtk_widget_get_style (tip), gtk_widget_get_window (tip),
-                      GTK_STATE_NORMAL, GTK_SHADOW_OUT, 
+                      GTK_STATE_NORMAL, GTK_SHADOW_OUT,
                       NULL, tip, "tooltip",
                       0, 0, -1, -1);
 
@@ -89,9 +89,9 @@ meta_fixed_tip_show (Display *xdisplay, int screen_number,
                      const char *markup_text)
 {
   int w, h;
-  
+
   if (tip == NULL)
-    {      
+    {
       tip = gtk_window_new (GTK_WINDOW_POPUP);
       gtk_window_set_type_hint (GTK_WINDOW(tip), GDK_WINDOW_TYPE_HINT_TOOLTIP);
 
@@ -109,7 +109,7 @@ meta_fixed_tip_show (Display *xdisplay, int screen_number,
 	screen_right_edge = monitor.x + monitor.width;
 	screen_bottom_edge = monitor.y + monitor.height;
       }
-      
+
       gtk_widget_set_app_paintable (tip, TRUE);
       gtk_window_set_resizable (GTK_WINDOW (tip), FALSE);
       gtk_widget_set_name (tip, "gtk-tooltips");
@@ -117,7 +117,7 @@ meta_fixed_tip_show (Display *xdisplay, int screen_number,
 
       #if GTK_CHECK_VERSION(3, 0, 0)
       g_signal_connect (tip, "draw",
-                        G_CALLBACK (draw_handler), NULL);      
+                        G_CALLBACK (draw_handler), NULL);
       #else
       g_signal_connect_swapped (tip, "expose_event",
 				 G_CALLBACK (expose_handler), NULL);
@@ -127,7 +127,7 @@ meta_fixed_tip_show (Display *xdisplay, int screen_number,
       gtk_label_set_line_wrap (GTK_LABEL (label), TRUE);
       gtk_misc_set_alignment (GTK_MISC (label), 0.5, 0.5);
       gtk_widget_show (label);
-      
+
       gtk_container_add (GTK_CONTAINER (tip), label);
 
       g_signal_connect (tip, "destroy",
@@ -135,7 +135,7 @@ meta_fixed_tip_show (Display *xdisplay, int screen_number,
     }
 
   gtk_label_set_markup (GTK_LABEL (label), markup_text);
-  
+
   gtk_window_get_size (GTK_WINDOW (tip), &w, &h);
 
   if (meta_ui_get_direction() == META_UI_DIRECTION_RTL)
@@ -143,7 +143,7 @@ meta_fixed_tip_show (Display *xdisplay, int screen_number,
 
   if ((root_x + w) > screen_right_edge)
     root_x -= (root_x + w) - screen_right_edge;
-  
+
   gtk_window_move (GTK_WINDOW (tip), root_x, root_y);
 
   gtk_widget_show (tip);

--- a/src/ui/fixedtip.h
+++ b/src/ui/fixedtip.h
@@ -1,8 +1,8 @@
 /* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -12,7 +12,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -21,7 +21,7 @@
 
 /**
  * \file fixedtip.h  Marco fixed tooltip routine
- * 
+ *
  * Sometimes we want to display a small floating rectangle with helpful
  * text near the pointer.  For example, if the user holds the mouse over
  * the maximise button, we can display a tooltip saying "Maximize".

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -2232,7 +2232,7 @@ generate_pixmap (MetaFrames            *frames,
   result = gdk_window_create_similar_surface (frame->window,
                                               CAIRO_CONTENT_COLOR,
                                               rect->width, rect->height);
-  
+
   cr = cairo_create (result);
   cairo_translate (cr, -rect->x, -rect->y);
 
@@ -2430,13 +2430,13 @@ cached_pixels_draw (CachedPixels   *pixels,
     {
       CachedFramePiece *piece;
       piece = &pixels->piece[i];
-      
+
       if (piece->pixmap)
         {
           cairo_set_source_surface (cr, piece->pixmap,
                                     piece->rect.x, piece->rect.y);
           cairo_paint (cr);
-          
+
           region_piece = cairo_region_create_rectangle (&piece->rect);
           cairo_region_subtract (region, region_piece);
           cairo_region_destroy (region_piece);
@@ -2486,7 +2486,7 @@ subtract_client_area (cairo_region_t *region, MetaUIFrame *frame)
   MetaFrameType type;
   cairo_region_t *tmp_region;
   Display *display;
-  
+
   display = GDK_DISPLAY_XDISPLAY (gdk_display_get_default ());
 
   meta_core_get (display, frame->xwindow,
@@ -2496,7 +2496,7 @@ subtract_client_area (cairo_region_t *region, MetaUIFrame *frame)
                  META_CORE_GET_CLIENT_HEIGHT, &area.height,
                  META_CORE_GET_END);
   meta_theme_get_frame_borders (meta_theme_get_current (),
-                         type, frame->text_height, flags, 
+                         type, frame->text_height, flags,
                          &area.x, NULL, &area.y, NULL);
 
   tmp_region = cairo_region_create_rectangle (&area);
@@ -2535,11 +2535,11 @@ meta_frames_draw (GtkWidget *widget,
   populate_cache (frames, frame);
 
   region = cairo_region_create_rectangle (&clip);
-  
+
   pixels = get_cache (frames, frame);
 
   cached_pixels_draw (pixels, cr, region);
-  
+
   clip_to_screen (region, frame);
   subtract_client_area (region, frame);
 
@@ -2567,7 +2567,7 @@ meta_frames_draw (GtkWidget *widget,
     }
 
   cairo_region_destroy (region);
-  
+
   return TRUE;
 }
 

--- a/src/ui/frames.h
+++ b/src/ui/frames.h
@@ -2,9 +2,9 @@
 
 /* Marco window frame manager widget */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -86,7 +86,7 @@ struct _MetaUIFrame
   char *title; /* NULL once we have a layout */
   guint expose_delayed : 1;
   guint shape_applied : 1;
-  
+
   /* FIXME get rid of this, it can just be in the MetaFrames struct */
   MetaFrameControl prelit_control;
 };
@@ -98,7 +98,7 @@ struct _MetaFrames
 #else
   GtkWindow parent_instance;
 #endif
-  
+
   GHashTable *text_heights;
 
   GHashTable *frames;

--- a/src/ui/gradient.c
+++ b/src/ui/gradient.c
@@ -2,11 +2,11 @@
 
 /* Marco gradient rendering */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington, 99% copied from wrlib in
  * WindowMaker, Copyright (C) 1997-2000 Dan Pascu and Alfredo Kojima
  * Copyright (C) 2005 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -16,7 +16,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -74,7 +74,7 @@ blank_pixbuf (int width, int height, gboolean no_padding)
   if (no_padding)
     rowstride = width * 3;
   else
-    /* Always align rows to 32-bit boundaries */  
+    /* Always align rows to 32-bit boundaries */
     rowstride = 4 * ((3 * width + 3) / 4);
 
   buf = g_try_malloc (height * rowstride);
@@ -163,7 +163,7 @@ meta_gradient_create_interwoven (int            width,
                                  const GdkColor colors2[2],
                                  int            thickness2)
 {
-  
+
   int i, j, k, l, ll;
   long r1, g1, b1, dr1, dg1, db1;
   long r2, g2, b2, dr2, dg2, db2;
@@ -171,14 +171,14 @@ meta_gradient_create_interwoven (int            width,
   unsigned char *ptr;
   unsigned char *pixels;
   int rowstride;
-  
+
   pixbuf = blank_pixbuf (width, height, FALSE);
   if (pixbuf == NULL)
     return NULL;
-    
+
   pixels = gdk_pixbuf_get_pixels (pixbuf);
   rowstride = gdk_pixbuf_get_rowstride (pixbuf);
-  
+
   r1 = colors1[0].red<<8;
   g1 = colors1[0].green<<8;
   b1 = colors1[0].blue<<8;
@@ -198,7 +198,7 @@ meta_gradient_create_interwoven (int            width,
   for (i=0,k=0,l=0,ll=thickness1; i<height; i++)
     {
       ptr = pixels + i * rowstride;
-      
+
       if (k == 0)
         {
           ptr[0] = (unsigned char) (r1>>16);
@@ -233,7 +233,7 @@ meta_gradient_create_interwoven (int            width,
       r1+=dr1;
       g1+=dg1;
       b1+=db1;
-	
+
       r2+=dr2;
       g2+=dg2;
       b2+=db2;
@@ -246,20 +246,20 @@ meta_gradient_create_interwoven (int            width,
  *----------------------------------------------------------------------
  * meta_gradient_create_horizontal--
  * 	Renders a horizontal linear gradient of the specified size in the
- * GdkPixbuf format with a border of the specified type. 
- * 
+ * GdkPixbuf format with a border of the specified type.
+ *
  * Returns:
  * 	A 24bit GdkPixbuf with the gradient (no alpha channel).
- * 
+ *
  * Side effects:
  * 	None
- *---------------------------------------------------------------------- 
+ *----------------------------------------------------------------------
  */
 static GdkPixbuf*
 meta_gradient_create_horizontal (int width, int height,
                                  const GdkColor *from,
                                  const GdkColor *to)
-{    
+{
   int i;
   long r, g, b, dr, dg, db;
   GdkPixbuf *pixbuf;
@@ -272,22 +272,22 @@ meta_gradient_create_horizontal (int width, int height,
   pixbuf = blank_pixbuf (width, height, FALSE);
   if (pixbuf == NULL)
     return NULL;
-    
+
   pixels = gdk_pixbuf_get_pixels (pixbuf);
   ptr = pixels;
   rowstride = gdk_pixbuf_get_rowstride (pixbuf);
-  
+
   r0 = (guchar) (from->red / 256.0);
   g0 = (guchar) (from->green / 256.0);
   b0 = (guchar) (from->blue / 256.0);
   rf = (guchar) (to->red / 256.0);
   gf = (guchar) (to->green / 256.0);
-  bf = (guchar) (to->blue / 256.0);  
-  
+  bf = (guchar) (to->blue / 256.0);
+
   r = r0 << 16;
   g = g0 << 16;
   b = b0 << 16;
-    
+
   dr = ((rf-r0)<<16)/(int)width;
   dg = ((gf-g0)<<16)/(int)width;
   db = ((bf-b0)<<16)/(int)width;
@@ -336,21 +336,21 @@ meta_gradient_create_vertical (int width, int height,
   int rf, gf, bf;
   int rowstride;
   unsigned char *pixels;
-  
+
   pixbuf = blank_pixbuf (width, height, FALSE);
   if (pixbuf == NULL)
     return NULL;
-    
+
   pixels = gdk_pixbuf_get_pixels (pixbuf);
   rowstride = gdk_pixbuf_get_rowstride (pixbuf);
-  
+
   r0 = (guchar) (from->red / 256.0);
   g0 = (guchar) (from->green / 256.0);
   b0 = (guchar) (from->blue / 256.0);
   rf = (guchar) (to->red / 256.0);
   gf = (guchar) (to->green / 256.0);
   bf = (guchar) (to->blue / 256.0);
-  
+
   r = r0<<16;
   g = g0<<16;
   b = b0<<16;
@@ -362,7 +362,7 @@ meta_gradient_create_vertical (int width, int height,
   for (i=0; i<height; i++)
     {
       ptr = pixels + i * rowstride;
-      
+
       ptr[0] = (unsigned char)(r>>16);
       ptr[1] = (unsigned char)(g>>16);
       ptr[2] = (unsigned char)(b>>16);
@@ -405,7 +405,7 @@ meta_gradient_create_diagonal (int width, int height,
   unsigned char *ptr;
   unsigned char *pixels;
   int rowstride;
-  
+
   if (width == 1)
     return meta_gradient_create_vertical (width, height, from, to);
   else if (height == 1)
@@ -414,7 +414,7 @@ meta_gradient_create_diagonal (int width, int height,
   pixbuf = blank_pixbuf (width, height, FALSE);
   if (pixbuf == NULL)
     return NULL;
-    
+
   pixels = gdk_pixbuf_get_pixels (pixbuf);
   rowstride = gdk_pixbuf_get_rowstride (pixbuf);
 
@@ -452,27 +452,27 @@ meta_gradient_create_multi_horizontal (int width, int height,
   GdkPixbuf *pixbuf;
   unsigned char *ptr;
   unsigned char *pixels;
-  int width2;  
+  int width2;
   int rowstride;
-  
+
   g_return_val_if_fail (count > 2, NULL);
 
   pixbuf = blank_pixbuf (width, height, FALSE);
   if (pixbuf == NULL)
     return NULL;
-    
+
   pixels = gdk_pixbuf_get_pixels (pixbuf);
   rowstride = gdk_pixbuf_get_rowstride (pixbuf);
   ptr = pixels;
-    
+
   if (count > width)
     count = width;
-    
+
   if (count > 1)
     width2 = width/(count-1);
   else
     width2 = width;
-    
+
   k = 0;
 
   r = colors[0].red << 8;
@@ -505,7 +505,7 @@ meta_gradient_create_multi_horizontal (int width, int height,
       *ptr++ = (unsigned char)(g>>16);
       *ptr++ = (unsigned char)(b>>16);
     }
-    
+
   /* copy the first line to the other lines */
   for (i=1; i<height; i++)
     {
@@ -526,25 +526,25 @@ meta_gradient_create_multi_vertical (int width, int height,
   int height2;
   int x;
   int rowstride;
-  
+
   g_return_val_if_fail (count > 2, NULL);
 
   pixbuf = blank_pixbuf (width, height, FALSE);
   if (pixbuf == NULL)
     return NULL;
-    
+
   pixels = gdk_pixbuf_get_pixels (pixbuf);
   rowstride = gdk_pixbuf_get_rowstride (pixbuf);
   ptr = pixels;
-    
+
   if (count > height)
     count = height;
-    
+
   if (count > 1)
     height2 = height/(count-1);
   else
     height2 = height;
-    
+
   k = 0;
 
   r = colors[0].red << 8;
@@ -568,7 +568,7 @@ meta_gradient_create_multi_vertical (int width, int height,
           memcpy (&(ptr[x*3]), ptr, (width - x)*3);
 
           ptr += rowstride;
-          
+
           r += dr;
           g += dg;
           b += db;
@@ -592,14 +592,14 @@ meta_gradient_create_multi_vertical (int width, int height,
       memcpy (&(ptr[x*3]), ptr, (width - x)*3);
 
       ptr += rowstride;
-      
+
       for (j=k+1; j<height; j++)
         {
           memcpy (ptr, tmp, rowstride);
           ptr += rowstride;
         }
     }
-    
+
   return pixbuf;
 }
 
@@ -615,7 +615,7 @@ meta_gradient_create_multi_diagonal (int width, int height,
   unsigned char *ptr;
   unsigned char *pixels;
   int rowstride;
-  
+
   g_return_val_if_fail (count > 2, NULL);
 
   if (width == 1)
@@ -627,10 +627,10 @@ meta_gradient_create_multi_diagonal (int width, int height,
                            width, height);
   if (pixbuf == NULL)
     return NULL;
-    
+
   pixels = gdk_pixbuf_get_pixels (pixbuf);
   rowstride = gdk_pixbuf_get_rowstride (pixbuf);
-  
+
   if (count > width)
     count = width;
   if (count > height)
@@ -677,12 +677,12 @@ simple_multiply_alpha (GdkPixbuf *pixbuf,
   int row;
 
   g_return_if_fail (GDK_IS_PIXBUF (pixbuf));
-  
+
   if (alpha == 255)
     return;
-  
+
   g_assert (gdk_pixbuf_get_has_alpha (pixbuf));
-  
+
   pixels = gdk_pixbuf_get_pixels (pixbuf);
   rowstride = gdk_pixbuf_get_rowstride (pixbuf);
   height = gdk_pixbuf_get_height (pixbuf);
@@ -707,7 +707,7 @@ simple_multiply_alpha (GdkPixbuf *pixbuf,
            */
           /* ((*p / 255.0) * (alpha / 255.0)) * 255; */
           *p = (guchar) (((int) *p * (int) alpha) / (int) 255);
-          
+
           ++p; /* skip A */
         }
 
@@ -724,13 +724,13 @@ meta_gradient_add_alpha_horizontal (GdkPixbuf           *pixbuf,
   long a, da;
   unsigned char *p;
   unsigned char *pixels;
-  int width2;  
+  int width2;
   int rowstride;
   int width, height;
   unsigned char *gradient;
   unsigned char *gradient_p;
   unsigned char *gradient_end;
-  
+
   g_return_if_fail (n_alphas > 0);
 
   if (n_alphas == 1)
@@ -739,24 +739,24 @@ meta_gradient_add_alpha_horizontal (GdkPixbuf           *pixbuf,
       simple_multiply_alpha (pixbuf, alphas[0]);
       return;
     }
-  
+
   width = gdk_pixbuf_get_width (pixbuf);
   height = gdk_pixbuf_get_height (pixbuf);
 
   gradient = g_new (unsigned char, width);
   gradient_end = gradient + width;
-  
+
   if (n_alphas > width)
     n_alphas = width;
-    
+
   if (n_alphas > 1)
     width2 = width / (n_alphas - 1);
   else
     width2 = width;
-    
+
   a = alphas[0] << 8;
   gradient_p = gradient;
-  
+
   /* render the gradient into an array */
   for (i = 1; i < n_alphas; i++)
     {
@@ -765,7 +765,7 @@ meta_gradient_add_alpha_horizontal (GdkPixbuf           *pixbuf,
       for (j = 0; j < width2; j++)
         {
           *gradient_p++ = (a >> 8);
-          
+
           a += da;
 	}
 
@@ -777,11 +777,11 @@ meta_gradient_add_alpha_horizontal (GdkPixbuf           *pixbuf,
     {
       *gradient_p++ = a >> 8;
     }
-    
+
   /* Now for each line of the pixbuf, fill in with the gradient */
   pixels = gdk_pixbuf_get_pixels (pixbuf);
   rowstride = gdk_pixbuf_get_rowstride (pixbuf);
-  
+
   p = pixels;
   i = 0;
   while (i < height)
@@ -807,7 +807,7 @@ meta_gradient_add_alpha_horizontal (GdkPixbuf           *pixbuf,
       p = row_end;
       ++i;
     }
-  
+
   g_free (gradient);
 }
 
@@ -820,21 +820,21 @@ meta_gradient_add_alpha (GdkPixbuf       *pixbuf,
   g_return_if_fail (GDK_IS_PIXBUF (pixbuf));
   g_return_if_fail (gdk_pixbuf_get_has_alpha (pixbuf));
   g_return_if_fail (n_alphas > 0);
-  
+
   switch (type)
     {
     case META_GRADIENT_HORIZONTAL:
       meta_gradient_add_alpha_horizontal (pixbuf, alphas, n_alphas);
       break;
-      
+
     case META_GRADIENT_VERTICAL:
       g_printerr ("marco: vertical alpha channel gradient not implemented yet\n");
       break;
-      
+
     case META_GRADIENT_DIAGONAL:
       g_printerr ("marco: diagonal alpha channel gradient not implemented yet\n");
       break;
-      
+
     case META_GRADIENT_LAST:
       g_assert_not_reached ();
       break;

--- a/src/ui/gradient.h
+++ b/src/ui/gradient.h
@@ -2,10 +2,10 @@
 
 /* Marco gradient rendering */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington, 99% copied from wrlib in
  * WindowMaker, Copyright (C) 1997-2000 Dan Pascu and Alfredo Kojima
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -15,7 +15,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA

--- a/src/ui/metaaccellabel.c
+++ b/src/ui/metaaccellabel.c
@@ -362,9 +362,9 @@ meta_accel_label_draw (GtkWidget *widget,
         cairo_translate (cr, ac_width, 0);
       if (gtk_label_get_ellipsize (label))
         pango_layout_set_width (label_layout,
-                                pango_layout_get_width (label_layout) 
+                                pango_layout_get_width (label_layout)
                                 - ac_width * PANGO_SCALE);
-      
+
       allocation.width -= ac_width;
       gtk_widget_set_allocation (widget, &allocation);
       if (GTK_WIDGET_CLASS (meta_accel_label_parent_class)->draw)
@@ -374,7 +374,7 @@ meta_accel_label_draw (GtkWidget *widget,
       gtk_widget_set_allocation (widget, &allocation);
       if (gtk_label_get_ellipsize (label))
         pango_layout_set_width (label_layout,
-                                pango_layout_get_width (label_layout) 
+                                pango_layout_get_width (label_layout)
                                 + ac_width * PANGO_SCALE);
 
       cairo_restore (cr);
@@ -409,7 +409,7 @@ meta_accel_label_draw (GtkWidget *widget,
       if (GTK_WIDGET_CLASS (meta_accel_label_parent_class)->draw)
         GTK_WIDGET_CLASS (meta_accel_label_parent_class)->draw (widget, cr);
     }
-  
+
   return FALSE;
 }
 

--- a/src/ui/preview-widget.c
+++ b/src/ui/preview-widget.c
@@ -2,9 +2,9 @@
 
 /* Marco theme preview widget */
 
-/* 
+/*
  * Copyright (C) 2002 Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -122,7 +122,7 @@ static void
 meta_preview_init (MetaPreview *preview)
 {
   int i;
-  
+
   gtk_widget_set_has_window (GTK_WIDGET (preview), FALSE);
 
   i = 0;
@@ -132,13 +132,13 @@ meta_preview_init (MetaPreview *preview)
       preview->button_layout.right_buttons[i] = META_BUTTON_FUNCTION_LAST;
       ++i;
     }
-  
+
   preview->button_layout.left_buttons[0] = META_BUTTON_FUNCTION_MENU;
 
   preview->button_layout.right_buttons[0] = META_BUTTON_FUNCTION_MINIMIZE;
   preview->button_layout.right_buttons[1] = META_BUTTON_FUNCTION_MAXIMIZE;
   preview->button_layout.right_buttons[2] = META_BUTTON_FUNCTION_CLOSE;
-  
+
   preview->type = META_FRAME_TYPE_NORMAL;
   preview->flags =
     META_FRAME_ALLOWS_DELETE |
@@ -150,7 +150,7 @@ meta_preview_init (MetaPreview *preview)
     META_FRAME_HAS_FOCUS |
     META_FRAME_ALLOWS_SHADE |
     META_FRAME_ALLOWS_MOVE;
-  
+
   preview->left_width = -1;
   preview->right_width = -1;
   preview->top_height = -1;
@@ -161,13 +161,13 @@ GtkWidget*
 meta_preview_new (void)
 {
   MetaPreview *preview;
-  
+
   #if GTK_CHECK_VERSION(3, 0, 0)
   preview = g_object_new (META_TYPE_PREVIEW, NULL);
   #else
   preview = gtk_type_new (META_TYPE_PREVIEW);
   #endif
-  
+
   return GTK_WIDGET (preview);
 }
 
@@ -180,7 +180,7 @@ meta_preview_finalize (GObject *object)
 
   g_free (preview->title);
   preview->title = NULL;
-  
+
   G_OBJECT_CLASS (parent_class)->finalize (object);
 }
 
@@ -190,7 +190,7 @@ ensure_info (MetaPreview *preview)
   GtkWidget *widget;
 
   widget = GTK_WIDGET (preview);
-  
+
   if (preview->layout == NULL)
     {
       PangoFontDescription *font_desc;
@@ -198,34 +198,34 @@ ensure_info (MetaPreview *preview)
       PangoAttrList *attrs;
       PangoAttribute *attr;
 
-      if (preview->theme)        
+      if (preview->theme)
         scale = meta_theme_get_title_scale (preview->theme,
                                             preview->type,
                                             preview->flags);
       else
         scale = 1.0;
-      
+
       preview->layout = gtk_widget_create_pango_layout (widget,
                                                         preview->title);
-      
+
       font_desc = meta_gtk_widget_get_font_desc (widget, scale, NULL);
-      
+
       preview->text_height =
         meta_pango_font_desc_get_text_height (font_desc,
                                               gtk_widget_get_pango_context (widget));
-          
+
       attrs = pango_attr_list_new ();
-      
+
       attr = pango_attr_size_new (pango_font_description_get_size (font_desc));
       attr->start_index = 0;
       attr->end_index = G_MAXINT;
-      
+
       pango_attr_list_insert (attrs, attr);
-      
+
       pango_layout_set_attributes (preview->layout, attrs);
-      
-      pango_attr_list_unref (attrs);      
-  
+
+      pango_attr_list_unref (attrs);
+
       pango_font_description_free (font_desc);
     }
 
@@ -341,7 +341,7 @@ meta_preview_draw(GtkWidget   *widget,
     META_BUTTON_STATE_NORMAL,
     META_BUTTON_STATE_NORMAL
   };
-  
+
   g_return_val_if_fail (META_IS_PREVIEW (widget), FALSE);
 
   preview = META_PREVIEW (widget);
@@ -351,7 +351,7 @@ meta_preview_draw(GtkWidget   *widget,
   cairo_save (cr);
 
   border_width = gtk_container_get_border_width (GTK_CONTAINER (widget));
-  
+
   gtk_widget_get_allocation (widget, &allocation);
   client_width = allocation.width - preview->left_width - preview->right_width - border_width * 2;
   client_height = allocation.height - preview->top_height - preview->bottom_height - border_width * 2;
@@ -359,8 +359,8 @@ meta_preview_draw(GtkWidget   *widget,
   if (client_width < 0)
     client_width = 1;
   if (client_height < 0)
-    client_height = 1;  
-  
+    client_height = 1;
+
   if (preview->theme)
     {
       border_width = gtk_container_get_border_width (GTK_CONTAINER (widget));
@@ -403,7 +403,7 @@ meta_preview_expose (GtkWidget      *widget,
     META_BUTTON_STATE_NORMAL,
     META_BUTTON_STATE_NORMAL
   };
-  
+
   g_return_val_if_fail (META_IS_PREVIEW (widget), FALSE);
   g_return_val_if_fail (event != NULL, FALSE);
 
@@ -412,7 +412,7 @@ meta_preview_expose (GtkWidget      *widget,
   ensure_info (preview);
 
   border_width = gtk_container_get_border_width (GTK_CONTAINER (widget));
-  
+
   gtk_widget_get_allocation (widget, &allocation);
   client_width = allocation.width - preview->left_width - preview->right_width - border_width * 2;
   client_height = allocation.height - preview->top_height - preview->bottom_height - border_width * 2;
@@ -420,12 +420,12 @@ meta_preview_expose (GtkWidget      *widget,
   if (client_width < 0)
     client_width = 1;
   if (client_height < 0)
-    client_height = 1;  
-  
+    client_height = 1;
+
   if (preview->theme)
     {
       border_width = gtk_container_get_border_width (GTK_CONTAINER (widget));
-      
+
       meta_theme_draw_frame (preview->theme,
                              widget,
                              gtk_widget_get_window (widget),
@@ -464,7 +464,7 @@ meta_preview_size_request (GtkWidget      *widget,
 
   req->width = preview->left_width + preview->right_width;
   req->height = preview->top_height + preview->bottom_height;
-  
+
   child = gtk_bin_get_child (GTK_BIN (preview));
   if (child &&
       gtk_widget_get_visible (child))
@@ -500,11 +500,11 @@ meta_preview_size_allocate (GtkWidget         *widget,
   GtkAllocation child_allocation;
 #endif
   GtkWidget *child;
-  
+
   preview = META_PREVIEW (widget);
 
   ensure_info (preview);
-  
+
 #if GTK_CHECK_VERSION(3, 0, 0)
   gtk_widget_set_allocation (widget, allocation);
 #else
@@ -512,7 +512,7 @@ meta_preview_size_allocate (GtkWidget         *widget,
 #endif
 
   border_width = gtk_container_get_border_width (GTK_CONTAINER (widget));
-  
+
   child = gtk_bin_get_child (GTK_BIN (widget));
   if (child &&
       gtk_widget_get_visible (child))
@@ -521,13 +521,13 @@ meta_preview_size_allocate (GtkWidget         *widget,
       gtk_widget_get_allocation (widget, &widget_allocation);
       child_allocation.x = widget_allocation.x + border_width + preview->left_width;
       child_allocation.y = widget_allocation.y + border_width + preview->top_height;
-      
+
       child_allocation.width = MAX (1, widget_allocation.width - border_width * 2 - preview->left_width - preview->right_width);
       child_allocation.height = MAX (1, widget_allocation.height - border_width * 2 - preview->top_height - preview->bottom_height);
 #else
       child_allocation.x = allocation->x + border_width + preview->left_width;
       child_allocation.y = allocation->y + border_width + preview->top_height;
-      
+
       child_allocation.width = MAX (1, allocation->width - border_width * 2 - preview->left_width - preview->right_width);
       child_allocation.height = MAX (1, allocation->height - border_width * 2 - preview->top_height - preview->bottom_height);
 #endif
@@ -557,7 +557,7 @@ meta_preview_set_theme (MetaPreview    *preview,
   g_return_if_fail (META_IS_PREVIEW (preview));
 
   preview->theme = theme;
-  
+
   clear_cache (preview);
 
   gtk_widget_queue_resize (GTK_WIDGET (preview));
@@ -571,7 +571,7 @@ meta_preview_set_title (MetaPreview    *preview,
 
   g_free (preview->title);
   preview->title = g_strdup (title);
-  
+
   clear_cache (preview);
 
   gtk_widget_queue_resize (GTK_WIDGET (preview));
@@ -608,9 +608,9 @@ meta_preview_set_button_layout (MetaPreview            *preview,
                                 const MetaButtonLayout *button_layout)
 {
   g_return_if_fail (META_IS_PREVIEW (preview));
-  
-  preview->button_layout = *button_layout;  
-  
+
+  preview->button_layout = *button_layout;
+
   gtk_widget_queue_draw (GTK_WIDGET (preview));
 }
 
@@ -643,7 +643,7 @@ meta_preview_get_icon (void)
 
       g_assert (default_icon);
     }
-  
+
   return default_icon;
 }
 
@@ -676,7 +676,7 @@ meta_preview_get_mini_icon (void)
 
       g_assert (default_icon);
     }
-  
+
   return default_icon;
 }
 

--- a/src/ui/preview-widget.h
+++ b/src/ui/preview-widget.h
@@ -2,9 +2,9 @@
 
 /* Marco theme preview widget */
 
-/* 
+/*
  * Copyright (C) 2002 Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -53,7 +53,7 @@ struct _MetaPreview
   MetaTheme *theme;
   char *title;
   MetaFrameType type;
-  MetaFrameFlags flags;  
+  MetaFrameFlags flags;
 
   PangoLayout *layout;
   int text_height;

--- a/src/ui/resizepopup.c
+++ b/src/ui/resizepopup.c
@@ -2,9 +2,9 @@
 
 /* Marco resizing-terminal-window feedback */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -36,13 +36,13 @@ struct _MetaResizePopup
   GtkWidget *size_window;
   GtkWidget *size_label;
   Display *display;
-  int screen_number;  
+  int screen_number;
 
   int vertical_size;
   int horizontal_size;
-  
+
   gboolean showing;
-  
+
   MetaRectangle rect;
 };
 
@@ -56,7 +56,7 @@ meta_ui_resize_popup_new (Display *display,
 
   popup->display = display;
   popup->screen_number = screen_number;
-  
+
   return popup;
 }
 
@@ -64,10 +64,10 @@ void
 meta_ui_resize_popup_free (MetaResizePopup *popup)
 {
   g_return_if_fail (popup != NULL);
-  
+
   if (popup->size_window)
     gtk_widget_destroy (popup->size_window);
-  
+
   g_free (popup);
 }
 
@@ -75,20 +75,20 @@ static void
 ensure_size_window (MetaResizePopup *popup)
 {
   GtkWidget *frame;
-  
+
   if (popup->size_window)
     return;
-  
+
   popup->size_window = gtk_window_new (GTK_WINDOW_POPUP);
 
   gtk_window_set_screen (GTK_WINDOW (popup->size_window),
 			 gdk_display_get_screen (gdk_x11_lookup_xdisplay (popup->display),
 						 popup->screen_number));
-  
+
   /* never shrink the size window */
   gtk_window_set_resizable (GTK_WINDOW (popup->size_window),
                             TRUE);
-  
+
   frame = gtk_frame_new (NULL);
   gtk_frame_set_shadow_type (GTK_FRAME (frame), GTK_SHADOW_OUT);
 
@@ -108,9 +108,9 @@ update_size_window (MetaResizePopup *popup)
   char *str;
   int x, y;
   int width, height;
-  
+
   g_return_if_fail (popup->size_window != NULL);
-  
+
   /* Translators: This represents the size of a window.  The first number is
    * the width of the window and the second is the height.
    */
@@ -126,7 +126,7 @@ update_size_window (MetaResizePopup *popup)
 
   x = popup->rect.x + (popup->rect.width - width) / 2;
   y = popup->rect.y + (popup->rect.height - height) / 2;
-  
+
   if (GTK_WIDGET_REALIZED (popup->size_window))
     {
       /* using move_resize to avoid jumpiness */
@@ -154,7 +154,7 @@ sync_showing (MetaResizePopup *popup)
     {
       if (popup->size_window)
         gtk_widget_show (popup->size_window);
-      
+
       if (popup->size_window && GTK_WIDGET_REALIZED (popup->size_window))
         #if GTK_CHECK_VERSION(3, 0, 0)
         gdk_window_raise (gtk_widget_get_window(GTK_WIDGET(popup->size_window)));
@@ -179,11 +179,11 @@ meta_ui_resize_popup_set (MetaResizePopup *popup,
 {
   gboolean need_update_size;
   int display_w, display_h;
-  
+
   g_return_if_fail (popup != NULL);
 
   need_update_size = FALSE;
-  
+
   display_w = rect.width - base_width;
   if (width_inc > 0)
     display_w /= width_inc;
@@ -196,17 +196,17 @@ meta_ui_resize_popup_set (MetaResizePopup *popup,
       display_w != popup->horizontal_size ||
       display_h != popup->vertical_size)
     need_update_size = TRUE;
-  
+
   popup->rect = rect;
   popup->vertical_size = display_h;
   popup->horizontal_size = display_w;
-  
+
   if (need_update_size)
     {
       ensure_size_window (popup);
       update_size_window (popup);
     }
-      
+
   sync_showing (popup);
 }
 
@@ -215,7 +215,7 @@ meta_ui_resize_popup_set_showing  (MetaResizePopup *popup,
                                    gboolean         showing)
 {
   g_return_if_fail (popup != NULL);
-  
+
   if (showing == popup->showing)
     return;
 
@@ -226,6 +226,6 @@ meta_ui_resize_popup_set_showing  (MetaResizePopup *popup,
       ensure_size_window (popup);
       update_size_window (popup);
     }
-  
+
   sync_showing (popup);
 }

--- a/src/ui/tabpopup.c
+++ b/src/ui/tabpopup.c
@@ -2,11 +2,11 @@
 
 /* Marco popup window thing showing windows you can tab to */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
  * Copyright (C) 2002 Red Hat, Inc.
  * Copyright (C) 2005 Elijah Newren
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -16,7 +16,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -85,11 +85,11 @@ outline_window_expose (GtkWidget      *widget,
                        gpointer        data)
 {
   MetaTabPopup *popup;
-  TabEntry *te;  
+  TabEntry *te;
   GtkStyle *style;
   GdkWindow *window;
   cairo_t *cr;
-  
+
   popup = data;
 
   if (!popup->outline || popup->current_selected_entry == NULL)
@@ -99,7 +99,7 @@ outline_window_expose (GtkWidget      *widget,
   window = gtk_widget_get_window (widget);
   style = gtk_widget_get_style (widget);
   cr = gdk_cairo_create (window);
-  
+
   cairo_set_line_width (cr, 1.0);
   gdk_cairo_set_source_color (cr, &style->white);
 
@@ -138,7 +138,7 @@ dimm_icon (GdkPixbuf *pixbuf)
     }
 
   w = gdk_pixbuf_get_width (dimmed_pixbuf);
-  h = gdk_pixbuf_get_height (dimmed_pixbuf);      
+  h = gdk_pixbuf_get_height (dimmed_pixbuf);
 
   pixel_stride = 4;
 
@@ -147,24 +147,24 @@ dimm_icon (GdkPixbuf *pixbuf)
 
   for (y = 0; y < h; y++)
     {
-      pixels = row;                     
-      for (x = 0; x < w; x++) 
+      pixels = row;
+      for (x = 0; x < w; x++)
         {
-          pixels[3] /= 2;                               
+          pixels[3] /= 2;
           pixels += pixel_stride;
-        }                       
+        }
       row += row_stride;
     }
   return dimmed_pixbuf;
 }
 
-static TabEntry*  
-tab_entry_new (const MetaTabEntry *entry, 
+static TabEntry*
+tab_entry_new (const MetaTabEntry *entry,
                gint                screen_width,
                gboolean            outline)
 {
   TabEntry *te;
-  
+
   te = g_new (TabEntry, 1);
   te->key = entry->key;
   te->title = NULL;
@@ -185,9 +185,9 @@ tab_entry_new (const MetaTabEntry *entry,
       g_free (str);
       str = tmp;
 
-      if (entry->demands_attention) 
-        {         
-          /* Escape the whole line of text then markup the text and 
+      if (entry->demands_attention)
+        {
+          /* Escape the whole line of text then markup the text and
            * copy it back into the original buffer.
            */
           tmp = g_strdup_printf ("<b>%s</b>", str);
@@ -209,7 +209,7 @@ tab_entry_new (const MetaTabEntry *entry,
       if (entry->hidden)
         te->dimmed_icon = dimm_icon (entry->icon);
     }
-  
+
   if (outline)
     {
       te->rect.x = entry->rect.x;
@@ -244,7 +244,7 @@ meta_ui_tab_popup_new (const MetaTabEntry *entries,
   AtkObject *obj;
   GdkScreen *screen;
   int screen_width;
-  
+
   popup = g_new (MetaTabPopup, 1);
 
   popup->outline_window = gtk_window_new (GTK_WINDOW_POPUP);
@@ -259,7 +259,7 @@ meta_ui_tab_popup_new (const MetaTabEntry *entries,
 
   g_signal_connect (G_OBJECT (popup->outline_window), "expose_event",
                     G_CALLBACK (outline_window_expose), popup);
-  
+
   popup->window = gtk_window_new (GTK_WINDOW_POPUP);
 
   gtk_window_set_screen (GTK_WINDOW (popup->window),
@@ -283,7 +283,7 @@ meta_ui_tab_popup_new (const MetaTabEntry *entries,
     }
 
   popup->entries = g_list_reverse (popup->entries);
-    
+
   g_assert (width > 0);
   height = i / width;
   if (i % width)
@@ -291,7 +291,7 @@ meta_ui_tab_popup_new (const MetaTabEntry *entries,
 
   table = gtk_table_new (height, width, FALSE);
   vbox = gtk_vbox_new (FALSE, 0);
-  
+
   frame = gtk_frame_new (NULL);
   gtk_frame_set_shadow_type (GTK_FRAME (frame), GTK_SHADOW_OUT);
   gtk_container_set_border_width (GTK_CONTAINER (table), 1);
@@ -326,7 +326,7 @@ meta_ui_tab_popup_new (const MetaTabEntry *entries,
   tmp = popup->entries;
 
   while (tmp && top < height)
-    {      
+    {
       left = 0;
       right = 1;
 
@@ -350,7 +350,7 @@ meta_ui_tab_popup_new (const MetaTabEntry *entries,
                 {
                   image = selectable_image_new (te->dimmed_icon);
                 }
-              else 
+              else
                 {
                   image = selectable_image_new (te->icon);
                 }
@@ -359,7 +359,7 @@ meta_ui_tab_popup_new (const MetaTabEntry *entries,
                                     INSIDE_SELECT_RECT + OUTSIDE_SELECT_RECT + 1,
                                     INSIDE_SELECT_RECT + OUTSIDE_SELECT_RECT + 1);
               gtk_misc_set_alignment (GTK_MISC (image), 0.5, 0.5);
-            }   
+            }
           else
             {
               image = selectable_workspace_new ((MetaWorkspace *) te->key);
@@ -378,13 +378,13 @@ meta_ui_tab_popup_new (const MetaTabEntry *entries,
                               te->title);
           gtk_widget_size_request (popup->label, &req);
           max_label_width = MAX (max_label_width, req.width);
-          
+
           tmp = tmp->next;
-          
+
           ++left;
           ++right;
         }
-      
+
       ++top;
       ++bottom;
     }
@@ -395,17 +395,17 @@ meta_ui_tab_popup_new (const MetaTabEntry *entries,
   gtk_label_set_ellipsize (GTK_LABEL (popup->label), PANGO_ELLIPSIZE_END);
 
   /* Limit the window size to no bigger than screen_width/4 */
-  if (max_label_width>(screen_width/4)) 
+  if (max_label_width>(screen_width/4))
     {
       max_label_width = screen_width/4;
     }
 
   max_label_width += 20; /* add random padding */
-  
+
   gtk_window_set_default_size (GTK_WINDOW (popup->window),
                                max_label_width,
                                -1);
-  
+
   return popup;
 }
 
@@ -415,7 +415,7 @@ free_tab_entry (gpointer data, gpointer user_data)
   TabEntry *te;
 
   te = data;
-  
+
   g_free (te->title);
   if (te->icon)
     g_object_unref (G_OBJECT (te->icon));
@@ -429,14 +429,14 @@ void
 meta_ui_tab_popup_free (MetaTabPopup *popup)
 {
   meta_verbose ("Destroying tab popup window\n");
-  
+
   gtk_widget_destroy (popup->outline_window);
   gtk_widget_destroy (popup->window);
-  
+
   g_list_foreach (popup->entries, free_tab_entry, NULL);
 
   g_list_free (popup->entries);
-  
+
   g_free (popup);
 }
 
@@ -468,7 +468,7 @@ display_entry (MetaTabPopup *popup,
   GdkRegion *inner_region;
   GdkWindow *window;
 
-  
+
   if (popup->current_selected_entry)
   {
     if (popup->outline)
@@ -476,7 +476,7 @@ display_entry (MetaTabPopup *popup,
     else
       unselect_workspace (popup->current_selected_entry->widget);
   }
-  
+
   gtk_label_set_markup (GTK_LABEL (popup->label), te->title);
 
   if (popup->outline)
@@ -489,7 +489,7 @@ display_entry (MetaTabPopup *popup,
       /* Do stuff behind gtk's back */
       gdk_window_hide (gtk_widget_get_window(popup->outline_window));
       meta_core_increment_event_serial (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()));
-  
+
       rect = te->rect;
       rect.x = 0;
       rect.y = 0;
@@ -499,7 +499,7 @@ display_entry (MetaTabPopup *popup,
       gdk_window_move_resize (window,
                               te->rect.x, te->rect.y,
                               te->rect.width, te->rect.height);
-  
+
       #if GTK_CHECK_VERSION(3, 0, 0)
       GdkRGBA black = { 0.0, 0.0, 0.0, 1.0 };
       gdk_window_set_background_rgba (window, &black);
@@ -507,18 +507,18 @@ display_entry (MetaTabPopup *popup,
       gdk_window_set_background (window,
                                  &popup->outline_window->style->black);
       #endif
-  
+
       region = gdk_region_rectangle (&rect);
       inner_region = gdk_region_rectangle (&te->inner_rect);
       gdk_region_subtract (region, inner_region);
       gdk_region_destroy (inner_region);
-  
+
       gdk_window_shape_combine_region (window,
                                        region,
                                        0, 0);
 
       gdk_region_destroy (region);
-  
+
       /* This should piss off gtk a bit, but we don't want to raise
        * above the tab popup.  So, instead of calling gtk_widget_show,
        * we manually set the window as mapped and then manually map it
@@ -544,7 +544,7 @@ meta_ui_tab_popup_forward (MetaTabPopup *popup)
 
   if (popup->current == NULL)
     popup->current = popup->entries;
-  
+
   if (popup->current != NULL)
     {
       TabEntry *te;
@@ -563,7 +563,7 @@ meta_ui_tab_popup_backward (MetaTabPopup *popup)
 
   if (popup->current == NULL)
     popup->current = g_list_last (popup->entries);
-  
+
   if (popup->current != NULL)
     {
       TabEntry *te;
@@ -598,7 +598,7 @@ meta_ui_tab_popup_select (MetaTabPopup *popup,
   /* Note, "key" may not be in the list of entries; other code assumes
    * it's OK to pass in a key that isn't.
    */
-  
+
   tmp = popup->entries;
   while (tmp != NULL)
     {
@@ -609,12 +609,12 @@ meta_ui_tab_popup_select (MetaTabPopup *popup,
       if (te->key == key)
         {
           popup->current = tmp;
-          
+
           display_entry (popup, te);
 
           return;
         }
-      
+
       tmp = tmp->next;
     }
 }
@@ -645,7 +645,7 @@ selectable_image_new (GdkPixbuf *pixbuf)
   GtkWidget *w;
 
   w = g_object_new (meta_select_image_get_type (), NULL);
-  gtk_image_set_from_pixbuf (GTK_IMAGE (w), pixbuf); 
+  gtk_image_set_from_pixbuf (GTK_IMAGE (w), pixbuf);
 
   return w;
 }
@@ -705,14 +705,14 @@ static void
 meta_select_image_class_init (MetaSelectImageClass *klass)
 {
   GtkWidgetClass *widget_class;
-  
+
   parent_class = g_type_class_peek (gtk_image_get_type ());
 
   widget_class = GTK_WIDGET_CLASS (klass);
 
   #if GTK_CHECK_VERSION(3, 0, 0)
   widget_class->draw = meta_select_image_draw;
-  #else  
+  #else
   widget_class->expose_event = meta_select_image_expose_event;
   #endif
 }
@@ -742,13 +742,13 @@ meta_select_image_draw (GtkWidget *widget,
       gtk_widget_get_requisition (widget, &requisition);
       gtk_misc_get_alignment (misc, &xalign, &yalign);
       gtk_misc_get_padding (misc, &xpad, &ypad);
-      
+
       x = (allocation.width - (requisition.width - xpad * 2)) * xalign + 0.5;
       y = (allocation.height - (requisition.height - ypad * 2)) * yalign + 0.5;
 
       x -= INSIDE_SELECT_RECT + 1;
-      y -= INSIDE_SELECT_RECT + 1;      
-      
+      y -= INSIDE_SELECT_RECT + 1;
+
       w = requisition.width - OUTSIDE_SELECT_RECT * 2 - 1;
       h = requisition.height - OUTSIDE_SELECT_RECT * 2 - 1;
 
@@ -789,7 +789,7 @@ meta_select_image_expose_event (GtkWidget      *widget,
       gtk_widget_get_allocation(widget, &allocation);
 
       misc = GTK_MISC (widget);
-      
+
       x = (allocation.x * (1.0 - misc->xalign) +
            (allocation.x + allocation.width
             - (widget->requisition.width - misc->xpad * 2)) *
@@ -800,8 +800,8 @@ meta_select_image_expose_event (GtkWidget      *widget,
            misc->yalign) + 0.5;
 
       x -= INSIDE_SELECT_RECT + 1;
-      y -= INSIDE_SELECT_RECT + 1;      
-      
+      y -= INSIDE_SELECT_RECT + 1;
+
       w = widget->requisition.width - OUTSIDE_SELECT_RECT * 2 - 1;
       h = widget->requisition.height - OUTSIDE_SELECT_RECT * 2 - 1;
 
@@ -822,7 +822,7 @@ meta_select_image_expose_event (GtkWidget      *widget,
       cairo_fill (cr);
 #endif
 
-#if 0      
+#if 0
       gtk_paint_focus (widget->style, widget->window,
                        &event->area, widget, "meta-tab-image",
                        x, y, w, h);
@@ -865,13 +865,13 @@ selectable_workspace_new (MetaWorkspace *workspace)
 {
   GtkWidget *widget;
   double screen_aspect;
-  
+
   widget = g_object_new (meta_select_workspace_get_type (), NULL);
 
   screen_aspect = (double) workspace->screen->rect.height /
                   (double) workspace->screen->rect.width;
-  
-  /* account for select rect */ 
+
+  /* account for select rect */
   gtk_widget_set_size_request (widget,
                                MINI_WORKSPACE_WIDTH + SELECT_OUTLINE_WIDTH * 2,
                                MINI_WORKSPACE_WIDTH * screen_aspect + SELECT_OUTLINE_WIDTH * 2);
@@ -925,9 +925,9 @@ meta_select_workspace_get_type (void)
         (GInstanceInitFunc) NULL,
       };
 
-      workspace_type = g_type_register_static (GTK_TYPE_DRAWING_AREA, 
-                                               "MetaSelectWorkspace", 
-                                               &workspace_info, 
+      workspace_type = g_type_register_static (GTK_TYPE_DRAWING_AREA,
+                                               "MetaSelectWorkspace",
+                                               &workspace_info,
                                                0);
     }
 
@@ -938,9 +938,9 @@ static void
 meta_select_workspace_class_init (MetaSelectWorkspaceClass *klass)
 {
   GtkWidgetClass *widget_class;
-  
+
   widget_class = GTK_WIDGET_CLASS (klass);
-  
+
   #if GTK_CHECK_VERSION(3, 0, 0)
   widget_class->draw = meta_select_workspace_draw;
   #else
@@ -959,7 +959,7 @@ meta_convert_meta_to_wnck (MetaWindow *window, MetaScreen *screen)
   WnckWindowDisplayInfo wnck_window;
   wnck_window.icon = window->icon;
   wnck_window.mini_icon = window->mini_icon;
-  
+
   wnck_window.is_active = FALSE;
   if (window == window->display->expected_focus_window)
     wnck_window.is_active = TRUE;
@@ -994,7 +994,7 @@ meta_select_workspace_draw (GtkWidget *widget,
   GList *tmp, *list;
 
   workspace = META_SELECT_WORKSPACE (widget)->workspace;
-              
+
   list = meta_stack_list_windows (workspace->screen->stack, workspace);
   n_windows = g_list_length (list);
   windows = g_new (WnckWindowDisplayInfo, n_windows);
@@ -1011,7 +1011,7 @@ meta_select_workspace_draw (GtkWidget *widget,
       ignoreable_sticky = window->on_all_workspaces &&
                           workspace != workspace->screen->active_workspace;
 
-      if (window->skip_pager || 
+      if (window->skip_pager ||
           !meta_window_showing_on_its_workspace (window) ||
           window->unmaps_pending ||
           ignoreable_sticky)
@@ -1044,7 +1044,7 @@ meta_select_workspace_draw (GtkWidget *widget,
                        n_windows);
 
   g_free (windows);
-  
+
   if (META_SELECT_WORKSPACE (widget)->selected)
     {
       GtkStyleContext *context;
@@ -1083,11 +1083,11 @@ meta_select_workspace_expose_event (GtkWidget      *widget,
   int i, n_windows;
   GList *tmp, *list;
   GtkAllocation allocation;
-  
+
   gtk_widget_get_allocation(widget, &allocation);
 
   workspace = META_SELECT_WORKSPACE (widget)->workspace;
-              
+
   list = meta_stack_list_windows (workspace->screen->stack, workspace);
   n_windows = g_list_length (list);
   windows = g_new (WnckWindowDisplayInfo, n_windows);
@@ -1104,7 +1104,7 @@ meta_select_workspace_expose_event (GtkWidget      *widget,
       ignoreable_sticky = window->on_all_workspaces &&
                           workspace != workspace->screen->active_workspace;
 
-      if (window->skip_pager || 
+      if (window->skip_pager ||
           !meta_window_showing_on_its_workspace (window) ||
           window->unmaps_pending ||
           ignoreable_sticky)
@@ -1135,7 +1135,7 @@ meta_select_workspace_expose_event (GtkWidget      *widget,
                        n_windows);
 
   g_free (windows);
-  
+
   if (META_SELECT_WORKSPACE (widget)->selected)
     {
       style = gtk_widget_get_style (widget);

--- a/src/ui/testgradient.c
+++ b/src/ui/testgradient.c
@@ -2,9 +2,9 @@
 
 /* Marco gradient test program */
 
-/* 
+/*
  * Copyright (C) 2002 Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -51,10 +51,10 @@ draw_checkerboard (GdkDrawable *drawable,
 #if !GTK_CHECK_VERSION (3, 0, 0)
   cairo_t *cr;
 #endif
-  
+
 #define CHECK_SIZE 10
-#define SPACING 2  
-  
+#define SPACING 2
+
   color1.red = 30000;
   color1.green = 30000;
   color1.blue = 30000;
@@ -112,7 +112,7 @@ render_simple (
 {
   GdkPixbuf *pixbuf;
   GdkColor from, to;
-  
+
   gdk_color_parse ("blue", &from);
   gdk_color_parse ("green", &to);
 
@@ -123,16 +123,16 @@ render_simple (
   if (with_alpha)
     {
       const unsigned char alphas[] = { 0xff, 0xaa, 0x2f, 0x0, 0xcc, 0xff, 0xff };
-      
+
       if (!gdk_pixbuf_get_has_alpha (pixbuf))
         {
           GdkPixbuf *new_pixbuf;
-          
+
           new_pixbuf = gdk_pixbuf_add_alpha (pixbuf, FALSE, 0, 0, 0);
           g_object_unref (G_OBJECT (pixbuf));
           pixbuf = new_pixbuf;
         }
-      
+
       meta_gradient_add_alpha (pixbuf,
                                alphas, G_N_ELEMENTS (alphas),
                                META_GRADIENT_HORIZONTAL);
@@ -143,7 +143,7 @@ render_simple (
       draw_checkerboard (drawable, width, height);
 #endif
     }
-    
+
   gdk_cairo_set_source_pixbuf (cr, pixbuf, 0, 0);
   cairo_rectangle (cr, 0, 0, width, height);
   cairo_fill (cr);
@@ -372,13 +372,13 @@ create_gradient_window (const char *title,
   window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
 
   gtk_window_set_title (GTK_WINDOW (window), title);
-  
+
   drawing_area = gtk_drawing_area_new ();
 
   gtk_widget_set_size_request (drawing_area, 1, 1);
 
   gtk_window_set_default_size (GTK_WINDOW (window), 175, 175);
-  
+
   g_signal_connect (G_OBJECT (drawing_area),
 #if GTK_CHECK_VERSION (3, 0, 0)
                     "draw",
@@ -392,7 +392,7 @@ create_gradient_window (const char *title,
   gtk_container_add (GTK_CONTAINER (window), drawing_area);
 
   gtk_widget_show_all (window);
-  
+
   return window;
 }
 
@@ -403,7 +403,7 @@ meta_gradient_test (void)
 
   window = create_gradient_window ("Simple vertical",
                                    render_vertical_func);
-  
+
   window = create_gradient_window ("Simple horizontal",
                                    render_horizontal_func);
 
@@ -412,7 +412,7 @@ meta_gradient_test (void)
 
   window = create_gradient_window ("Multi vertical",
                                    render_vertical_multi_func);
-  
+
   window = create_gradient_window ("Multi horizontal",
                                    render_horizontal_multi_func);
 

--- a/src/ui/theme-parser.h
+++ b/src/ui/theme-parser.h
@@ -2,9 +2,9 @@
 
 /* Marco theme parsing */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA

--- a/src/ui/theme-viewer.c
+++ b/src/ui/theme-viewer.c
@@ -96,12 +96,12 @@ normal_contents (void)
   GtkWidget *contents;
   GtkWidget *sw;
   GtkItemFactory *item_factory;
-      
+
   table = gtk_table_new (1, 4, FALSE);
-  
+
   /* Create the menubar
    */
-      
+
   item_factory = gtk_item_factory_new (GTK_TYPE_MENU_BAR, "<main>", NULL);
 
   gtk_item_factory_set_translate_func(item_factory,
@@ -156,7 +156,7 @@ normal_contents (void)
   handlebox = gtk_handle_box_new ();
 
   gtk_container_add (GTK_CONTAINER (handlebox), toolbar);
-      
+
   gtk_table_attach (GTK_TABLE (table),
                     handlebox,
                     /* X direction */       /* Y direction */
@@ -175,18 +175,18 @@ normal_contents (void)
 
   gtk_scrolled_window_set_shadow_type (GTK_SCROLLED_WINDOW (sw),
                                        GTK_SHADOW_IN);
-      
+
   gtk_table_attach (GTK_TABLE (table),
                     sw,
                     /* X direction */       /* Y direction */
                     0, 1,                   2, 3,
                     GTK_EXPAND | GTK_FILL,  GTK_EXPAND | GTK_FILL,
                     0,                      0);
-      
+
   contents = gtk_text_view_new ();
   gtk_text_view_set_wrap_mode (GTK_TEXT_VIEW (contents),
                                PANGO_WRAP_WORD);
-      
+
   gtk_container_add (GTK_CONTAINER (sw),
                      contents);
 
@@ -223,19 +223,19 @@ dialog_contents (void)
   GtkWidget *label;
   GtkWidget *image;
   GtkWidget *button;
-  
+
   vbox = gtk_vbox_new (FALSE, 0);
 
   action_area = gtk_hbutton_box_new ();
 
   gtk_button_box_set_layout (GTK_BUTTON_BOX (action_area),
-                             GTK_BUTTONBOX_END);  
+                             GTK_BUTTONBOX_END);
 
   button = gtk_button_new_from_stock (GTK_STOCK_OK);
   gtk_box_pack_end (GTK_BOX (action_area),
                     button,
                     FALSE, TRUE, 0);
-  
+
   gtk_box_pack_end (GTK_BOX (vbox), action_area,
                     FALSE, TRUE, 0);
 
@@ -245,10 +245,10 @@ dialog_contents (void)
   image = gtk_image_new_from_stock (GTK_STOCK_DIALOG_INFO,
                                     GTK_ICON_SIZE_DIALOG);
   gtk_misc_set_alignment (GTK_MISC (image), 0.5, 0.0);
-  
+
   gtk_label_set_line_wrap (GTK_LABEL (label), TRUE);
   gtk_label_set_selectable (GTK_LABEL (label), TRUE);
-  
+
   hbox = gtk_hbox_new (FALSE, 6);
 
   gtk_box_pack_start (GTK_BOX (hbox), image,
@@ -284,11 +284,11 @@ utility_contents (void)
           char *str;
 
           str = g_strdup_printf ("_%c", (char) ('A' + 4*i + j));
-          
+
           button = gtk_button_new_with_mnemonic (str);
 
           g_free (str);
-          
+
           gtk_table_attach (GTK_TABLE (table),
                             button,
                             /* X direction */       /* Y direction */
@@ -303,7 +303,7 @@ utility_contents (void)
     }
 
   gtk_widget_show_all (table);
-  
+
   return table;
 }
 
@@ -311,7 +311,7 @@ static GtkWidget*
 menu_contents (void)
 {
   GtkWidget *vbox;
-  GtkWidget *mi;  
+  GtkWidget *mi;
   int i;
   GtkWidget *frame;
 
@@ -329,14 +329,14 @@ menu_contents (void)
       gtk_misc_set_alignment (GTK_MISC (mi), 0.0, 0.5);
       g_free (str);
       gtk_box_pack_start (GTK_BOX (vbox), mi, FALSE, FALSE, 0);
-      
+
       ++i;
     }
 
   gtk_container_add (GTK_CONTAINER (frame), vbox);
-  
+
   gtk_widget_show_all (frame);
-  
+
   return frame;
 }
 
@@ -354,19 +354,19 @@ border_only_contents (void)
   color.green = 0;
   color.blue = 40000;
   gtk_widget_modify_bg (event_box, GTK_STATE_NORMAL, &color);
-  
+
   vbox = gtk_vbox_new (FALSE, 0);
   gtk_container_set_border_width (GTK_CONTAINER (vbox), 3);
-  
+
   w = gtk_label_new (_("Border-only window"));
   gtk_box_pack_start (GTK_BOX (vbox), w, FALSE, FALSE, 0);
   w = gtk_button_new_with_label (_("Bar"));
   gtk_box_pack_start (GTK_BOX (vbox), w, FALSE, FALSE, 0);
 
   gtk_container_add (GTK_CONTAINER (event_box), vbox);
-  
+
   gtk_widget_show_all (event_box);
-  
+
   return event_box;
 }
 
@@ -399,7 +399,7 @@ get_window_contents (MetaFrameType  type,
     case META_FRAME_TYPE_BORDER:
       *title = _("Border");
       return border_only_contents ();
-      
+
     case META_FRAME_TYPE_LAST:
       g_assert_not_reached ();
       break;
@@ -422,7 +422,7 @@ get_window_flags (MetaFrameType type)
     META_FRAME_HAS_FOCUS |
     META_FRAME_ALLOWS_SHADE |
     META_FRAME_ALLOWS_MOVE;
-  
+
   switch (type)
     {
     case META_FRAME_TYPE_NORMAL:
@@ -446,12 +446,12 @@ get_window_flags (MetaFrameType type)
 
     case META_FRAME_TYPE_BORDER:
       break;
-      
+
     case META_FRAME_TYPE_LAST:
       g_assert_not_reached ();
       break;
-    }  
-  
+    }
+
   return flags;
 }
 
@@ -476,7 +476,7 @@ preview_collection (int font_size,
 
   eventbox = gtk_event_box_new ();
   gtk_container_add (GTK_CONTAINER (eventbox), box);
-  
+
   gtk_scrolled_window_add_with_viewport (GTK_SCROLLED_WINDOW (sw), eventbox);
 
   desktop_color.red = 0x5144;
@@ -496,23 +496,23 @@ preview_collection (int font_size,
       GtkWidget *preview;
       PangoFontDescription *font_desc;
       double scale;
-      
+
       eventbox2 = gtk_event_box_new ();
-      
+
       preview = meta_preview_new ();
-      
+
       gtk_container_add (GTK_CONTAINER (eventbox2), preview);
-      
+
       meta_preview_set_frame_type (META_PREVIEW (preview), i);
       meta_preview_set_frame_flags (META_PREVIEW (preview),
                                     get_window_flags (i));
-            
+
       meta_preview_set_theme (META_PREVIEW (preview), global_theme);
-      
+
       contents = get_window_contents (i, &title);
-      
+
       meta_preview_set_title (META_PREVIEW (preview), title);
-      
+
       gtk_container_add (GTK_CONTAINER (preview), contents);
 
       if (i == META_FRAME_TYPE_MENU)
@@ -525,10 +525,10 @@ preview_collection (int font_size,
           xalign = 0.5;
           yalign = 0.5;
         }
-      
+
       align = gtk_alignment_new (0.0, 0.0, xalign, yalign);
       gtk_container_add (GTK_CONTAINER (align), eventbox2);
-      
+
       gtk_box_pack_start (GTK_BOX (box), align, TRUE, TRUE, 0);
 
       switch (font_size)
@@ -547,17 +547,17 @@ preview_collection (int font_size,
       if (scale != 1.0)
         {
           font_desc = pango_font_description_new ();
-          
+
           pango_font_description_set_size (font_desc,
                                            MAX (pango_font_description_get_size (base_desc) * scale, 1));
-          
+
           gtk_widget_modify_font (preview, font_desc);
 
           pango_font_description_free (font_desc);
         }
-      
+
       previews[font_size*META_FRAME_TYPE_LAST + i] = preview;
-      
+
       ++i;
     }
 
@@ -586,13 +586,13 @@ init_layouts (void)
         }
       ++i;
     }
-  
+
 #ifndef ALLOW_DUPLICATE_BUTTONS
   i = 0;
   while (i <= MAX_BUTTONS_PER_CORNER)
     {
       int j;
-      
+
       j = 0;
       while (j < i)
         {
@@ -604,34 +604,34 @@ init_layouts (void)
           different_layouts[i].left_buttons[j-i] = (MetaButtonFunction) j;
           ++j;
         }
-      
+
       ++i;
     }
 
   /* Special extra case for no buttons on either side */
   different_layouts[i].left_buttons[0] = META_BUTTON_FUNCTION_LAST;
   different_layouts[i].right_buttons[0] = META_BUTTON_FUNCTION_LAST;
-  
+
 #else
   /* FIXME this code is if we allow duplicate buttons,
    * which we currently do not
    */
   int left;
   int i;
-  
+
   left = 0;
   i = 0;
 
   while (left < MAX_BUTTONS_PER_CORNER)
     {
       int right;
-      
+
       right = 0;
-      
+
       while (right < MAX_BUTTONS_PER_CORNER)
         {
           int j;
-          
+
           static MetaButtonFunction left_functions[MAX_BUTTONS_PER_CORNER] = {
             META_BUTTON_FUNCTION_MENU,
             META_BUTTON_FUNCTION_MINIMIZE,
@@ -646,7 +646,7 @@ init_layouts (void)
           };
 
           g_assert (i < BUTTON_LAYOUT_COMBINATIONS);
-          
+
           j = 0;
           while (j <= left)
             {
@@ -660,12 +660,12 @@ init_layouts (void)
               different_layouts[i].right_buttons[j] = right_functions[j];
               ++j;
             }
-          
+
           ++i;
-          
+
           ++right;
         }
-      
+
       ++left;
     }
 #endif
@@ -681,13 +681,13 @@ previews_of_button_layouts (void)
   GdkColor desktop_color;
   int i;
   GtkWidget *eventbox;
-  
+
   if (!initted)
     {
       init_layouts ();
       initted = TRUE;
     }
-  
+
   sw = gtk_scrolled_window_new (NULL, NULL);
   gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (sw),
                                   GTK_POLICY_AUTOMATIC,
@@ -699,7 +699,7 @@ previews_of_button_layouts (void)
 
   eventbox = gtk_event_box_new ();
   gtk_container_add (GTK_CONTAINER (eventbox), box);
-  
+
   gtk_scrolled_window_add_with_viewport (GTK_SCROLLED_WINDOW (sw), eventbox);
 
   desktop_color.red = 0x5144;
@@ -718,11 +718,11 @@ previews_of_button_layouts (void)
       char *title;
 
       eventbox2 = gtk_event_box_new ();
-  
+
       preview = meta_preview_new ();
-  
-      gtk_container_add (GTK_CONTAINER (eventbox2), preview);  
-  
+
+      gtk_container_add (GTK_CONTAINER (eventbox2), preview);
+
       meta_preview_set_theme (META_PREVIEW (preview), global_theme);
 
       title = g_strdup_printf (_("Button layout test %d"), i+1);
@@ -731,20 +731,20 @@ previews_of_button_layouts (void)
 
       meta_preview_set_button_layout (META_PREVIEW (preview),
                                       &different_layouts[i]);
-  
+
       xalign = 0.5;
       yalign = 0.5;
-      
+
       align = gtk_alignment_new (0.0, 0.0, xalign, yalign);
       gtk_container_add (GTK_CONTAINER (align), eventbox2);
-  
+
       gtk_box_pack_start (GTK_BOX (box), align, TRUE, TRUE, 0);
 
       previews[META_FRAME_TYPE_LAST*FONT_SIZE_LAST + i] = preview;
-      
+
       ++i;
     }
-  
+
   return sw;
 }
 
@@ -753,7 +753,7 @@ benchmark_summary (void)
 {
   char *msg;
   GtkWidget *label;
-  
+
   msg = g_strdup_printf (_("%g milliseconds to draw one window frame"),
                          milliseconds_to_draw_frame);
   label = gtk_label_new (msg);
@@ -771,7 +771,7 @@ main (int argc, char **argv)
   clock_t start, end;
   GtkWidget *notebook;
   int i;
-  
+
   bindtextdomain (GETTEXT_PACKAGE, MARCO_LOCALEDIR);
   textdomain(GETTEXT_PACKAGE);
   bind_textdomain_codeset(GETTEXT_PACKAGE, "UTF-8");
@@ -788,7 +788,7 @@ main (int argc, char **argv)
       meta_set_debugging (TRUE);
       meta_set_verbose (TRUE);
     }
-  
+
   start = clock ();
   err = NULL;
   if (argc == 1)
@@ -815,7 +815,7 @@ main (int argc, char **argv)
            (end - start) / (double) CLOCKS_PER_SEC);
 
   run_theme_benchmark ();
-  
+
   window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
   gtk_window_set_default_size (GTK_WINDOW (window), 350, 350);
 
@@ -835,7 +835,7 @@ main (int argc, char **argv)
                             title);
 
       g_free (title);
-    }       
+    }
 
   g_signal_connect (G_OBJECT (window), "destroy",
                     G_CALLBACK (gtk_main_quit), NULL);
@@ -843,7 +843,7 @@ main (int argc, char **argv)
   gtk_widget_realize (window);
   g_assert (window->style);
   g_assert (window->style->font_desc);
-  
+
   notebook = gtk_notebook_new ();
   gtk_container_add (GTK_CONTAINER (window), notebook);
 
@@ -852,13 +852,13 @@ main (int argc, char **argv)
   gtk_notebook_append_page (GTK_NOTEBOOK (notebook),
                             collection,
                             gtk_label_new (_("Normal Title Font")));
-  
+
   collection = preview_collection (FONT_SIZE_SMALL,
                                    window->style->font_desc);
   gtk_notebook_append_page (GTK_NOTEBOOK (notebook),
                             collection,
                             gtk_label_new (_("Small Title Font")));
-  
+
   collection = preview_collection (FONT_SIZE_LARGE,
                                    window->style->font_desc);
   gtk_notebook_append_page (GTK_NOTEBOOK (notebook),
@@ -874,7 +874,7 @@ main (int argc, char **argv)
   gtk_notebook_append_page (GTK_NOTEBOOK (notebook),
                             collection,
                             gtk_label_new (_("Benchmark")));
-  
+
   i = 0;
   while (i < (int) G_N_ELEMENTS (previews))
     {
@@ -885,7 +885,7 @@ main (int argc, char **argv)
 
       ++i;
     }
-  
+
   gtk_widget_show_all (window);
 
   gtk_main ();
@@ -948,10 +948,10 @@ run_theme_benchmark (void)
   int client_width;
   int client_height;
   int inc;
-  
+
   widget = gtk_window_new (GTK_WINDOW_TOPLEVEL);
   gtk_widget_realize (widget);
-  
+
   meta_theme_get_frame_borders (global_theme,
                                 META_FRAME_TYPE_NORMAL,
                                 get_text_height (widget),
@@ -960,9 +960,9 @@ run_theme_benchmark (void)
                                 &bottom_height,
                                 &left_width,
                                 &right_width);
-  
+
   layout = create_title_layout (widget);
-  
+
   i = 0;
   while (i < MAX_BUTTONS_PER_CORNER)
     {
@@ -970,7 +970,7 @@ run_theme_benchmark (void)
       button_layout.right_buttons[i] = META_BUTTON_FUNCTION_LAST;
       ++i;
     }
-  
+
   button_layout.left_buttons[0] = META_BUTTON_FUNCTION_MENU;
 
   button_layout.right_buttons[0] = META_BUTTON_FUNCTION_MINIMIZE;
@@ -985,7 +985,7 @@ run_theme_benchmark (void)
   inc = 1000 / ITERATIONS; /* Increment to grow width/height,
                             * eliminates caching effects.
                             */
-  
+
   i = 0;
   while (i < ITERATIONS)
     {
@@ -1013,7 +1013,7 @@ run_theme_benchmark (void)
                              meta_preview_get_icon ());
 
       g_object_unref (G_OBJECT (pixmap));
-      
+
       ++i;
       client_width += inc;
       client_height += inc;
@@ -1023,7 +1023,7 @@ run_theme_benchmark (void)
   g_timer_stop (timer);
 
   milliseconds_to_draw_frame = (g_timer_elapsed (timer, NULL) / (double) ITERATIONS) * 1000;
-  
+
   g_print (_("Drew %d frames in %g client-side seconds (%g milliseconds per frame) and %g seconds wall clock time including X server resources (%g milliseconds per frame)\n"),
            ITERATIONS,
            ((double)end - (double)start) / CLOCKS_PER_SEC,
@@ -1217,7 +1217,7 @@ run_position_expression_tests (void)
                  test->expr, test->expected_x, test->expected_y);
 
       err = NULL;
-      
+
       env.rect = meta_rect (test->rect.x, test->rect.y,
                             test->rect.width, test->rect.height);
       env.object_width = -1;

--- a/src/ui/theme.c
+++ b/src/ui/theme.c
@@ -3464,7 +3464,7 @@ meta_draw_op_draw_with_env (const MetaDrawOp    *op,
       cairo_clip (cr);
     }
   #endif
-  
+
   switch (op->type)
     {
     case META_DRAW_LINE:
@@ -3935,12 +3935,12 @@ meta_draw_op_draw_with_env (const MetaDrawOp    *op,
         /* tile offset should not include x/y */
         tile_xoffset -= rect.x;
         tile_yoffset -= rect.y;
-        
+
         tile.width = parse_size_unchecked (op->data.tile.tile_width, env);
         tile.height = parse_size_unchecked (op->data.tile.tile_height, env);
 
         tile.x = rx - tile_xoffset;
-    
+
         while (tile.x < (rx + rwidth))
           {
             tile.y = ry - tile_yoffset;
@@ -4148,7 +4148,7 @@ meta_draw_op_list_draw_with_style  (const MetaDrawOpList *op_list,
    * evaluated), we make an array of those, and then fold
    * adjacent items when possible.
    */
-  
+
   #if GTK_CHECK_VERSION(3, 0, 0)
   cairo_save(cr);
   #else
@@ -4176,13 +4176,13 @@ meta_draw_op_list_draw_with_style  (const MetaDrawOpList *op_list,
         {
           cairo_restore (cr);
 
-          cairo_rectangle (cr, 
+          cairo_rectangle (cr,
                            parse_x_position_unchecked (op->data.clip.x, &env),
                            parse_y_position_unchecked (op->data.clip.y, &env),
                            parse_size_unchecked (op->data.clip.width, &env),
                            parse_size_unchecked (op->data.clip.height, &env));
           cairo_clip (cr);
-          
+
           cairo_save (cr);
         }
       else if (gdk_cairo_get_clip_rectangle (cr, NULL))
@@ -4801,7 +4801,7 @@ meta_frame_style_draw_with_style (MetaFrameStyle          *style,
               button_rect (j, fgeom, middle_bg_offset, &rect);
 
               op_list = get_button (style, j, button_states[j]);
-              
+
               if (op_list)
                 {
                   cairo_save (cr);

--- a/src/ui/theme.h
+++ b/src/ui/theme.h
@@ -2,9 +2,9 @@
 
 /* Marco Theme Rendering */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -34,7 +34,7 @@ typedef struct _MetaFrameStyleSet MetaFrameStyleSet;
 typedef struct _MetaDrawOp MetaDrawOp;
 typedef struct _MetaDrawOpList MetaDrawOpList;
 typedef struct _MetaGradientSpec MetaGradientSpec;
-typedef struct _MetaAlphaGradientSpec MetaAlphaGradientSpec; 
+typedef struct _MetaAlphaGradientSpec MetaAlphaGradientSpec;
 typedef struct _MetaColorSpec MetaColorSpec;
 typedef struct _MetaFrameLayout MetaFrameLayout;
 typedef struct _MetaButtonSpace MetaButtonSpace;
@@ -84,14 +84,14 @@ struct _MetaFrameLayout
 {
   /** Reference count. */
   int refcount;
-  
+
   /** Size of left side */
   int left_width;
   /** Size of right side */
   int right_width;
   /** Size of bottom side */
   int bottom_height;
-  
+
   /** Border of blue title region
    * \bug (blue?!)
    **/
@@ -99,12 +99,12 @@ struct _MetaFrameLayout
 
   /** Extra height for inside of title region, above the font height */
   int title_vertical_pad;
-  
+
   /** Right indent of buttons from edges of frame */
   int right_titlebar_edge;
   /** Left indent of buttons from edges of frame */
   int left_titlebar_edge;
-  
+
   /**
    * Sizing rule of buttons, either META_BUTTON_SIZING_ASPECT
    * (in which case button_aspect will be honoured, and
@@ -120,7 +120,7 @@ struct _MetaFrameLayout
    * Otherwise we figure out the height from the button_border.
    */
   double button_aspect;
-  
+
   /** Width of a button; set even when we are using aspect sizing */
   int button_width;
 
@@ -132,7 +132,7 @@ struct _MetaFrameLayout
 
   /** scale factor for title text */
   double title_scale;
-  
+
   /** Whether title text will be displayed */
   guint has_title : 1;
 
@@ -174,7 +174,7 @@ struct _MetaFrameGeometry
   int bottom_height;
 
   int width;
-  int height;  
+  int height;
 
   GdkRectangle title_rect;
 
@@ -186,7 +186,7 @@ struct _MetaFrameGeometry
   /* used for a memset hack */
 #define ADDRESS_OF_BUTTON_RECTS(fgeom) (((char*)(fgeom)) + G_STRUCT_OFFSET (MetaFrameGeometry, close_rect))
 #define LENGTH_OF_BUTTON_RECTS (G_STRUCT_OFFSET (MetaFrameGeometry, right_right_background) + sizeof (GdkRectangle) - G_STRUCT_OFFSET (MetaFrameGeometry, close_rect))
-  
+
   /* The button rects (if changed adjust memset hack) */
   MetaButtonSpace close_rect;
   MetaButtonSpace max_rect;
@@ -209,7 +209,7 @@ struct _MetaFrameGeometry
   GdkRectangle right_middle_backgrounds[MAX_MIDDLE_BACKGROUNDS];
   GdkRectangle right_right_background;
   /* End of button rects (if changed adjust memset hack) */
-  
+
   /* Round corners */
   guint top_left_corner_rounded_radius;
   guint top_right_corner_rounded_radius;
@@ -309,14 +309,14 @@ typedef enum
 
   /** Clip to a rectangle */
   META_DRAW_CLIP,
-  
+
   /* Texture thingies */
 
   /** Just a filled rectangle with alpha */
   META_DRAW_TINT,
   META_DRAW_GRADIENT,
   META_DRAW_IMAGE,
-  
+
   /** GTK theme engine stuff */
   META_DRAW_GTK_ARROW,
   META_DRAW_GTK_BOX,
@@ -402,7 +402,7 @@ typedef struct _MetaDrawSpec
    * otherwise it is zero.
    */
   int value;
-  
+
   /** A list of tokens in the expression. */
   PosToken *tokens;
 
@@ -460,7 +460,7 @@ struct _MetaDrawOp
       MetaDrawSpec *width;
       MetaDrawSpec *height;
     } clip;
-    
+
     struct {
       MetaColorSpec *color_spec;
       MetaAlphaGradientSpec *alpha_spec;
@@ -494,7 +494,7 @@ struct _MetaDrawOp
       unsigned int vertical_stripes : 1;
       unsigned int horizontal_stripes : 1;
     } image;
-    
+
     struct {
       GtkStateType state;
       GtkShadowType shadow;
@@ -520,7 +520,7 @@ struct _MetaDrawOp
       GtkStateType state;
       MetaDrawSpec *x;
       MetaDrawSpec *y1;
-      MetaDrawSpec *y2;  
+      MetaDrawSpec *y2;
     } gtk_vline;
 
     struct {
@@ -557,7 +557,7 @@ struct _MetaDrawOp
       MetaDrawSpec *tile_width;
       MetaDrawSpec *tile_height;
     } tile;
-    
+
   } data;
 };
 
@@ -630,7 +630,7 @@ typedef enum
    *   |       rather than   |
    *
    */
-  
+
   /* entire frame */
   META_FRAME_PIECE_ENTIRE_BACKGROUND,
   /* entire titlebar background */
@@ -698,7 +698,7 @@ struct _MetaFrameStyle
 };
 
 /* Kinds of frame...
- * 
+ *
  *  normal ->   noresize / vert only / horz only / both
  *              focused / unfocused
  *  max    ->   focused / unfocused
@@ -710,7 +710,7 @@ struct _MetaFrameStyle
  *
  * 14 window states times 7 or 8 window types. Except some
  * window types never get a frame so that narrows it down a bit.
- * 
+ *
  */
 typedef enum
 {
@@ -1130,7 +1130,7 @@ void meta_theme_calc_geometry (MetaTheme              *theme,
                                int                     client_height,
                                const MetaButtonLayout *button_layout,
                                MetaFrameGeometry      *fgeom);
-                                   
+
 MetaFrameLayout*   meta_theme_lookup_layout       (MetaTheme         *theme,
                                                    const char        *name);
 void               meta_theme_insert_layout       (MetaTheme         *theme,

--- a/src/ui/themewidget.c
+++ b/src/ui/themewidget.c
@@ -2,9 +2,9 @@
 
 /* Marco theme widget (displays themed draw operations) */
 
-/* 
+/*
  * Copyright (C) 2002 Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -123,10 +123,10 @@ meta_area_new (void)
 
   #if GTK_CHECK_VERSION(3, 0, 0)
   area = g_object_new (META_TYPE_AREA, NULL);
-  #else  
+  #else
   area = gtk_type_new (META_TYPE_AREA);
   #endif
-  
+
   return GTK_WIDGET (area);
 }
 
@@ -136,10 +136,10 @@ meta_area_finalize (GObject *object)
   MetaArea *area;
 
   area = META_AREA (object);
-  
+
   if (area->dnotify)
     (* area->dnotify) (area->user_data);
-  
+
   G_OBJECT_CLASS (parent_class)->finalize (object);
 }
 
@@ -177,21 +177,21 @@ meta_area_draw (GtkWidget       *widget,
 
       gtk_misc_get_padding(misc, &xpad, &ypad);
 
-  
+
       x = floor (allocation.x + xpad
          + ((allocation.width - req.width) * xalign)
          + 0.5);
-      y = floor (allocation.y + ypad 
+      y = floor (allocation.y + ypad
          + ((allocation.height - req.height) * yalign)
          + 0.5);
-      
+
       if (area->draw_func)
         {
           (* area->draw_func) (area, cr,
                                  area->user_data);
         }
     }
-  
+
   return FALSE;
 }
 
@@ -218,21 +218,21 @@ meta_area_expose (GtkWidget      *widget,
 	xalign = misc->xalign;
       else
 	xalign = 1.0 - misc->xalign;
-  
+
       x = floor (widget->allocation.x + misc->xpad
 		 + ((widget->allocation.width - widget->requisition.width) * xalign)
 		 + 0.5);
-      y = floor (widget->allocation.y + misc->ypad 
+      y = floor (widget->allocation.y + misc->ypad
 		 + ((widget->allocation.height - widget->requisition.height) * misc->yalign)
 		 + 0.5);
-      
+
       if (area->expose_func)
         {
           (* area->expose_func) (area, event, x, y,
                                  area->user_data);
         }
     }
-  
+
   return FALSE;
 }
 
@@ -245,10 +245,10 @@ meta_area_size_request (GtkWidget      *widget,
   MetaArea *area;
 
   area = META_AREA (widget);
-  
+
   req->width = 0;
   req->height = 0;
-  
+
   if (area->size_func)
     {
       (* area->size_func) (area, &req->width, &req->height,
@@ -258,7 +258,7 @@ meta_area_size_request (GtkWidget      *widget,
 
 #if GTK_CHECK_VERSION(3, 0, 0)
 
-static void 
+static void
 meta_area_get_preferred_width (GtkWidget *widget,
                                gint      *minimal,
                                gint      *natural)
@@ -270,7 +270,7 @@ meta_area_get_preferred_width (GtkWidget *widget,
   *minimal = *natural = requisition.width;
 }
 
-static void 
+static void
 meta_area_get_preferred_height (GtkWidget *widget,
                                gint      *minimal,
                                gint      *natural)
@@ -297,7 +297,7 @@ meta_area_setup (MetaArea           *area,
 {
   if (area->dnotify)
     (* area->dnotify) (area->user_data);
-  
+
   area->size_func = size_func;
   #if GTK_CHECK_VERSION(3, 0, 0)
   area->draw_func = draw_func;

--- a/src/ui/themewidget.h
+++ b/src/ui/themewidget.h
@@ -2,9 +2,9 @@
 
 /* Marco theme widget (displays themed draw operations) */
 
-/* 
+/*
  * Copyright (C) 2002 Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -14,7 +14,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA

--- a/src/wm-tester/focus-window.c
+++ b/src/wm-tester/focus-window.c
@@ -9,18 +9,18 @@ int main (int argc, char **argv)
   Window w;
   const char *w_str;
   char *end;
-  
+
   if (argc != 2)
     {
       fprintf (stderr, "Usage: focus-window WINDOWID\n");
       exit (1);
     }
-  
+
   d = XOpenDisplay (NULL);
 
   w_str = argv[1];
   end = NULL;
-  
+
   w = strtoul (w_str, &end, 16);
   if (end == w_str)
     {
@@ -31,7 +31,7 @@ int main (int argc, char **argv)
   printf ("Setting input focus to 0x%lx\n", w);
   XSetInputFocus (d, w, RevertToPointerRoot, CurrentTime);
   XFlush (d);
-  
+
   return 0;
 }
 

--- a/src/wm-tester/main.c
+++ b/src/wm-tester/main.c
@@ -1,8 +1,8 @@
 /* WM tester main() */
 
-/* 
+/*
  * Copyright (C) 2001 Havoc Pennington
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2 of the
@@ -12,7 +12,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -43,17 +43,17 @@ main (int argc, char **argv)
   int i;
   gboolean do_evil;
   gboolean do_icon_windows;
-  
-  gtk_init (&argc, &argv);  
-  
+
+  gtk_init (&argc, &argv);
+
   do_evil = FALSE;
   do_icon_windows = FALSE;
-  
+
   i = 1;
   while (i < argc)
     {
       const char *arg = argv[i];
-      
+
       if (strcmp (arg, "--help") == 0 ||
           strcmp (arg, "-h") == 0 ||
           strcmp (arg, "-?") == 0)
@@ -64,20 +64,20 @@ main (int argc, char **argv)
         do_icon_windows = TRUE;
       else
         usage ();
-      
+
       ++i;
     }
 
   /* Be sure some option was provided */
   if (! (do_evil || do_icon_windows))
     return 1;
-  
+
   if (do_evil)
     set_up_the_evil ();
 
   if (do_icon_windows)
     set_up_icon_windows ();
-  
+
   gtk_main ();
 
   return 0;
@@ -93,9 +93,9 @@ evil_timeout (gpointer data)
   int len;
   int create_count;
   int destroy_count;
-  
-  len = g_slist_length (evil_windows);  
-  
+
+  len = g_slist_length (evil_windows);
+
   if (len > 35)
     {
       create_count = 2;
@@ -109,7 +109,7 @@ evil_timeout (gpointer data)
 
   /* Create some windows */
   n_windows = g_random_int_range (0, create_count);
-  
+
   i = 0;
   while (i < n_windows)
     {
@@ -117,7 +117,7 @@ evil_timeout (gpointer data)
       GtkWidget *c;
       int t;
       GtkWidget *parent;
-      
+
       w = gtk_window_new (GTK_WINDOW_TOPLEVEL);
 
       #if GTK_CHECK_VERSION(3, 0, 0)
@@ -131,7 +131,7 @@ evil_timeout (gpointer data)
                                                     gdk_screen_height ()));
 
       parent = NULL;
-      
+
       /* set transient for random window (may create all kinds of weird cycles) */
       if (len > 0)
         {
@@ -139,22 +139,22 @@ evil_timeout (gpointer data)
           if (t >= 0)
             {
               parent = g_slist_nth_data (evil_windows, t);
-              
+
               if (parent != NULL)
                 gtk_window_set_transient_for (GTK_WINDOW (w), GTK_WINDOW (parent));
             }
         }
-      
+
       if (parent != NULL)
         c = gtk_button_new_with_label ("Evil Transient!");
       else
         c = gtk_button_new_with_label ("Evil Window!");
       gtk_container_add (GTK_CONTAINER (w), c);
-      
+
       gtk_widget_show_all (w);
-      
+
       evil_windows = g_slist_prepend (evil_windows, w);
-      
+
       ++i;
     }
 
@@ -166,7 +166,7 @@ evil_timeout (gpointer data)
       while (i < n_windows)
         {
           GtkWidget *w;
-          
+
           w = g_slist_nth_data (evil_windows,
                                 g_random_int_range (0, len));
           if (w)
@@ -175,11 +175,11 @@ evil_timeout (gpointer data)
               evil_windows = g_slist_remove (evil_windows, w);
               gtk_widget_destroy (w);
             }
-          
+
           ++i;
         }
     }
-  
+
   return TRUE;
 }
 
@@ -197,7 +197,7 @@ set_up_icon_windows (void)
 
   /* Create some windows */
   n_windows = 9;
-  
+
   i = 0;
   while (i < n_windows)
     {
@@ -205,7 +205,7 @@ set_up_icon_windows (void)
       GtkWidget *c;
       GList *icons;
       GdkPixbuf *pix;
-      
+
       w = gtk_window_new (GTK_WINDOW_TOPLEVEL);
       c = gtk_button_new_with_label ("Icon window");
       gtk_container_add (GTK_CONTAINER (w), c);
@@ -216,7 +216,7 @@ set_up_icon_windows (void)
                                     GTK_STOCK_SAVE,
                                     GTK_ICON_SIZE_LARGE_TOOLBAR,
                                     NULL);
-      
+
       icons = g_list_append (icons, pix);
 
       if (i % 2)
@@ -241,9 +241,9 @@ set_up_icon_windows (void)
 
       g_list_foreach (icons, (GFunc) g_object_unref, NULL);
       g_list_free (icons);
-      
+
       gtk_widget_show_all (w);
-      
+
       ++i;
     }
 }

--- a/src/wm-tester/test-gravity.c
+++ b/src/wm-tester/test-gravity.c
@@ -4,11 +4,11 @@
 #include <string.h>
 
 static int gravities[10] = {
-  NorthWestGravity, 
-  NorthGravity,  
+  NorthWestGravity,
+  NorthGravity,
   NorthEastGravity,
-  WestGravity,      
-  CenterGravity, 
+  WestGravity,
+  CenterGravity,
   EastGravity,
   SouthWestGravity,
   SouthGravity,
@@ -73,7 +73,7 @@ calculate_position (int i, int doubled, int *x, int *y)
       *x = 150;
       *y = 150;
     }
-  else 
+  else
     {
       int xoff = x_offset[i % 3];
       int yoff = y_offset[i / 3];
@@ -82,7 +82,7 @@ calculate_position (int i, int doubled, int *x, int *y)
           xoff *= 2;
           yoff *= 2;
         }
-      
+
       *x = screen_x_fraction[i % 3] * screen_width + xoff;
       *y = screen_y_fraction[i / 3] * screen_height + yoff;
     }
@@ -123,12 +123,12 @@ int main (int argc, char **argv)
   int screen;
   XEvent ev;
   int noframes;
-  
+
   if (argc > 1 && strcmp (argv[1], "--noframes") == 0)
     noframes = 1;
   else
     noframes = 0;
-  
+
   d = XOpenDisplay (NULL);
 
   screen = DefaultScreen (d);
@@ -138,11 +138,11 @@ int main (int argc, char **argv)
   for (i=0; i<10; i++)
     {
       int x, y;
-      
+
       calculate_position (i, doubled[i], &x, &y);
 
-      w = XCreateSimpleWindow (d, RootWindow (d, screen), 
-                               x, y, WINDOW_WIDTH, WINDOW_HEIGHT, 0, 
+      w = XCreateSimpleWindow (d, RootWindow (d, screen),
+                               x, y, WINDOW_WIDTH, WINDOW_HEIGHT, 0,
                                WhitePixel (d, screen), WhitePixel (d, screen));
 
       windows[i] = w;
@@ -150,11 +150,11 @@ int main (int argc, char **argv)
       window_rects[i].y = y;
       window_rects[i].width = WINDOW_WIDTH;
       window_rects[i].height = WINDOW_HEIGHT;
-      
+
       XSelectInput (d, w, ButtonPressMask | ExposureMask | StructureNotifyMask);
-      
+
       hints.flags = USPosition | PMinSize | PMaxSize | PWinGravity;
-      
+
       hints.min_width = WINDOW_WIDTH / 2;
       hints.min_height = WINDOW_HEIGHT / 2;
 
@@ -170,7 +170,7 @@ int main (int argc, char **argv)
       hints.max_height = WINDOW_HEIGHT * 2 + WINDOW_HEIGHT / 2;
 #endif
       hints.win_gravity = gravities[i];
-      
+
       XSetWMNormalHints (d, w, &hints);
 
       XStoreName (d, w, window_gravity_to_string (hints.win_gravity));
@@ -179,10 +179,10 @@ int main (int argc, char **argv)
         {
           MotifWmHints mwm;
           Atom mwm_atom;
-          
+
           mwm.decorations = 0;
           mwm.flags = MWM_HINTS_DECORATIONS;
-          
+
           mwm_atom = XInternAtom (d, "_MOTIF_WM_HINTS", False);
 
           XChangeProperty (d, w, mwm_atom, mwm_atom,
@@ -190,7 +190,7 @@ int main (int argc, char **argv)
                            (unsigned char *)&mwm,
                            sizeof (MotifWmHints)/sizeof (long));
         }
-      
+
       XMapWindow (d, w);
     }
 
@@ -201,14 +201,14 @@ int main (int argc, char **argv)
       if (ev.xany.type == ConfigureNotify)
         {
           i = find_window (ev.xconfigure.window);
-          
+
           if (i >= 0)
             {
               Window ignored;
-              
+
               window_rects[i].width = ev.xconfigure.width;
               window_rects[i].height = ev.xconfigure.height;
-              
+
               XClearArea (d, windows[i], 0, 0,
                           ev.xconfigure.width,
                           ev.xconfigure.height,
@@ -227,17 +227,17 @@ int main (int argc, char **argv)
             }
         }
       else if (ev.xany.type == Expose)
-        {          
+        {
           i = find_window (ev.xexpose.window);
-          
+
           if (i >= 0)
             {
               GC gc;
               XGCValues values;
               char buf[256];
-              
+
               values.foreground = BlackPixel (d, screen);
-              
+
               gc = XCreateGC (d, windows[i],
                               GCForeground, &values);
 
@@ -245,7 +245,7 @@ int main (int argc, char **argv)
                        "%d,%d",
                        window_rects[i].x,
                        window_rects[i].y);
-              
+
               XDrawString (d, windows[i], gc, 10, 15,
                            buf, strlen (buf));
 
@@ -253,10 +253,10 @@ int main (int argc, char **argv)
                        "%dx%d",
                        window_rects[i].width,
                        window_rects[i].height);
-              
+
               XDrawString (d, windows[i], gc, 10, 35,
                            buf, strlen (buf));
-              
+
               XFreeGC (d, gc);
             }
         }
@@ -267,13 +267,13 @@ int main (int argc, char **argv)
           if (i >= 0)
             {
               /* Button 1 = move, 2 = resize, 3 = both at once */
-                  
-              if (ev.xbutton.button == Button1) 
-                { 
+
+              if (ev.xbutton.button == Button1)
+                {
                   int x, y;
-		      
+
                   calculate_position (i, doubled[i], &x, &y);
-                  XMoveWindow (d, windows[i], x, y); 
+                  XMoveWindow (d, windows[i], x, y);
                 }
               else if (ev.xbutton.button == Button2)
                 {
@@ -287,7 +287,7 @@ int main (int argc, char **argv)
               else if (ev.xbutton.button == Button3)
                 {
                   int x, y;
-		      
+
                   calculate_position (i, !doubled[i], &x, &y);
 
                   if (doubled[i])

--- a/src/wm-tester/test-resizing.c
+++ b/src/wm-tester/test-resizing.c
@@ -17,7 +17,7 @@ calc_rects (XRectangle *rects, int width, int height)
       rects[i].height = h;
       ++i;
     }
-  
+
   /* NW */
   rects[0].x = 0;
   rects[0].y = 0;
@@ -70,7 +70,7 @@ get_size (Display *d, Drawable draw,
   int x, y;
   unsigned int width=0, height=0, border=0, depth=0;
   Window root;
-  
+
   XGetGeometry (d, draw, &root, &x, &y, &width, &height, &border, &depth);
 
   if (xp)
@@ -93,20 +93,20 @@ main (int argc, char **argv)
   XEvent ev;
   int x, y, width, height;
   Pixmap pix;
-  GC gc;  
+  GC gc;
   XGCValues gc_vals;
   XSetWindowAttributes set_attrs;
   XWindowChanges changes;
   XRectangle rects[9];
   gboolean redraw_pending;
   unsigned int mask;
-  
+
   d = XOpenDisplay (NULL);
 
   screen = DefaultScreen (d);
 
-  /* Print some debug spew to show how StaticGravity works */     
-  w = XCreateSimpleWindow (d, RootWindow (d, screen), 
+  /* Print some debug spew to show how StaticGravity works */
+  w = XCreateSimpleWindow (d, RootWindow (d, screen),
                            0, 0, 100, 100, 0,
                            WhitePixel (d, screen),
                            WhitePixel (d, screen));
@@ -115,21 +115,21 @@ main (int argc, char **argv)
                             WhitePixel (d, screen),
                             WhitePixel (d, screen));
   set_attrs.win_gravity = StaticGravity;
-      
+
   XChangeWindowAttributes (d, cw,
                            CWWinGravity,
                            &set_attrs);
-  
+
   get_size (d, w, &x, &y, &width, &height);
-  
+
   g_print ("Parent is %d,%d  %d x %d before configuring parent\n",
            x, y, width, height);
-  
+
   get_size (d, cw, &x, &y, &width, &height);
 
   g_print ("Child is %d,%d  %d x %d before configuring parent\n",
            x, y, width, height);
-  
+
   changes.x = 10;
   changes.y = 10;
   changes.width = 110;
@@ -138,7 +138,7 @@ main (int argc, char **argv)
   mask = CWX | CWY;
   mask = CWWidth | CWHeight;
   mask = CWX | CWY | CWWidth | CWHeight;
-  
+
   XConfigureWindow (d, w, mask, &changes);
   XSync (d, False);
 
@@ -146,42 +146,42 @@ main (int argc, char **argv)
 
   g_print ("Parent is %d,%d  %d x %d after configuring parent\n",
            x, y, width, height);
-  
+
   get_size (d, cw, &x, &y, &width, &height);
 
   g_print ("Child is %d,%d  %d x %d after configuring parent\n",
-           x, y, width, height);  
+           x, y, width, height);
 
   XDestroyWindow (d, w);
-  
+
   /* The window that gets displayed */
-  
+
   x = 20;
   y = 20;
   width = 100;
   height = 100;
 
   calc_rects (rects, width, height);
-  
-  w = XCreateSimpleWindow (d, RootWindow (d, screen), 
+
+  w = XCreateSimpleWindow (d, RootWindow (d, screen),
                            x, y, width, height, 0,
                            WhitePixel (d, screen),
                            WhitePixel (d, screen));
-  
+
   set_attrs.bit_gravity = StaticGravity;
-      
+
   XChangeWindowAttributes (d, w,
                            CWBitGravity,
                            &set_attrs);
-  
+
   XSelectInput (d, w,
                 ButtonPressMask | ExposureMask | StructureNotifyMask);
-  
+
   hints.flags = PMinSize;
-  
+
   hints.min_width = 100;
   hints.min_height = 100;
-  
+
   XSetWMNormalHints (d, w, &hints);
   XMapWindow (d, w);
 
@@ -189,7 +189,7 @@ main (int argc, char **argv)
   while (1)
     {
       XNextEvent (d, &ev);
-      
+
       switch (ev.xany.type)
         {
         case ButtonPress:
@@ -208,11 +208,11 @@ main (int argc, char **argv)
 
           redraw_pending = TRUE;
           break;
-          
+
         case Expose:
           redraw_pending = TRUE;
           break;
-          
+
         default:
           break;
         }
@@ -225,24 +225,24 @@ main (int argc, char **argv)
       else if (redraw_pending)
         {
           calc_rects (rects, width, height);
-          
+
           pix = XCreatePixmap (d, w, width, height,
                                DefaultDepth (d, screen));
-          
+
           gc_vals.foreground = WhitePixel (d, screen);
-          
+
           gc = XCreateGC (d, pix, GCForeground, &gc_vals);
-          
+
           XFillRectangle (d, pix, gc, 0, 0, width, height);
-              
+
           /* Draw rectangles at each gravity point */
           gc_vals.foreground = BlackPixel (d, screen);
           XChangeGC (d, gc, GCForeground, &gc_vals);
-          
+
           XFillRectangles (d, pix, gc, rects, G_N_ELEMENTS (rects));
-          
+
           XCopyArea (d, pix, w, gc, 0, 0, width, height, 0, 0);
-          
+
           XFreePixmap (d, pix);
           XFreeGC (d, gc);
 

--- a/src/wm-tester/test-size-hints.c
+++ b/src/wm-tester/test-size-hints.c
@@ -19,7 +19,7 @@ get_size (Display *d, Drawable draw,
   int x, y;
   unsigned int width, height, border, depth;
   Window root;
-  
+
   XGetGeometry (d, draw, &root, &x, &y, &width, &height, &border, &depth);
 
   if (xp)
@@ -43,10 +43,10 @@ main (int argc, char **argv)
   XEvent ev;
   int x, y, width, height;
   Pixmap pix;
-  GC gc;  
+  GC gc;
   XGCValues gc_vals;
   gboolean redraw_pending;
-  
+
   d = XOpenDisplay (NULL);
 
   screen = DefaultScreen (d);
@@ -55,20 +55,20 @@ main (int argc, char **argv)
   y = 0;
   width = 100;
   height = 100;
-  
-  zero_min_size = XCreateSimpleWindow (d, RootWindow (d, screen), 
+
+  zero_min_size = XCreateSimpleWindow (d, RootWindow (d, screen),
                                        x, y, width, height, 0,
                                        WhitePixel (d, screen),
-                                       WhitePixel (d, screen));  
-  
+                                       WhitePixel (d, screen));
+
   XSelectInput (d, zero_min_size,
                 ButtonPressMask | ExposureMask | StructureNotifyMask);
-  
+
   hints.flags = PMinSize;
-  
+
   hints.min_width = 0;
   hints.min_height = 0;
-  
+
   XSetWMNormalHints (d, zero_min_size, &hints);
   XMapWindow (d, zero_min_size);
 
@@ -76,7 +76,7 @@ main (int argc, char **argv)
   while (1)
     {
       XNextEvent (d, &ev);
-      
+
       switch (ev.xany.type)
         {
         case ButtonPress:
@@ -95,11 +95,11 @@ main (int argc, char **argv)
 
           redraw_pending = TRUE;
           break;
-          
+
         case Expose:
           redraw_pending = TRUE;
           break;
-          
+
         default:
           break;
         }
@@ -113,15 +113,15 @@ main (int argc, char **argv)
         {
           pix = XCreatePixmap (d, zero_min_size, width, height,
                                DefaultDepth (d, screen));
-          
+
           gc_vals.foreground = WhitePixel (d, screen);
-          
+
           gc = XCreateGC (d, pix, GCForeground, &gc_vals);
-          
+
           XFillRectangle (d, pix, gc, 0, 0, width, height);
-          
+
           XCopyArea (d, pix, zero_min_size, gc, 0, 0, width, height, 0, 0);
-          
+
           XFreePixmap (d, pix);
           XFreeGC (d, gc);
 


### PR DESCRIPTION
Just run:

```
 $ find -name '*.c' -print0 | xargs -r0 sed -e 's/[[:blank:]]\+$//' -i
 $ find -name '*.h' -print0 | xargs -r0 sed -e 's/[[:blank:]]\+$//' -i
```

Trivial, but useful
