### PR TITLE
Reverting center-new-windows default to false. 

### DIFF
--- a/src/org.mate.marco.gschema.xml
+++ b/src/org.mate.marco.gschema.xml
@@ -162,7 +162,7 @@
       <description>Some applications disregard specifications in ways that result in window manager misfeatures. This option puts Marco in a rigorously correct mode, which gives a more consistent user interface, provided one does not need to run any misbehaving applications.</description>
     </key>
     <key name="center-new-windows" type="b">
-      <default>true</default>
+      <default>false</default>
       <summary>Determine if new windows are created on the center of the screen</summary>
       <description>By default, marco open new windows on the top left of the screen. If this option is enabled, new windows are open on the center of the screen, instead.</description>
     </key>


### PR DESCRIPTION
This is changed to match the description of the setting. In addition, the behavior to open new windows on the top left of the screen has been consistent for over a decade. I believe it's counter-productive to change this now.