### PR TITLE
window: add _NET_WM_STATE_FOCUSED hint to _NET_WM_STATE

### DIFF
--- a/src/core/atomnames.h
+++ b/src/core/atomnames.h
@@ -158,6 +158,7 @@ item(_NET_WM_ACTION_ABOVE)
 item(_NET_WM_ACTION_BELOW)
 item(_NET_WM_STATE_STICKY)
 item(_NET_WM_FULLSCREEN_MONITORS)
+item(_NET_WM_STATE_FOCUSED)
 
 #if 0
 /* We apparently never use: */


### PR DESCRIPTION
Fixes https://github.com/mate-desktop/marco/issues/383 if :backdrop state supported in themes
ported from:
https://github.com/GNOME/metacity/commit/4ccb99a50c54f345c4c7d9ac77f1ea76bc6c7c74