### PR TITLE
[1.8] preview-widget: use correct name for missing icon

### DIFF
--- a/src/ui/preview-widget.c
+++ b/src/ui/preview-widget.c
@@ -550,7 +550,7 @@ meta_preview_get_icon (void)
                                                    NULL);
       else
           default_icon = gtk_icon_theme_load_icon (theme,
-                                                   "gtk-missing-image",
+                                                   "image-missing",
                                                    META_ICON_WIDTH,
                                                    0,
                                                    NULL);
@@ -583,7 +583,7 @@ meta_preview_get_mini_icon (void)
                                                    NULL);
       else
           default_icon = gtk_icon_theme_load_icon (theme,
-                                                   "gtk-missing-image",
+                                                   "image-missing",
                                                    META_MINI_ICON_WIDTH,
                                                    0,
                                                    NULL);


### PR DESCRIPTION
from https://git.gnome.org/browse/metacity/commit/?id=5f8df557b8dbe962f19e8b641c007073665ff878