### PR TITLE
prefs: make workspace name actually change

### DIFF
--- a/src/core/prefs.c
+++ b/src/core/prefs.c
@@ -972,7 +972,7 @@ change_notify (GSettings *settings,
 
       g_free(str);
     }
-  else if (g_strcmp0 (schema_name, KEY_WORKSPACE_NAME_SCHEMA))
+  else if (g_strcmp0 (schema_name, KEY_WORKSPACE_NAME_SCHEMA) == 0)
     {
       gchar *str;
         str = g_settings_get_string (settings, key);


### PR DESCRIPTION
now workspace names actually change on-the-fly when you change them in dconf-editor.
and this works with GLib 2.43 as well.