### PR TITLE
theme: Remove outdated assertion

### DIFF
--- a/src/ui/theme.c
+++ b/src/ui/theme.c
@@ -1312,7 +1312,6 @@ meta_color_spec_new_from_string (const char *str,
       spec = meta_color_spec_new (META_COLOR_SPEC_GTK);
       spec->data.gtk.state = state;
       spec->data.gtk.component = component;
-      g_assert (spec->data.gtk.state < N_GTK_STATES);
       g_assert (spec->data.gtk.component < META_GTK_COLOR_LAST);
     }
   else if (str[0] == 'b' && str[1] == 'l' && str[2] == 'e' && str[3] == 'n' &&

--- a/src/ui/theme.h
+++ b/src/ui/theme.h
@@ -694,8 +694,6 @@ typedef enum
   META_FRAME_PIECE_LAST
 } MetaFramePiece;
 
-#define N_GTK_STATES 5
-
 /**
  * How to draw a frame in a particular state (say, a focussed, non-maximised,
  * resizable frame). This corresponds closely to the <frame_style> tag


### PR DESCRIPTION
The theme state used to use GtkStateType, but was ported over to GtkStateFlags,
leaving behind a broken assertion that fails when using certain Metacity
themes, for example Nodoka.

https://bugzilla.gnome.org/show_bug.cgi?id=661286
https://git.gnome.org/browse/mutter/commit/?id=28deea4
https://git.gnome.org/browse/metacity/commit/?id=c9099b4
https://github.com/mate-desktop/marco/issues/205