### PR TITLE
Fullscreen windows can be minimized even if they do not have a minimize button, fixes wine alt-tab out of fullscreen game

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -5195,7 +5195,7 @@ meta_window_client_message (MetaWindow *window,
       meta_verbose ("WM_CHANGE_STATE client message, state: %ld\n",
                     event->xclient.data.l[0]);
       if (event->xclient.data.l[0] == IconicState &&
-          window->has_minimize_func)
+          ( window->has_minimize_func || window->fullscreen ))
         meta_window_minimize (window);
 
       return TRUE;


### PR DESCRIPTION
Fullscreen windows can be minimized even if they do not have a minimize button, fixes wine alt-tab out of fullscreen game

Signed-off-by: Tiziano Bacocco <tizbac2@gmail.com>