### PR TITLE
Fix synthetic keybinding/button-grab window

### DIFF
--- a/src/core/display.c
+++ b/src/core/display.c
@@ -1779,6 +1779,22 @@ static gboolean event_callback(XEvent* event, gpointer data)
       meta_display_process_key_event (display, window, event);
       break;
     case ButtonPress:
+      /* Use window under pointer when processing synthetic events from another client */
+      if (window == NULL && event->xbutton.send_event)
+        {
+          int x, y, root_x, root_y;
+          Window root, child;
+          guint mask;
+          MetaScreen *random_screen;
+          random_screen = display->screens->data;
+          XQueryPointer (display->xdisplay,
+                         event->xany.window,
+                         &root, &child,
+                         &root_x, &root_y,
+                         &x, &y,
+                         &mask);
+          window = meta_display_lookup_x_window (display, child);
+        }
       if ((window &&
            grab_op_is_mouse (display->grab_op) &&
            display->grab_button != (int) event->xbutton.button &&

--- a/src/core/display.c
+++ b/src/core/display.c
@@ -1785,8 +1785,6 @@ static gboolean event_callback(XEvent* event, gpointer data)
           int x, y, root_x, root_y;
           Window root, child;
           guint mask;
-          MetaScreen *random_screen;
-          random_screen = display->screens->data;
           XQueryPointer (display->xdisplay,
                          event->xany.window,
                          &root, &child,

--- a/src/core/keybindings.c
+++ b/src/core/keybindings.c
@@ -1310,6 +1310,14 @@ meta_display_process_key_event (MetaDisplay *display,
       meta_ui_window_is_widget (screen->ui, event->xany.window))
     return;
 
+  /* Use focused window when processing synthetic events from another client */
+  if (window == NULL && event->xkey.send_event) {
+    Window focus = None;
+    int ret_to = RevertToPointerRoot;
+    XGetInputFocus (display->xdisplay, &focus, &ret_to);
+    window = meta_display_lookup_x_window (display, focus);
+  }
+
   /* window may be NULL */
 
 #ifdef HAVE_XKB


### PR DESCRIPTION
When a client is passively grabbing keys or mouse clicks that it does not need, it sends them up for other clients to process (this sets the `send_event` flag inside `XEvent`).

Often in this situation, the event contains the wrong window (either root, for global keybindings, or the original client itself). This means that Marco will attempt to process the event for the wrong window.

This is not an issue for global bindings within Marco, as the focused/current window does not matter. However, for shortcuts that operate directly on specific windows, the events gets lost.

This change addresses this issue by determining which is the currently-focused (for key grabs), or under-the-pointer (for button grabs), window, regardless of which client forwarded the event.