### PR TITLE
ui: use correct name for missing icon

### DIFF
--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -863,7 +863,7 @@ meta_ui_get_default_window_icon (MetaUI *ui)
                                                    NULL);
       else
           default_icon = gtk_icon_theme_load_icon (theme,
-                                                   "gtk-missing-image",
+                                                   "image-missing",
                                                    META_ICON_WIDTH,
                                                    0,
                                                    NULL);
@@ -898,7 +898,7 @@ meta_ui_get_default_mini_icon (MetaUI *ui)
                                                    NULL);
       else
           default_icon = gtk_icon_theme_load_icon (theme,
-                                                   "gtk-missing-image",
+                                                   "image-missing",
                                                    META_MINI_ICON_WIDTH,
                                                    0,
                                                    NULL);


### PR DESCRIPTION
According to Icon Naming Specification[1], the name "gtk-missing-image" is not a standard icon, and may not available in all themes (e.g. missing from the new Adwaita icon theme). Use "image-missing" instead.

The patch comes from metacity.[2]

[1] http://standards.freedesktop.org/icon-naming-spec/icon-naming-spec-latest.html
[2] https://git.gnome.org/browse/metacity/commit/?id=aa16325e8b938ca6d471fdf508a7276e577f8212
