### PR TITLE
GTK+3: Get values from GtkStyleContext states properly

### DIFF
--- a/src/ui/tile-preview.c
+++ b/src/ui/tile-preview.c
@@ -143,8 +143,13 @@ on_preview_window_style_set (GtkWidget *widget,
   gtk_widget_path_append_type (path, GTK_TYPE_ICON_VIEW);
   gtk_style_context_set_path (context, path);
 
-  gtk_style_context_get (context, GTK_STATE_FLAG_SELECTED, "background-color", &preview->preview_color, NULL);
+  gtk_style_context_save (context);
+  gtk_style_context_set_state (context, GTK_STATE_FLAG_SELECTED);
+  gtk_style_context_get (context, gtk_style_context_get_state (context),
+                         "background-color",
+                         &preview->preview_color, NULL);
   gtk_style_context_get_style (context, "selection-box-alpha", &alpha, NULL);
+  gtk_style_context_restore (context);
 
   preview->preview_color->alpha = (double)alpha / 0xFF;
 

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -849,7 +849,14 @@ meta_ui_theme_get_frame_borders (MetaUI *ui,
           gtk_style_context_set_path (style, widget_path);
           gtk_widget_path_free (widget_path);
 
-          gtk_style_context_get (style, GTK_STATE_FLAG_NORMAL, "font", &free_font_desc, NULL);
+          gtk_style_context_save (style);
+          gtk_style_context_set_state (style, GTK_STATE_FLAG_NORMAL);
+          gtk_style_context_get (style,
+                                 gtk_style_context_get_state (style),
+                                 "font",
+                                 &free_font_desc,
+                                 NULL);
+          gtk_style_context_restore (context);
           font_desc = (const PangoFontDescription *) free_font_desc;
 #else
           GtkStyle *default_style;


### PR DESCRIPTION
this avoids warnings like this:
Warning of Windowmanagement:Log level 16: State 4 for context 0x55988f9ad950
doesn't match state 128 set via gtk_style_context_set_state ()