### PR TITLE
Forces a window scale of 1 for Marco. Closes #335

### DIFF
--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -62,6 +62,11 @@ void meta_ui_init(int* argc, char*** argv)
 	{
 		meta_fatal ("Unable to open X display %s\n", XDisplayName (NULL));
 	}
+
+  /* We need to be able to fully trust that the window and monitor sizes
+   * that GDK reports corresponds to the X ones, so we disable the automatic
+   * scale handling */
+  gdk_x11_display_set_window_scale (gdk_display_get_default (), 1);
 }
 
 Display* meta_ui_get_display(void)


### PR DESCRIPTION
The pull request forces a specific window scale for `marco`, instead of using the default or user configured scale. 

Tested on a Dell XPS 15 with 3840 x 2160 and `GDK_SCALE=2` and `GDK_DPI_SCALE=0.5` exported to the Xsession. Windows and screen dimensions are now correct.