### PR TITLE
Update compositor-xrender.c

### DIFF
--- a/src/compositor/compositor-xrender.c
+++ b/src/compositor/compositor-xrender.c
@@ -1821,6 +1821,10 @@ add_win (MetaScreen *screen,
 
   if (xwindow == info->output)
     return;
+    
+  /* If already added, ignore */
+  if (find_window_for_screen (screen, xwindow) != NULL)
+    return;
 
   cw = g_new0 (MetaCompWindow, 1);
   cw->screen = screen;


### PR DESCRIPTION
Fixes panels go completely transparent with compositing (issue #45). Backport from https://github.com/mate-desktop/marco/pull/107 to fix https://github.com/mate-desktop/marco/issues/45