### PR TITLE
Implemented a setting to disable top tiling

### DIFF
--- a/src/core/prefs.c
+++ b/src/core/prefs.c
@@ -120,7 +120,8 @@ static gboolean resize_with_right_button = FALSE;
 static gboolean show_tab_border = FALSE;
 static gboolean center_new_windows = FALSE;
 static gboolean force_fullscreen = TRUE;
-static gboolean side_by_side_tiling = FALSE;
+static gboolean allow_tiling = FALSE;
+static gboolean allow_top_tiling = TRUE;
 static GList *show_desktop_skip_list = NULL;
 
 static MetaVisualBellType visual_bell_type = META_VISUAL_BELL_FULLSCREEN_FLASH;
@@ -422,10 +423,16 @@ static MetaBoolPreference preferences_bool[] =
       &center_new_windows,
       FALSE,
     },
-    { "side-by-side-tiling",
+    { "allow-tiling",
       KEY_GENERAL_SCHEMA,
-      META_PREF_SIDE_BY_SIDE_TILING,
-      &side_by_side_tiling,
+      META_PREF_ALLOW_TILING,
+      &allow_tiling,
+      FALSE,
+    },
+    { "allow-top-tiling",
+      KEY_GENERAL_SCHEMA,
+      META_PREF_ALLOW_TOP_TILING,
+      &allow_top_tiling,
       FALSE,
     },
     { NULL, NULL, 0, NULL, FALSE },
@@ -1618,8 +1625,11 @@ meta_preference_to_string (MetaPreference pref)
     case META_PREF_FORCE_FULLSCREEN:
       return "FORCE_FULLSCREEN";
 
-    case META_PREF_SIDE_BY_SIDE_TILING:
-      return "SIDE_BY_SIDE_TILING";
+    case META_PREF_ALLOW_TILING:
+      return "ALLOW_TILING";
+
+    case META_PREF_ALLOW_TOP_TILING:
+      return "ALLOW_TOP_TILING";
 
     case META_PREF_PLACEMENT_MODE:
       return "PLACEMENT_MODE";
@@ -2288,9 +2298,15 @@ meta_prefs_get_center_new_windows (void)
 }
 
 gboolean
-meta_prefs_get_side_by_side_tiling ()
+meta_prefs_get_allow_tiling ()
 {
-  return side_by_side_tiling;
+  return allow_tiling;
+}
+
+gboolean
+meta_prefs_get_allow_top_tiling ()
+{
+  return allow_top_tiling;
 }
 
 guint

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -7028,7 +7028,7 @@ update_move (MetaWindow  *window,
       window->tile_mode = META_TILE_NONE;
       window->tile_monitor_number = -1;
     }
-  else if (meta_prefs_get_side_by_side_tiling () &&
+  else if (meta_prefs_get_allow_tiling () &&
            !META_WINDOW_MAXIMIZED (window) &&
            !META_WINDOW_TILED (window))
     {
@@ -7056,16 +7056,16 @@ update_move (MetaWindow  *window,
       /* Check if the cursor is in a position which triggers tiling
        * and set tile_mode accordingly.
        */
-      MetaTileMode tile_mode = window->tile_mode;
+      MetaTileMode old_tile_mode = window->tile_mode;
       window->tile_mode = calculate_tiling_mode(x, y, window, monitor,
                                                 work_area, shake_threshold);
-
-
+      
+      
       if (window->tile_mode != META_TILE_NONE)
         window->tile_monitor_number = monitor->number;
 
       /* Reset resized flag when changing tile mode */
-      if (tile_mode != window->tile_mode)
+      if (old_tile_mode != window->tile_mode)
         window->tile_resized = FALSE;
     }  
 
@@ -7260,7 +7260,8 @@ static MetaTileMode calculate_tiling_mode(int x,
         return META_TILE_RIGHT; 
     }
   else if (meta_window_can_tile_maximized (window) &&
-           y >= monitor->rect.y && y <= work_area.y)
+           y >= monitor->rect.y && y <= work_area.y &&
+           meta_prefs_get_allow_top_tiling ())
     return META_TILE_MAXIMIZED; 
   else
     return META_TILE_NONE;

--- a/src/include/prefs.h
+++ b/src/include/prefs.h
@@ -64,7 +64,8 @@ typedef enum
   META_PREF_RESIZE_WITH_RIGHT_BUTTON,
   META_PREF_SHOW_TAB_BORDER,
   META_PREF_CENTER_NEW_WINDOWS,
-  META_PREF_SIDE_BY_SIDE_TILING,
+  META_PREF_ALLOW_TILING,
+  META_PREF_ALLOW_TOP_TILING,
   META_PREF_FORCE_FULLSCREEN,
   META_PREF_PLACEMENT_MODE,
   META_PREF_SHOW_DESKTOP_SKIP_LIST
@@ -98,8 +99,9 @@ int                         meta_prefs_get_auto_raise_delay   (void);
 MetaWrapStyle               meta_prefs_get_wrap_style         (void);
 gboolean                    meta_prefs_get_reduced_resources  (void);
 gboolean                    meta_prefs_get_mate_accessibility (void);
-gboolean                    meta_prefs_get_mate_animations   (void);
-gboolean                    meta_prefs_get_side_by_side_tiling (void);
+gboolean                    meta_prefs_get_mate_animations    (void);
+gboolean                    meta_prefs_get_allow_tiling       (void);
+gboolean                    meta_prefs_get_allow_top_tiling   (void);
 
 const char*                 meta_prefs_get_command            (int i);
 

--- a/src/org.mate.marco.gschema.xml
+++ b/src/org.mate.marco.gschema.xml
@@ -176,10 +176,15 @@
       <summary>Determines if new windows are created on the center of the screen</summary>
       <description>If set to true, new windows are opened in the center of the screen. Otherwise, they are opened at the top left of the screen.</description>
     </key>
-    <key name="side-by-side-tiling" type="b">
+    <key name="allow-tiling" type="b">
       <default>true</default>
       <summary>Whether to enable side-by-side tiling</summary>
-      <description>If enabled, dropping windows on screen edges maximizes them vertically and resizes them horizontally to cover half of the available area. Drag-dropping to the top maximizes the window.</description>
+      <description>If enabled, dropping windows on screen edges maximizes them vertically and resizes them horizontally to cover half of the available area. Drag-dropping to the top maximizes the windowif allow-top-tiling is enabled.</description>
+    </key>
+    <key name="allow-top-tiling" type="b">
+      <default>true</default>
+      <summary>Wether to maximize the window when dragged to the top of the screen</summary>
+      <description>If enabled, drag-dropping a window to the top of the screen will maximize it. Only works when allow-tiling is enabled.</description>
     </key>
     <key name="placement-mode" enum="org.mate.Marco.placement_type">
       <default>'automatic'</default>


### PR DESCRIPTION
@raveit65 

I implemented a setting to disable the maximization when dragged to the top of the screen.
You have to recompile the gschema file to test it :)

The two settings are now called `allow-tiling` and `allow-top-tiling`