### PR TITLE
Allow tiled windows to be resized horizontally

### DIFF
--- a/src/core/constraints.c
+++ b/src/core/constraints.c
@@ -876,6 +876,7 @@ constrain_tiling (MetaWindow         *window,
   gboolean hminbad, vminbad;
   gboolean horiz_equal, vert_equal;
   gboolean constraint_already_satisfied;
+  gboolean allow_resize = FALSE;
 
   if (priority > PRIORITY_TILING)
     return TRUE;
@@ -908,9 +909,37 @@ constrain_tiling (MetaWindow         *window,
   if (check_only || constraint_already_satisfied)
     return constraint_already_satisfied;
 
+  /* Allow the user to resize horizontally when tiled */
+  if (info->is_user_action)
+    {
+      /* Only allow resizing from the window side farther from the screen edge */
+      switch (info->resize_gravity)
+        {
+        case NorthEastGravity:
+        case EastGravity:
+        case SouthEastGravity:
+          if (window->tile_mode == META_TILE_RIGHT)
+            allow_resize = TRUE;
+          break;
+        case NorthWestGravity:
+        case WestGravity:
+        case SouthWestGravity:
+          if (window->tile_mode == META_TILE_LEFT)
+            allow_resize = TRUE;
+          break;
+        }
+
+      /* Maintain current tile size for all other user-initiated alternatives */
+      target_size.x = info->orig.x;
+      target_size.width = info->orig.width;
+    }
+
   /*** Enforce constraint ***/
-  info->current.x      = target_size.x;
-  info->current.width  = target_size.width;
+  if (!allow_resize)
+    {
+      info->current.x      = target_size.x;
+      info->current.width  = target_size.width;
+    }
   info->current.y      = target_size.y;
   info->current.height = target_size.height;
 

--- a/src/core/constraints.c
+++ b/src/core/constraints.c
@@ -929,7 +929,13 @@ constrain_tiling (MetaWindow         *window,
           break;
         }
 
-      /* Maintain current tile size for all other user-initiated alternatives */
+      /* Mark window as being resized from a tiled state */
+      window->tile_resized = TRUE;
+    }
+
+  if (window->tile_resized)
+    {
+      /* Maintain current tile size for user-resized windows */
       target_size.x = info->orig.x;
       target_size.width = info->orig.width;
     }

--- a/src/core/keybindings.c
+++ b/src/core/keybindings.c
@@ -3109,6 +3109,7 @@ handle_toggle_tiled (MetaDisplay *display,
   else if (meta_window_can_tile (window))
     {
       window->tile_mode = mode;
+      window->tile_resized = FALSE;
       window->tile_monitor_number = meta_screen_get_xinerama_for_window (window->screen, window)->number;
       /* Maximization constraints beat tiling constraints, so if the window
        * is maximized, tiling won't have any effect unless we unmaximize it

--- a/src/core/window-private.h
+++ b/src/core/window-private.h
@@ -146,6 +146,7 @@ struct _MetaWindow
    * this is the current mode. If not, it is the mode which will be
    * requested after the window grab is released */
   guint tile_mode : 2;
+  guint tile_resized : 1;
 
   /* The last "full" maximized/unmaximized state. We need to keep track of
    * that to toggle between normal/tiled or maximized/tiled states. */

--- a/src/core/window-private.h
+++ b/src/core/window-private.h
@@ -408,12 +408,12 @@ struct _MetaWindow
 #define META_WINDOW_TILED_RIGHT(w) (META_WINDOW_TILED(w) && \
                                     (w)->tile_mode == META_TILE_RIGHT)
 #define META_WINDOW_ALLOWS_MOVE(w)     ((w)->has_move_func && !(w)->fullscreen)
-#define META_WINDOW_ALLOWS_RESIZE_EXCEPT_HINTS(w)   ((w)->has_resize_func && !META_WINDOW_MAXIMIZED (w) && !META_WINDOW_TILED(w) && !(w)->fullscreen && !(w)->shaded)
+#define META_WINDOW_ALLOWS_RESIZE_EXCEPT_HINTS(w)   ((w)->has_resize_func && !META_WINDOW_MAXIMIZED (w) && !(w)->fullscreen && !(w)->shaded)
 #define META_WINDOW_ALLOWS_RESIZE(w)   (META_WINDOW_ALLOWS_RESIZE_EXCEPT_HINTS (w) &&                \
                                         (((w)->size_hints.min_width < (w)->size_hints.max_width) ||  \
                                          ((w)->size_hints.min_height < (w)->size_hints.max_height)))
 #define META_WINDOW_ALLOWS_HORIZONTAL_RESIZE(w) (META_WINDOW_ALLOWS_RESIZE_EXCEPT_HINTS (w) && (w)->size_hints.min_width < (w)->size_hints.max_width)
-#define META_WINDOW_ALLOWS_VERTICAL_RESIZE(w)   (META_WINDOW_ALLOWS_RESIZE_EXCEPT_HINTS (w) && (w)->size_hints.min_height < (w)->size_hints.max_height)
+#define META_WINDOW_ALLOWS_VERTICAL_RESIZE(w)   (META_WINDOW_ALLOWS_RESIZE_EXCEPT_HINTS (w) && !META_WINDOW_TILED(w) && (w)->size_hints.min_height < (w)->size_hints.max_height)
 
 MetaWindow* meta_window_new                (MetaDisplay *display,
                                             Window       xwindow,

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -476,6 +476,7 @@ meta_window_new_with_attrs (MetaDisplay       *display,
   window->require_titlebar_visible = TRUE;
   window->on_all_workspaces = FALSE;
   window->tile_mode = META_TILE_NONE;
+  window->tile_resized = FALSE;
   window->tile_monitor_number = -1;
   window->shaded = FALSE;
   window->initially_iconic = FALSE;
@@ -7032,6 +7033,7 @@ update_move (MetaWindow  *window,
       /* Check if the cursor is in a position which triggers tiling
        * and set tile_mode accordingly.
        */
+      MetaTileMode tile_mode = window->tile_mode;
       if (meta_window_can_tile (window) &&
           x >= monitor->rect.x && x < (work_area.x + shake_threshold))
         window->tile_mode = META_TILE_LEFT;
@@ -7047,6 +7049,10 @@ update_move (MetaWindow  *window,
 
       if (window->tile_mode != META_TILE_NONE)
         window->tile_monitor_number = monitor->number;
+
+      /* Reset resized flag when changing tile mode */
+      if (tile_mode != window->tile_mode)
+        window->tile_resized = FALSE;
     }
 
   /* shake loose (unmaximize) maximized or tiled window if dragged beyond


### PR DESCRIPTION
Determine whether the user is initiating a resize action on a tiled
window. If the user is trying to grab the window for resizing
horizontally from the edge that's farther away from the screen edge,
allow the resize to occur. Otherwise maintain the current tile geometry.

Also modified the window hints to allow resizing from the window menu.

Fixes #250