### PR TITLE
show tile preview with external compositor

### DIFF
--- a/src/core/screen-private.h
+++ b/src/core/screen-private.h
@@ -115,6 +115,7 @@ struct _MetaScreen
 #endif
 
 #ifdef HAVE_COMPOSITE_EXTENSIONS
+  Atom wm_cm_atom;
   Window wm_cm_selection_window;
   guint32 wm_cm_timestamp;
 #endif

--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -1475,14 +1475,12 @@ meta_screen_tile_preview_update_timeout (gpointer data)
 {
   MetaScreen *screen = data;
   MetaWindow *window = screen->display->grab_window;
-  gboolean composited = screen->display->compositor != NULL;
   gboolean needs_preview = FALSE;
 
   screen->tile_preview_timeout_id = 0;
 
   if (!screen->tile_preview)
-    screen->tile_preview = meta_tile_preview_new (screen->number,
-                                                  composited);
+    screen->tile_preview = meta_tile_preview_new (screen->number);
 
   if (window)
     {

--- a/src/include/screen.h
+++ b/src/include/screen.h
@@ -43,6 +43,7 @@ MetaScreen *meta_screen_for_x_screen (Screen *xscreen);
 #ifdef HAVE_COMPOSITE_EXTENSIONS
 void meta_screen_set_cm_selection (MetaScreen *screen);
 void meta_screen_unset_cm_selection (MetaScreen *screen);
+gboolean meta_screen_is_cm_selected (MetaScreen *screen);
 #endif
 
 #endif

--- a/src/include/tile-preview.h
+++ b/src/include/tile-preview.h
@@ -24,13 +24,15 @@
 #define META_TILE_PREVIEW_H
 
 #include "boxes.h"
+#include "types.h"
 
 typedef struct _MetaTilePreview MetaTilePreview;
 
 MetaTilePreview   *meta_tile_preview_new    (int                screen_number);
 void               meta_tile_preview_free   (MetaTilePreview   *preview);
 void               meta_tile_preview_show   (MetaTilePreview   *preview,
-                                             MetaRectangle     *rect);
+                                             MetaRectangle     *rect,
+                                             MetaScreen        *screen);
 void               meta_tile_preview_hide   (MetaTilePreview   *preview);
 
 #endif /* META_TILE_PREVIEW_H */

--- a/src/include/tile-preview.h
+++ b/src/include/tile-preview.h
@@ -27,8 +27,7 @@
 
 typedef struct _MetaTilePreview MetaTilePreview;
 
-MetaTilePreview   *meta_tile_preview_new    (int                screen_number,
-                                             gboolean           composited);
+MetaTilePreview   *meta_tile_preview_new    (int                screen_number);
 void               meta_tile_preview_free   (MetaTilePreview   *preview);
 void               meta_tile_preview_show   (MetaTilePreview   *preview,
                                              MetaRectangle     *rect);

--- a/src/ui/tile-preview.c
+++ b/src/ui/tile-preview.c
@@ -177,8 +177,7 @@ on_preview_window_style_set (GtkWidget *widget,
 }
 
 MetaTilePreview *
-meta_tile_preview_new (int      screen_number,
-                       gboolean composited)
+meta_tile_preview_new (int      screen_number)
 {
   MetaTilePreview *preview;
 #if !GTK_CHECK_VERSION (3, 0, 0)
@@ -207,9 +206,9 @@ meta_tile_preview_new (int      screen_number,
   preview->tile_rect.width = preview->tile_rect.height = 0;
 
 #if GTK_CHECK_VERSION (3, 0, 0)
-  preview->has_alpha = composited && (gdk_screen_get_rgba_visual (screen) != NULL);
+  preview->has_alpha = gdk_screen_is_composited (screen) && (gdk_screen_get_rgba_visual (screen) != NULL);
 #else
-  preview->has_alpha = rgba_colormap && composited;
+  preview->has_alpha = rgba_colormap && gdk_screen_is_composited (screen);
 #endif
 
   if (preview->has_alpha)


### PR DESCRIPTION
current implementation of tile preview depends on buildin compositor. 
ie when builtin compositor is disabled, tile preview always display only borders.

with this patch tile preview works well with external compositor( for example with "compton")