### PR TITLE
Fix for unfullscreening after resizing tiled window

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -2902,6 +2902,7 @@ meta_window_make_fullscreen_internal (MetaWindow  *window)
       meta_window_save_rect (window);
 
       window->fullscreen = TRUE;
+      window->tile_resized = FALSE;
       window->force_save_user_rect = FALSE;
 
       meta_stack_freeze (window->screen->stack);
@@ -2936,9 +2937,13 @@ meta_window_unmake_fullscreen (MetaWindow  *window)
 
       meta_topic (META_DEBUG_WINDOW_OPS,
                   "Unfullscreening %s\n", window->desc);
-
+      
       window->fullscreen = FALSE;
-      target_rect = window->saved_rect;
+
+      if(!META_WINDOW_TILED (window))
+        target_rect = window->saved_rect;
+      else
+        meta_window_get_current_tile_area(window, &target_rect);
 
       /* Window's size hints may have changed while maximized, making
        * saved_rect invalid.  #329152


### PR DESCRIPTION
With this fix the window gets correctly set back to its tiled state after leaving fullscreen mode and after having resized it when it was tiled. Please test

Fixes #357 