### PR TITLE
Fix #329: Compositer leaks XFIXES regions

### DIFF
--- a/src/compositor/compositor-xrender.c
+++ b/src/compositor/compositor-xrender.c
@@ -1216,8 +1216,15 @@ paint_windows (MetaScreen   *screen,
 
           if (cw->type == META_COMP_WINDOW_DESKTOP)
             {
-              desktop_region = XFixesCreateRegion (xdisplay, 0, 0);
-              XFixesCopyRegion (xdisplay, desktop_region, paint_region);
+              if(desktop_region)
+              {
+                XFixesUnionRegion (xdisplay, desktop_region, desktop_region, paint_region);
+              }
+              else
+              {
+                desktop_region = XFixesCreateRegion (xdisplay, 0, 0);
+                XFixesCopyRegion (xdisplay, desktop_region, paint_region);
+              }
             }
 
           XFixesSubtractRegion (xdisplay, paint_region,


### PR DESCRIPTION
XFIXES regions are leaked during paint_windows if more than one META_COMP_WINDOW_DESKTOP is available (#329)