### PR TITLE
keybindings: pass screen name instead of number to error dialog

### DIFF
--- a/src/core/keybindings.c
+++ b/src/core/keybindings.c
@@ -2321,7 +2321,7 @@ static void
 error_on_command (int         command_index,
                   const char *command,
                   const char *message,
-                  int         screen_number,
+                  const char *screen_name,
                   guint32     timestamp)
 {
   if (command_index < 0)
@@ -2350,7 +2350,7 @@ error_on_command (int         command_index,
       meta_show_dialog ("--error",
                         text,
                         NULL,
-                        screen_number,
+                        screen_name,
                         NULL, NULL, 0,
                         NULL, NULL);
 
@@ -2362,7 +2362,7 @@ error_on_command (int         command_index,
       meta_show_dialog ("--error",
                         message,
                         NULL,
-                        screen_number,
+                        screen_name,
                         NULL, NULL, 0,
                         NULL, NULL);
     }
@@ -2433,7 +2433,7 @@ handle_run_command (MetaDisplay    *display,
 
       s = g_strdup_printf (_("No command %d has been defined.\n"),
                            which + 1);
-      error_on_command (which, NULL, s, screen->number, event->xkey.time);
+      error_on_command (which, NULL, s, screen->screen_name, event->xkey.time);
       g_free (s);
 
       return;
@@ -2442,7 +2442,7 @@ handle_run_command (MetaDisplay    *display,
   err = NULL;
   if (!meta_spawn_command_line_async_on_screen (command, screen, &err))
     {
-      error_on_command (which, command, err->message, screen->number, event->xkey.time);
+      error_on_command (which, command, err->message, screen->screen_name, event->xkey.time);
 
       g_error_free (err);
     }
@@ -3431,7 +3431,7 @@ handle_run_terminal (MetaDisplay    *display,
 		  "keybinding press\n");
 
       s = g_strdup_printf (_("No terminal command has been defined.\n"));
-      error_on_command (-1, NULL, s, screen->number, event->xkey.time);
+      error_on_command (-1, NULL, s, screen->screen_name, event->xkey.time);
       g_free (s);
 
       return;
@@ -3440,7 +3440,7 @@ handle_run_terminal (MetaDisplay    *display,
   err = NULL;
   if (!meta_spawn_command_line_async_on_screen (command, screen, &err))
     {
-      error_on_command (-1, command, err->message, screen->number,
+      error_on_command (-1, command, err->message, screen->screen_name,
                         event->xkey.time);
 
       g_error_free (err);


### PR DESCRIPTION
makes error dialogs on wrong command/terminal command actually work,
and fixes https://github.com/mate-desktop/marco/issues/150