### PR TITLE
Possible keybinding to switch to previous workspace.

### DIFF
--- a/src/50-marco-global-key.xml.in
+++ b/src/50-marco-global-key.xml.in
@@ -127,5 +127,8 @@
 	schema="org.mate.Marco.general"
 	comparison="gt" />
 
+	<KeyListEntry name="switch-to-workspace-prev"
+	_description="Switch to previously selected workspace" />
+
 </KeyListEntries>
 

--- a/src/core/keybindings.c
+++ b/src/core/keybindings.c
@@ -2288,6 +2288,14 @@ handle_switch_to_workspace (MetaDisplay    *display,
 {
   gint which = binding->handler->data;
   MetaWorkspace *workspace;
+
+  if (which == META_MOTION_PREV)
+    {
+      workspace = screen->prev_workspace;
+      if (workspace)
+          meta_workspace_activate (workspace, event->xkey.time);
+      return;
+    }
   
   if (which < 0)
     {

--- a/src/core/screen-private.h
+++ b/src/core/screen-private.h
@@ -85,6 +85,9 @@ struct _MetaScreen
 
   MetaWorkspace *active_workspace;
 
+  /* Previous active workspace */
+  MetaWorkspace *prev_workspace;
+
   /* This window holds the focus when we don't want to focus
    * any actual clients
    */

--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -385,6 +385,9 @@ meta_workspace_activate_with_focus (MetaWorkspace *workspace,
   /* Note that old can be NULL; e.g. when starting up */
   old = workspace->screen->active_workspace;
   
+  /* Save old workspace, to be able to switch back. */
+  workspace->screen->prev_workspace = old;
+
   workspace->screen->active_workspace = workspace;
 
   set_active_space_hint (workspace->screen);
@@ -798,6 +801,8 @@ meta_motion_direction_to_string (MetaMotionDirection direction)
       return "Left";
     case META_MOTION_RIGHT:
       return "Right";
+    case META_MOTION_PREV:
+      return "Previous";
     }
 
   return "Unknown";
@@ -837,6 +842,8 @@ meta_workspace_get_neighbor (MetaWorkspace      *workspace,
       break;
     case META_MOTION_DOWN:
       layout.current_row += 1;
+      break;
+    case META_MOTION_PREV:
       break;
     }
 
@@ -913,6 +920,8 @@ meta_workspace_get_neighbor (MetaWorkspace      *workspace,
         layout.current_row = 0;
         if (wrap == META_WRAP_TOROIDAL)
 	  layout.current_col = layout.current_col < layout.cols - 1 ? layout.current_col + 1 : 0;
+        break;
+      case META_MOTION_PREV:
         break;
       }
 

--- a/src/core/workspace.h
+++ b/src/core/workspace.h
@@ -43,7 +43,8 @@ typedef enum
   META_MOTION_UP = -1,
   META_MOTION_DOWN = -2,
   META_MOTION_LEFT = -3,
-  META_MOTION_RIGHT = -4
+  META_MOTION_RIGHT = -4,
+  META_MOTION_PREV = -5
 } MetaMotionDirection;
 
 struct _MetaWorkspace

--- a/src/include/all-keybindings.h
+++ b/src/include/all-keybindings.h
@@ -272,5 +272,8 @@ keybind (move-to-side-w, handle_move_to_side_w, 0,
 keybind (move-to-center, handle_move_to_center, 0,
         BINDING_PER_WINDOW)
 
+keybind (switch-to-workspace-prev, handle_switch_to_workspace,
+         META_MOTION_PREV, 0)
+
 /* eof all-keybindings.h */
 

--- a/src/org.mate.marco.gschema.xml
+++ b/src/org.mate.marco.gschema.xml
@@ -497,6 +497,11 @@
       <summary>Switch to workspace below the current workspace</summary>
       <description>The format looks like "&lt;Control&gt;a" or "&lt;Shift&gt;&lt;Alt&gt;F1". The parser is fairly liberal and allows lower or upper case, and also abbreviations such as "&lt;Ctl&gt;" and "&lt;Ctrl&gt;". If you set the option to the special string "disabled", then there will be no keybinding for this action.</description>
     </key>
+    <key name="switch-to-workspace-prev" type="s">
+      <default>'disabled'</default>
+      <summary>Switch to previously selected workspace</summary>
+      <description>The format looks like "&lt;Control&gt;a" or "&lt;Shift&gt;&lt;Alt&gt;F1". The parser is fairly liberal and allows lower or upper case, and also abbreviations such as "&lt;Ctl&gt;" and "&lt;Ctrl&gt;". If you set the option to the special string "disabled", then there will be no keybinding for this action.</description>
+    </key>
     <key name="switch-group" type="s">
       <default>'disabled'</default>
       <summary>Move between windows of an application, using a popup window</summary>


### PR DESCRIPTION
This is fixed version of previously rewerted pull request. It is partly cleaned and the affected atl+tab problem is fixed by placing keybind definition in all-keybindings.h on the end of file. This is not perfect, but I did not found any better solution.