### PR TITLE
display: don't use deprecated GDK_DEVICE_MANAGER

### DIFF
--- a/src/core/display.c
+++ b/src/core/display.c
@@ -1437,6 +1437,12 @@ static gboolean maybe_send_event_to_gtk(MetaDisplay* display, XEvent* xevent)
 	GdkEvent* gdk_event = NULL;
 	GdkWindow* gdk_window;
 	Window window;
+#if GTK_CHECK_VERSION (3, 20, 0)
+	GdkSeat *seat;
+#else
+	GdkDeviceManager *manager;
+#endif
+	GdkDevice *device;
 
 	switch (xevent->type)
 	{
@@ -1471,8 +1477,14 @@ static gboolean maybe_send_event_to_gtk(MetaDisplay* display, XEvent* xevent)
 	 * (client-side) subwindow for individual menu items.
 	 */
 
-	GdkDeviceManager *device_manager = gdk_display_get_device_manager (gdk_display);
-	GdkDevice *device = gdk_device_manager_get_client_pointer (device_manager);
+#if GTK_CHECK_VERSION (3, 20, 0)
+	gdk_display = gdk_window_get_display (gdk_window);
+	seat = gdk_display_get_default_seat (gdk_display);
+	device = gdk_seat_get_pointer (seat);
+#else
+	manager = gdk_display_get_device_manager (gdk_display);
+	device = gdk_device_manager_get_client_pointer (manager);
+#endif
 
 	if (gdk_display_device_is_grabbed(gdk_display, device))
 	{


### PR DESCRIPTION
use GdkSeat for >= gtk+-3.20

Please test.