### PR TITLE
keybindings.c: Fix build warning: assignment discards ‘const’ qualifier from pointer target type

### DIFF
--- a/src/core/keybindings.c
+++ b/src/core/keybindings.c
@@ -3591,7 +3591,8 @@ handle_rename_workspace(MetaDisplay *display,
                         XEvent *event,
                         MetaKeyBinding *binding)
 {
-  gchar *window_title, *window_content, *entry_text;
+  gchar *window_title, *window_content;
+  const char *entry_text;
   GPid dialog_pid;
   
   meta_topic (META_DEBUG_KEYBINDINGS, "handle_rename_workspace: called.\n");


### PR DESCRIPTION
We have this build warning since the PR https://github.com/mate-desktop/marco/pull/308 merged with the commit https://github.com/mate-desktop/marco/commit/5ded52f5e98d60abb903cc9194714a9b293ad482