### PR TITLE
Fix setting name typo

### DIFF
--- a/README
+++ b/README
@@ -90,7 +90,7 @@ MARCO FEATURES
    marco-theme-viewer to preview themes.
 
  - Change number of workspaces via gsettings:
-     gsettings set org.mate.Marco.general num_workspaces 5
+     gsettings set org.mate.Marco.general num-workspaces 5
 
    Can also change workspaces from MATE 2 pager.
 


### PR DESCRIPTION
The setting name was incorrect:
```
jw@t470p:~$ gsettings list-recursively |grep num-work
org.gnome.desktop.wm.preferences num-workspaces 4
org.mate.Marco.general num-workspaces 1
org.mate.Marco.general num-workspaces 1
```