### PR TITLE
Gtk3: fix colors

### DIFF
--- a/src/ui/theme.c
+++ b/src/ui/theme.c
@@ -1555,6 +1555,10 @@ meta_set_color_from_style (GdkRGBA               *color,
 {
   GdkRGBA other;
 
+  /* Add background class to context to get the correct colors from the GTK+
+     theme instead of white text over black background. */
+  gtk_style_context_add_class (context, GTK_STYLE_CLASS_BACKGROUND);
+
   switch (component)
     {
     case META_GTK_COLOR_BG:


### PR DESCRIPTION
Add GTK_STYLE_CLASS_BACKGROUND class to context, so we have correct colors from the GTK+ theme instead of white text over black background.

This change is required to completely fix issue #208 in addition to commit 6ca27a4.