### PR TITLE
fix seqfault when animation is disabled

### DIFF
--- a/src/core/effects.c
+++ b/src/core/effects.c
@@ -754,7 +754,8 @@ run_handler (MetaEffect *effect)
   }
   else
   {
-    effect->priv->finished(effect->priv->finished_data);
+    if (effect->priv->finished)
+      effect->priv->finished(effect->priv->finished_data);
   }
 
   effect_free (effect);


### PR DESCRIPTION
fix crash when org.mate.interface.enable-animations = false
