### PR TITLE
fix uninitialized data field for sending _NET_WM_SYNC_REQUEST event

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -3333,6 +3333,7 @@ send_sync_request (MetaWindow *window)
   ev.data.l[1] = meta_display_get_current_time (window->display);
   ev.data.l[2] = XSyncValueLow32 (value);
   ev.data.l[3] = XSyncValueHigh32 (value);
+  ev.data.l[4] = 0;
 
   /* We don't need to trap errors here as we are already
    * inside an error_trap_push()/pop() pair.


### PR DESCRIPTION
If this field is left uninitialized, a client may mistake Marco to support more than the single update request counter described in EWMH 1.5.