### PR TITLE
Fixes move_to_center moving window between monitors

### DIFF
--- a/src/core/keybindings.c
+++ b/src/core/keybindings.c
@@ -2652,12 +2652,16 @@ handle_move_to_center  (MetaDisplay    *display,
                         XEvent         *event,
                         MetaKeyBinding *binding)
 {
+  const MetaXineramaScreenInfo* current;
   MetaRectangle work_area;
   MetaRectangle outer;
   int orig_x, orig_y;
   int frame_width, frame_height;
 
-  meta_window_get_work_area_all_xineramas (window, &work_area);
+  current = meta_screen_get_xinerama_for_window(screen, window);
+  meta_window_get_work_area_for_xinerama (window,
+                                          current->number,
+                                          &work_area);
   meta_window_get_outer_rect (window, &outer);
   meta_window_get_position (window, &orig_x, &orig_y);
 


### PR DESCRIPTION
When two or more monitors are connected, the move_to_center keybind moves the window to the center of the whole xinerama, which in case of two monitors means that the window lands between the monitors. I think that this is unwanted behavior (?). This is a small fix that moves the window to the center of the monitor that the window belongs to.