### PR TITLE
Restore Polish translation credits from GNOME

### DIFF
--- a/po/gnome-copyrights.txt
+++ b/po/gnome-copyrights.txt
@@ -810,12 +810,17 @@
 
 
 ========== pl.po ==========
-# -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-# Aviary.pl
-# Jeśli masz jakiekolwiek uwagi odnoszące się do tłumaczenia lub chcesz
-# pomóc w jego rozwijaniu i pielęgnowaniu, napisz do nas:
-# matepl@aviary.pl
-# -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+# Polish translation for metacity.
+# Copyright © 2002-2010 the metacity authors.
+# This file is distributed under the same license as the metacity package.
+# Zbigniew Chyla <chyla@alice.ci.pwr.wroc.pl>, 2002-2003.
+# Artur Flinta <aflinta@at.kernel.pl>, 2003-2005.
+# Marek Stępień <marcoos@aviary.pl>, 2007.
+# Wadim Dziedzic <wdziedzic@aviary.pl>, 2007.
+# Tomasz Dominikowski <dominikowski@gmail.com>, 2008-2009.
+# Piotr Drąg <piotrdrag@gmail.com>, 2010.
+# Aviary.pl <gnomepl@aviary.pl>, 2007-2010.
+#
 
 
 


### PR DESCRIPTION
This commit restores proper credits and copyrights for the Polish translation that were somehow lost during forking, using historical information from git.gnome.org.