### PR TITLE
compositor-xrender: don't add shadows to ARGB windows

### DIFF
--- a/src/compositor/compositor-xrender.c
+++ b/src/compositor/compositor-xrender.c
@@ -911,6 +911,12 @@ window_has_shadow (MetaCompWindow *cw)
       }
     }
 
+  /* Do not add shadows to ARGB windows */
+  if (cw->mode == WINDOW_ARGB) {
+    meta_verbose ("Window has no shadow as it is ARGB\n");
+    return FALSE;
+  }
+
   /* Never put a shadow around shaped windows */
   if (cw->shaped) {
     meta_verbose ("Window has no shadow as it is shaped\n");


### PR DESCRIPTION
When marcos software compositor is enabled and GTK 3.14 is installed, drop down menus in GTK3 applications show "ghosting" around the menu.

This pull request stops adding shadows to ARGB windows which corrects the issue and is adapted from:
- https://git.gnome.org/browse/metacity/commit/?id=a6b29b2d2f6a7787c59cfffdc2bed1b5b5b99244

Tested on Arch Linux and Fedora 21 thanks to @NiceandGently.
