### PR TITLE
Added functionality to disable display preselected tab window border

### DIFF
--- a/src/core/prefs.c
+++ b/src/core/prefs.c
@@ -117,6 +117,7 @@ static gboolean force_compositor_manager = FALSE;
 static gboolean compositing_manager = FALSE;
 static gboolean compositing_fast_alt_tab = FALSE;
 static gboolean resize_with_right_button = FALSE;
+static gboolean show_tab_border = FALSE;
 static gboolean center_new_windows = FALSE;
 static gboolean force_fullscreen = TRUE;
 static gboolean side_by_side_tiling = FALSE;
@@ -405,6 +406,12 @@ static MetaBoolPreference preferences_bool[] =
       KEY_GENERAL_SCHEMA,
       META_PREF_RESIZE_WITH_RIGHT_BUTTON,
       &resize_with_right_button,
+      FALSE,
+    },
+    { "show-tab-border",
+      KEY_GENERAL_SCHEMA,
+      META_PREF_SHOW_TAB_BORDER,
+      &show_tab_border,
       FALSE,
     },
     { "center-new-windows",
@@ -1558,6 +1565,9 @@ meta_preference_to_string (MetaPreference pref)
     case META_PREF_RESIZE_WITH_RIGHT_BUTTON:
       return "RESIZE_WITH_RIGHT_BUTTON";
 
+    case META_PREF_SHOW_TAB_BORDER:
+      return "SHOW_TAB_BORDER";
+
     case META_PREF_FORCE_FULLSCREEN:
       return "FORCE_FULLSCREEN";
 
@@ -2243,6 +2253,12 @@ guint
 meta_prefs_get_mouse_button_menu (void)
 {
   return resize_with_right_button ? 2: 3;
+}
+
+gboolean
+meta_prefs_show_tab_border(void)
+{
+    return show_tab_border;
 }
 
 gboolean

--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -1288,6 +1288,7 @@ meta_screen_ensure_tab_popup (MetaScreen      *screen,
   GList *tmp;
   int len;
   int i;
+  gint border;
 
   if (screen->tab_popup)
     return;
@@ -1304,6 +1305,8 @@ meta_screen_ensure_tab_popup (MetaScreen      *screen,
   entries[len].title = NULL;
   entries[len].icon = NULL;
 
+  border = meta_prefs_show_tab_border() ? BORDER_OUTLINE_TAB |
+    BORDER_OUTLINE_WINDOW : BORDER_OUTLINE_TAB;
   i = 0;
   tmp = tab_list;
   while (i < len)
@@ -1368,38 +1371,43 @@ meta_screen_ensure_tab_popup (MetaScreen      *screen,
        * sides.  On the top it should be the size of the south frame
        * edge.
        */
-#define OUTLINE_WIDTH 5
-      /* Top side */
-      if (!entries[i].hidden &&
-          window->frame && window->frame->bottom_height > 0 &&
-          window->frame->child_y >= window->frame->bottom_height)
-        entries[i].inner_rect.y = window->frame->bottom_height;
-      else
-        entries[i].inner_rect.y = OUTLINE_WIDTH;
+       if (border & BORDER_OUTLINE_WINDOW)
+         {
+           const gint border_outline_width = 5;
 
-      /* Bottom side */
-      if (!entries[i].hidden &&
-          window->frame && window->frame->bottom_height != 0)
-        entries[i].inner_rect.height = r.height
-          - entries[i].inner_rect.y - window->frame->bottom_height;
-      else
-        entries[i].inner_rect.height = r.height
-          - entries[i].inner_rect.y - OUTLINE_WIDTH;
+           /* Top side */
+           if (!entries[i].hidden &&
+                window->frame && window->frame->bottom_height > 0 &&
+                window->frame->child_y >= window->frame->bottom_height)
+             entries[i].inner_rect.y = window->frame->bottom_height;
+           else
+              entries[i].inner_rect.y = border_outline_width;
 
-      /* Left side */
-      if (!entries[i].hidden && window->frame && window->frame->child_x != 0)
-        entries[i].inner_rect.x = window->frame->child_x;
-      else
-        entries[i].inner_rect.x = OUTLINE_WIDTH;
+            /* Bottom side */
+            if (!entries[i].hidden &&
+                window->frame && window->frame->bottom_height != 0)
+              entries[i].inner_rect.height = r.height
+                - entries[i].inner_rect.y - window->frame->bottom_height;
+            else
+              entries[i].inner_rect.height = r.height
+                - entries[i].inner_rect.y - border_outline_width;
 
-      /* Right side */
-      if (!entries[i].hidden &&
-          window->frame && window->frame->right_width != 0)
-        entries[i].inner_rect.width = r.width
-          - entries[i].inner_rect.x - window->frame->right_width;
-      else
-        entries[i].inner_rect.width = r.width
-          - entries[i].inner_rect.x - OUTLINE_WIDTH;
+            /* Left side */
+            if (!entries[i].hidden && window->frame && window->frame->child_x != 0)
+                entries[i].inner_rect.x = window->frame->child_x;
+            else
+                entries[i].inner_rect.x = border_outline_width;
+
+            /* Right side */
+            if (!entries[i].hidden &&
+                    window->frame && window->frame->right_width != 0)
+              entries[i].inner_rect.width = r.width
+                - entries[i].inner_rect.x - window->frame->right_width;
+            else
+              entries[i].inner_rect.width = r.width
+                - entries[i].inner_rect.x - border_outline_width;
+        }
+
 
       ++i;
       tmp = tmp->next;
@@ -1409,7 +1417,7 @@ meta_screen_ensure_tab_popup (MetaScreen      *screen,
                                              screen->number,
                                              len,
                                              5, /* FIXME */
-                                             TRUE);
+                                             border);
 
   for (i = 0; i < len; i++)
     g_object_unref (entries[i].icon);
@@ -1481,7 +1489,7 @@ meta_screen_ensure_workspace_popup (MetaScreen *screen)
                                              screen->number,
                                              len,
                                              layout.cols,
-                                             FALSE);
+                                             BORDER_OUTLINE_WORKSPACE);
 
   g_free (entries);
   meta_screen_free_workspace_layout (&layout);

--- a/src/include/prefs.h
+++ b/src/include/prefs.h
@@ -62,6 +62,7 @@ typedef enum
   META_PREF_COMPOSITING_MANAGER,
   META_PREF_COMPOSITING_FAST_ALT_TAB,
   META_PREF_RESIZE_WITH_RIGHT_BUTTON,
+  META_PREF_SHOW_TAB_BORDER,
   META_PREF_CENTER_NEW_WINDOWS,
   META_PREF_SIDE_BY_SIDE_TILING,
   META_PREF_FORCE_FULLSCREEN,
@@ -127,6 +128,7 @@ gboolean    meta_prefs_get_compositing_manager (void);
 gboolean    meta_prefs_get_compositing_fast_alt_tab (void);
 gboolean    meta_prefs_get_center_new_windows  (void);
 gboolean    meta_prefs_get_force_fullscreen  (void);
+gboolean    meta_prefs_show_tab_border (void);
 
 /**
  * Sets whether the compositor is turned on.

--- a/src/include/tabpopup.h
+++ b/src/include/tabpopup.h
@@ -36,6 +36,13 @@ typedef struct _MetaTabEntry MetaTabEntry;
 typedef struct _MetaTabPopup MetaTabPopup;
 typedef void *MetaTabEntryKey;
 
+typedef enum border_outline_t
+{
+  BORDER_OUTLINE_WINDOW = 1,
+  BORDER_OUTLINE_TAB = 2,
+  BORDER_OUTLINE_WORKSPACE = 4
+} border_outline_t;
+
 struct _MetaTabEntry
 {
   MetaTabEntryKey  key;

--- a/src/org.mate.marco.gschema.xml
+++ b/src/org.mate.marco.gschema.xml
@@ -55,6 +55,11 @@
       <summary>Whether to resize with the right button</summary>
       <description>Set this to true to resize with the right button and show a menu with the middle button while holding down the key given in "mouse_button_modifier"; set it to false to make it work the opposite way around.</description>
     </key>
+    <key name="show-tab-border" type="b">
+        <default>true</default>
+        <summary>Whether to display preselected tab window border</summary>
+        <description>Set this to false to disable border of preselected window while performing tab switching.</description>
+    </key>
     <key name="button-layout" type="s">
       <default>'menu:minimize,maximize,close'</default>
       <summary>Arrangement of buttons on the titlebar</summary>

--- a/src/ui/tabpopup.c
+++ b/src/ui/tabpopup.c
@@ -69,7 +69,7 @@ struct _MetaTabPopup
   GList *entries;
   TabEntry *current_selected_entry;
   GtkWidget *outline_window;
-  gboolean outline;
+  gint border;
 };
 
 static GtkWidget* selectable_image_new (GdkPixbuf *pixbuf);
@@ -101,8 +101,11 @@ outline_window_expose (GtkWidget      *widget,
 
   popup = data;
 
-  if (!popup->outline || popup->current_selected_entry == NULL)
+  if (popup->border & BORDER_OUTLINE_WORKSPACE ||
+        popup->current_selected_entry == NULL)
+  {
     return FALSE;
+  }
 
   te = popup->current_selected_entry;
 #if !GTK_CHECK_VERSION (3, 0, 0)
@@ -247,7 +250,7 @@ meta_ui_tab_popup_new (const MetaTabEntry *entries,
                        int                 screen_number,
                        int                 entry_count,
                        int                 width,
-                       gboolean            outline)
+                       gint                border)
 {
   MetaTabPopup *popup;
   int i, left, right, top, bottom;
@@ -301,12 +304,13 @@ meta_ui_tab_popup_new (const MetaTabEntry *entries,
   popup->current = NULL;
   popup->entries = NULL;
   popup->current_selected_entry = NULL;
-  popup->outline = outline;
+  popup->border = border;
 
   screen_width = gdk_screen_get_width (screen);
   for (i = 0; i < entry_count; ++i)
     {
-      TabEntry* new_entry = tab_entry_new (&entries[i], screen_width, outline);
+      TabEntry* new_entry = tab_entry_new (&entries[i], screen_width,
+        border & BORDER_OUTLINE_WINDOW);
       popup->entries = g_list_prepend (popup->entries, new_entry);
     }
 
@@ -403,7 +407,7 @@ meta_ui_tab_popup_new (const MetaTabEntry *entries,
               image = gtk_alignment_new (0.0, 0.0, 0.0, 0.0);
 #endif
             }
-          else if (outline)
+          else if (border & BORDER_OUTLINE_TAB)
             {
               if (te->dimmed_icon)
                 {
@@ -544,7 +548,7 @@ display_entry (MetaTabPopup *popup,
 
   if (popup->current_selected_entry)
   {
-    if (popup->outline)
+    if (popup->border & BORDER_OUTLINE_TAB)
       unselect_image (popup->current_selected_entry->widget);
     else
       unselect_workspace (popup->current_selected_entry->widget);
@@ -552,12 +556,12 @@ display_entry (MetaTabPopup *popup,
 
   gtk_label_set_markup (GTK_LABEL (popup->label), te->title);
 
-  if (popup->outline)
+  if (popup->border & BORDER_OUTLINE_TAB)
     select_image (te->widget);
   else
     select_workspace (te->widget);
 
-  if (popup->outline)
+  if (popup->border & BORDER_OUTLINE_WINDOW)
     {
       window = gtk_widget_get_window (popup->outline_window);
 


### PR DESCRIPTION
For better user experience by provide functionality to disable preselected tab windows border. User might turn on functionality via dconf-editor by going to the org/mate/marco/general and switch off 'show-tab-border' botton.
