### PR TITLE
Integrate upstream patches from metacity for new-window-always-on-top

### DIFF
--- a/src/core/prefs.c
+++ b/src/core/prefs.c
@@ -95,6 +95,7 @@ static MetaVirtualModifier mouse_button_mods = Mod1Mask;
 static MetaFocusMode focus_mode = META_FOCUS_MODE_CLICK;
 static MetaFocusNewWindows focus_new_windows = META_FOCUS_NEW_WINDOWS_SMART;
 static gboolean raise_on_click = TRUE;
+static gboolean new_windows_always_on_top = FALSE;
 static char* current_theme = NULL;
 static int num_workspaces = 4;
 static MetaWrapStyle wrap_style = META_WRAP_NONE;
@@ -417,6 +418,12 @@ static MetaBoolPreference preferences_bool[] =
       KEY_GENERAL_SCHEMA,
       META_PREF_SIDE_BY_SIDE_TILING,
       &side_by_side_tiling,
+      FALSE,
+    },
+    { "new-windows-always-on-top",
+      KEY_GENERAL_SCHEMA,
+      META_PREF_NEW_WINDOWS_ALWAYS_ON_TOP,
+      &new_windows_always_on_top,
       FALSE,
     },
     { NULL, NULL, 0, NULL, FALSE },
@@ -1060,6 +1067,12 @@ meta_prefs_get_raise_on_click (void)
   return raise_on_click || focus_mode == META_FOCUS_MODE_CLICK;
 }
 
+gboolean
+meta_prefs_get_new_windows_always_on_top (void)
+{
+  return new_windows_always_on_top;
+}
+
 const char*
 meta_prefs_get_theme (void)
 {
@@ -1473,6 +1486,9 @@ meta_preference_to_string (MetaPreference pref)
 
     case META_PREF_RAISE_ON_CLICK:
       return "RAISE_ON_CLICK";
+
+    case META_PREF_NEW_WINDOWS_ALWAYS_ON_TOP:
+      return "NEW_WINDOWS_ALWAYS_ON_TOP";
 
     case META_PREF_THEME:
       return "THEME";

--- a/src/include/prefs.h
+++ b/src/include/prefs.h
@@ -35,6 +35,7 @@ typedef enum
   META_PREF_FOCUS_MODE,
   META_PREF_FOCUS_NEW_WINDOWS,
   META_PREF_RAISE_ON_CLICK,
+  META_PREF_NEW_WINDOWS_ALWAYS_ON_TOP,
   META_PREF_ACTION_DOUBLE_CLICK_TITLEBAR,
   META_PREF_ACTION_MIDDLE_CLICK_TITLEBAR,
   META_PREF_ACTION_RIGHT_CLICK_TITLEBAR,
@@ -85,6 +86,7 @@ guint                       meta_prefs_get_mouse_button_menu  (void);
 MetaFocusMode               meta_prefs_get_focus_mode         (void);
 MetaFocusNewWindows         meta_prefs_get_focus_new_windows  (void);
 gboolean                    meta_prefs_get_raise_on_click     (void);
+gboolean                    meta_prefs_get_new_windows_always_on_top (void);
 const char*                 meta_prefs_get_theme              (void);
 /* returns NULL if GTK default should be used */
 const PangoFontDescription* meta_prefs_get_titlebar_font      (void);

--- a/src/org.mate.marco.gschema.xml
+++ b/src/org.mate.marco.gschema.xml
@@ -70,6 +70,33 @@
       <summary>Control how new windows get focus</summary>
       <description>This option provides additional control over how newly created windows get focus.  It has two possible values; "smart" applies the user's normal focus mode, and "strict" results in windows started from a terminal not being given focus.</description>
     </key>
+    <key name="new-windows-always-on-top" type="b">
+      <default>false</default>
+      <summary>Whether new windows should always be placed on top</summary>
+      <description>The normal behavior is that if a new window is not given the
+           focus (since, for example, the user has interacted with another
+           window after launching an application), then if the window would
+           be stacked on top of the focus window, the window is instead
+           stacked beneath and flashed in the taskbar. This behavior can
+           be annoying on large screens and multihead setups where the
+           taskbar is hard to notice and difficult to get to, so this option,
+           if set, disables this behavior, and new windows are always placed
+           on top, whether or not they get focus.
+
+           Note that if this option is set, a new window may completely hide
+           the focus window but not get focus itself, which can be quite confusing
+           to users. Also, note that setting this option breaks the normal
+           invariant in the 'click' focus mode that the topmost window always
+           has focus, so its most suitable for use with the 'mouse' and
+           'sloppy' focus modes.
+
+           This key also affects windows that try to activate or raise themselves
+           themselves but don't succeed in getting the the focus. Without
+           this key being set, such windows are flashed in the taskbar. With
+           this key set they, like entirely new windows, are raised but not
+           focused.
+      </description>
+    </key>
     <key name="raise-on-click" type="b">
       <default>true</default>
       <summary>Whether raising should be a side-effect of other user interactions</summary>


### PR DESCRIPTION
These changes correspond with the fixes associated with Red Hat Bugzilla #530263

The normal behavior is that if a new window is not given the
  focus (since, for example, the user has interacted with another
  window after launching an application), then if the window would
  be stacked on top of the focus window, the window is instead
  stacked beneath and flashed in the taskbar. This behavior can
  be annoying on large screens and multihead setups where the
  taskbar is hard to notice and difficult to get to, so this option,
  if set, disables this behavior, and new windows are always placed
  on top, whether or not they get focus.

  Note that if this option is set, a new window may completely hide
  the focus window but not get focus itself, which can be quite confusing
  to users. Also, note that setting this option breaks the normal
  invariant in the 'click' focus mode that the topmost window always
  has focus, so its most suitable for use with the 'mouse' and
  'sloppy' focus modes.

Upstream bug is https://bugzilla.gnome.org/show_bug.cgi?id=599261
