### PR TITLE
WidthOfScreen and HeightOfScreen implementation

### DIFF
--- a/src/tools/marco-window-demo.c
+++ b/src/tools/marco-window-demo.c
@@ -559,8 +559,6 @@ make_dock (int type)
   GtkWidget *image;
   GtkWidget *box;
   GtkWidget *button;
-  int        sc_width;
-  int        sc_height;
 
   g_return_if_fail (type != DOCK_ALL);
 
@@ -595,9 +593,6 @@ make_dock (int type)
 
   gtk_container_add (GTK_CONTAINER (window), box);
 
-  gdk_window_get_geometry (gdk_screen_get_root_window (gdk_screen_get_default()),
-                           NULL, NULL, &sc_width, &sc_height);
-
 #define DOCK_SIZE 48
   switch (type)
     {
@@ -609,7 +604,7 @@ make_dock (int type)
       break;
     case DOCK_RIGHT:
       gtk_widget_set_size_request (window, DOCK_SIZE, 400);
-      gtk_window_move (GTK_WINDOW (window), sc_width - DOCK_SIZE, 200);
+      gtk_window_move (GTK_WINDOW (window), WidthOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())) - DOCK_SIZE, 200);
       set_gtk_window_struts (window, 0, DOCK_SIZE, 0, 0);
       gtk_window_set_title (GTK_WINDOW (window), "RightDock");
       break;
@@ -621,7 +616,7 @@ make_dock (int type)
       break;
     case DOCK_BOTTOM:
       gtk_widget_set_size_request (window, 600, DOCK_SIZE);
-      gtk_window_move (GTK_WINDOW (window), 200, sc_height - DOCK_SIZE);
+      gtk_window_move (GTK_WINDOW (window), 200, HeightOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())) - DOCK_SIZE);
       set_gtk_window_struts (window, 0, 0, 0, DOCK_SIZE);
       gtk_window_set_title (GTK_WINDOW (window), "BottomDock");
       break;
@@ -698,16 +693,13 @@ desktop_cb (GSimpleAction *action,
   GtkWidget *window;
   GtkWidget *label;
   GdkRGBA    desktop_color;
-  int        sc_width;
-  int        sc_height;
-
-  gdk_window_get_geometry (gdk_screen_get_root_window (gdk_screen_get_default()),
-                           NULL, NULL, &sc_width, &sc_height);
 
   window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
   set_gtk_window_type (GTK_WINDOW (window), "_NET_WM_WINDOW_TYPE_DESKTOP");
   gtk_window_set_title (GTK_WINDOW (window), "Desktop");
-  gtk_widget_set_size_request (window, sc_width, sc_height);
+  gtk_widget_set_size_request (window,
+                               WidthOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())),
+                               HeightOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())));
   gtk_window_move (GTK_WINDOW (window), 0, 0);
 
   desktop_color.red = 0.32;

--- a/src/ui/menu.c
+++ b/src/ui/menu.c
@@ -21,6 +21,7 @@
  * 02110-1301, USA.
  */
 
+#include <gdk/gdkx.h>
 #include <config.h>
 #include <stdio.h>
 #include <string.h>
@@ -103,7 +104,6 @@ static void popup_position_func(GtkMenu* menu, gint* x, gint* y, gboolean* push_
 {
 	GtkRequisition req;
 	GdkPoint* pos;
-	int sc_width, sc_height;
 
 	pos = user_data;
 
@@ -117,12 +117,9 @@ static void popup_position_func(GtkMenu* menu, gint* x, gint* y, gboolean* push_
 		*x = MAX (0, *x - req.width);
 	}
 
-	gdk_window_get_geometry (gdk_screen_get_root_window (gdk_screen_get_default()),
-				 NULL, NULL, &sc_width, &sc_height);
-
 	/* Ensure onscreen */
-	*x = CLAMP (*x, 0, MAX(0, sc_width - req.width));
-	*y = CLAMP (*y, 0, MAX(0, sc_height - req.height));
+	*x = CLAMP (*x, 0, MAX(0, WidthOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())) - req.width));
+	*y = CLAMP (*y, 0, MAX(0, HeightOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())) - req.height));
 }
 
 static void menu_closed(GtkMenu* widget, gpointer data)

--- a/src/ui/tabpopup.c
+++ b/src/ui/tabpopup.c
@@ -34,6 +34,7 @@
 #include "../core/frame-private.h"
 #include "draw-workspace.h"
 #include <gtk/gtk.h>
+#include <gdk/gdkx.h>
 #include <math.h>
 
 #define OUTSIDE_SELECT_RECT 2
@@ -259,9 +260,7 @@ meta_ui_tab_popup_new (const MetaTabEntry *entries,
   popup->current_selected_entry = NULL;
   popup->border = border;
 
-  gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-                           &screen_width, NULL);
-
+  screen_width = WidthOfScreen (gdk_x11_screen_get_xscreen (screen));
   for (i = 0; i < entry_count; ++i)
     {
       TabEntry* new_entry = tab_entry_new (&entries[i], screen_width,

--- a/src/wm-tester/main.c
+++ b/src/wm-tester/main.c
@@ -20,6 +20,7 @@
  */
 
 #include <gtk/gtk.h>
+#include <gdk/gdkx.h>
 
 #include <stdlib.h>
 #include <sys/types.h>
@@ -117,16 +118,14 @@ evil_timeout (gpointer data)
       GtkWidget *c;
       int t;
       GtkWidget *parent;
-      int sc_width, sc_height;
-
-      gdk_window_get_geometry (gdk_screen_get_root_window (gdk_screen_get_default()),
-                               NULL, NULL, &sc_width, &sc_height);
 
       w = gtk_window_new (GTK_WINDOW_TOPLEVEL);
 
       gtk_window_move (GTK_WINDOW (w),
-                       g_random_int_range (0, sc_width),
-                       g_random_int_range (0, sc_height));
+                       g_random_int_range (0,
+                                           WidthOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ()))),
+                       g_random_int_range (0,
+                                           HeightOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ()))));
 
       parent = NULL;
 


### PR DESCRIPTION
This commit reverts:

https://github.com/mate-desktop/marco/commit/f0541e3dfda29c26fe14c9c9117f95c49006c75c
https://github.com/mate-desktop/marco/commit/d18c2fb4acb58c408c01700682b9922de86e8b2f

And it applies an alternative to fix the deprecated functions:

gdk_screen_get_width

gdk_screen_width
gdk_screen_height