### PR TITLE
window menu: make minimize item insensitive when window should not be minimized

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -6721,8 +6721,8 @@ meta_window_show_menu (MetaWindow *window,
   if (!window->has_maximize_func)
     insensitive |= META_MENU_OP_UNMAXIMIZE | META_MENU_OP_MAXIMIZE;
 
-  /*if (!window->has_minimize_func)
-    insensitive |= META_MENU_OP_MINIMIZE;*/
+  if (!window->has_minimize_func)
+    insensitive |= META_MENU_OP_MINIMIZE;
 
   /*if (!window->has_close_func)
     insensitive |= META_MENU_OP_DELETE;*/


### PR DESCRIPTION
(e.g. delete confirmation dialog, logout dialog...)

it was working that way in gnome 2, I don't know why perberos commented it out...

fixes https://github.com/mate-desktop/caja/issues/443

@NiceandGently @infirit @flexiondotorg
please test it for any possible regressions :smile: