### PR TITLE
Gtk3: fix colors

### DIFF
--- a/src/ui/theme.c
+++ b/src/ui/theme.c
@@ -1482,67 +1482,27 @@ meta_color_spec_new_gtk (MetaGtkColorComponent component,
 
 #if GTK_CHECK_VERSION (3, 0, 0)
 static void
-get_background_color_real (GtkStyleContext *context,
-                           GtkStateFlags    state,
-                           GdkRGBA         *color)
-{
-  GdkRGBA *c;
-
-  g_return_if_fail (color != NULL);
-  g_return_if_fail (GTK_IS_STYLE_CONTEXT (context));
-
-  gtk_style_context_get (context,
-                         state,
-                         "background-color", &c,
-                         NULL);
-
-  *color = *c;
-  gdk_rgba_free (c);
-}
-
-static void
 get_background_color (GtkStyleContext *context,
                       GtkStateFlags    state,
                       GdkRGBA         *color)
 {
-  GdkRGBA empty = { 0.0, 0.0, 0.0, 0.0 };
   GdkRGBA rgba;
+  GtkWidget *toplevel;
+  GtkStyleContext *tmp;
 
-  get_background_color_real (context, state, &rgba);
+  toplevel = gtk_window_new (GTK_WINDOW_TOPLEVEL);
+  tmp = gtk_widget_get_style_context (toplevel);
 
-  if (gdk_rgba_equal (&rgba, &empty))
-    {
-      GtkWidget *toplevel;
-      GtkStyleContext *tmp;
+  g_return_if_fail (GTK_IS_STYLE_CONTEXT (tmp));
 
-      toplevel = gtk_window_new (GTK_WINDOW_TOPLEVEL);
-      tmp = gtk_widget_get_style_context (toplevel);
-
-      get_background_color_real (tmp, state, &rgba);
-
-      gtk_widget_destroy (toplevel);
-    }
-
-  *color = rgba;
-}
-
-static void
-get_foreground_color_real (GtkStyleContext *context,
-                           GtkStateFlags    state,
-                           GdkRGBA         *color)
-{
-  GdkRGBA *c;
-
-  g_return_if_fail (color != NULL);
-  g_return_if_fail (GTK_IS_STYLE_CONTEXT (context));
-
-  gtk_style_context_get (context,
+  gtk_style_context_get (tmp,
                          state,
-                         "color", &c,
+                         "background-color", &rgba,
                          NULL);
 
-  *color = *c;
-  gdk_rgba_free (c);
+  gtk_widget_destroy (toplevel);
+
+  *color = rgba;
 }
 
 static void
@@ -1550,23 +1510,21 @@ get_foreground_color (GtkStyleContext *context,
                       GtkStateFlags    state,
                       GdkRGBA         *color)
 {
-  GdkRGBA empty = { 1.0, 1.0, 1.0, 1.0 };
   GdkRGBA rgba;
+  GtkWidget *toplevel;
+  GtkStyleContext *tmp;
 
-  get_foreground_color_real (context, state, &rgba);
+  toplevel = gtk_window_new (GTK_WINDOW_TOPLEVEL);
+  tmp = gtk_widget_get_style_context (toplevel);
 
-  if (gdk_rgba_equal (&rgba, &empty))
-    {
-      GtkWidget *toplevel;
-      GtkStyleContext *tmp;
+  g_return_if_fail (GTK_IS_STYLE_CONTEXT (tmp));
 
-      toplevel = gtk_window_new (GTK_WINDOW_TOPLEVEL);
-      tmp = gtk_widget_get_style_context (toplevel);
+  gtk_style_context_get (tmp,
+                         state,
+                         "color", &rgba,
+                         NULL);
 
-      get_foreground_color_real (tmp, state, &rgba);
-
-      gtk_widget_destroy (toplevel);
-    }
+  gtk_widget_destroy (toplevel);
 
   *color = rgba;
 }


### PR DESCRIPTION
These changes are required to completely fix issue #208 in addition to commit 6ca27a47.

Gtk3: Fix foreground color
Similar to the previous background color fix, we need to fix text color too.

Gtk3: Always read colors
Without reading GTK+ colors every time, the colors remain unchanged, when the user changes the actual GTK+ theme.