### PR TITLE
GSettings preference to control compositor shadow rendering

### DIFF
--- a/src/compositor/compositor-xrender.c
+++ b/src/compositor/compositor-xrender.c
@@ -38,6 +38,7 @@
 
 #include <cairo/cairo-xlib.h>
 
+#include "prefs.h"
 #include "display.h"
 #include "../core/display-private.h"
 #include "screen.h"
@@ -2786,7 +2787,9 @@ xrender_manage_screen (MetaCompositor *compositor,
   info->overlays = 0;
   info->clip_changed = TRUE;
 
-  info->have_shadows = (g_getenv("META_DEBUG_NO_SHADOW") == NULL);
+  info->have_shadows = (g_getenv("META_DEBUG_NO_SHADOW") == NULL &&
+                        meta_prefs_get_compositing_shadows() == TRUE);
+
   if (info->have_shadows)
     {
       meta_verbose ("Enabling shadows\n");

--- a/src/core/prefs.c
+++ b/src/core/prefs.c
@@ -50,6 +50,7 @@
 #define KEY_GENERAL_TITLEBAR_FONT "titlebar-font"
 #define KEY_GENERAL_NUM_WORKSPACES "num-workspaces"
 #define KEY_GENERAL_COMPOSITOR "compositing-manager"
+#define KEY_GENERAL_COMPOSITOR_SHADOWS "compositing-shadows"
 #define KEY_GENERAL_COMPOSITOR_FAST_ALT_TAB "compositing-fast-alt-tab"
 #define KEY_GENERAL_CENTER_NEW_WINDOWS "center-new-windows"
 
@@ -116,6 +117,7 @@ static int   cursor_size = 24;
 static gboolean use_force_compositor_manager = FALSE;
 static gboolean force_compositor_manager = FALSE;
 static gboolean compositing_manager = FALSE;
+static gboolean compositing_shadows = TRUE;
 static gboolean compositing_fast_alt_tab = FALSE;
 static gboolean resize_with_right_button = FALSE;
 static gboolean show_tab_border = FALSE;
@@ -399,6 +401,12 @@ static MetaBoolPreference preferences_bool[] =
       META_PREF_COMPOSITING_MANAGER,
       &compositing_manager,
       FALSE,
+    },
+    { "compositing-shadows",
+      KEY_GENERAL_SCHEMA,
+      META_PREF_COMPOSITING_SHADOWS,
+      &compositing_shadows,
+      TRUE,
     },
     { "compositing-fast-alt-tab",
       KEY_GENERAL_SCHEMA,
@@ -1614,6 +1622,9 @@ meta_preference_to_string (MetaPreference pref)
     case META_PREF_COMPOSITING_MANAGER:
       return "COMPOSITING_MANAGER";
 
+    case META_PREF_COMPOSITING_SHADOWS:
+      return "COMPOSITING_SHADOWS";
+
     case META_PREF_COMPOSITING_FAST_ALT_TAB:
       return "COMPOSITING_FAST_ALT_TAB";
 
@@ -2290,6 +2301,12 @@ meta_prefs_get_compositing_manager (void)
 }
 
 gboolean
+meta_prefs_get_compositing_shadows (void)
+{
+    return compositing_shadows;
+}
+
+gboolean
 meta_prefs_get_compositing_fast_alt_tab (void)
 {
     return compositing_fast_alt_tab;
@@ -2348,6 +2365,14 @@ meta_prefs_set_force_compositing_manager (gboolean whether)
 {
   use_force_compositor_manager = TRUE;
   force_compositor_manager = whether;
+}
+
+void
+meta_prefs_set_compositing_shadows (gboolean whether)
+{
+    g_settings_set_boolean (settings_general,
+                            KEY_GENERAL_COMPOSITOR_SHADOWS,
+                            whether);
 }
 
 void

--- a/src/include/prefs.h
+++ b/src/include/prefs.h
@@ -60,6 +60,7 @@ typedef enum
   META_PREF_CURSOR_THEME,
   META_PREF_CURSOR_SIZE,
   META_PREF_COMPOSITING_MANAGER,
+  META_PREF_COMPOSITING_SHADOWS,
   META_PREF_COMPOSITING_FAST_ALT_TAB,
   META_PREF_RESIZE_WITH_RIGHT_BUTTON,
   META_PREF_SHOW_TAB_BORDER,
@@ -128,6 +129,7 @@ void        meta_prefs_change_workspace_name (int         i,
 const char* meta_prefs_get_cursor_theme      (void);
 int         meta_prefs_get_cursor_size       (void);
 gboolean    meta_prefs_get_compositing_manager (void);
+gboolean    meta_prefs_get_compositing_shadows (void);
 gboolean    meta_prefs_get_compositing_fast_alt_tab (void);
 gboolean    meta_prefs_get_center_new_windows  (void);
 gboolean    meta_prefs_get_force_fullscreen  (void);
@@ -140,6 +142,8 @@ gboolean    meta_prefs_is_in_skip_list (char *class);
  * \param whether   TRUE to turn on, FALSE to turn off
  */
 void meta_prefs_set_force_compositing_manager (gboolean whether);
+
+void meta_prefs_set_compositing_shadows (gboolean whether);
 
 void meta_prefs_set_compositing_fast_alt_tab (gboolean whether);
 

--- a/src/org.mate.marco.gschema.xml
+++ b/src/org.mate.marco.gschema.xml
@@ -151,6 +151,11 @@
       <summary>Compositing Manager</summary>
       <description>Determines whether Marco is a compositing manager.</description>
     </key>
+    <key name="compositing-shadows" type="b">
+      <default>true</default>
+      <summary>Draw shadows with compositing manager</summary>
+      <description>If set to true, drop shadows will be drawn beneath windows when the compositing manager is enabled.</description>
+    </key>
     <key name="compositing-fast-alt-tab" type="b">
       <default>false</default>
       <summary>Fast Alt-Tab with compositing manager (disable thumbnails)</summary>


### PR DESCRIPTION
Please don't merge yet: help/advice needed (see below).

This is an (almost complete) patch that allows for the compositor's rendering of drop shadows to be controlled via a new GSettings preference, `org.mate.Marco.general.compositing-shadows`: a value of `true` enables shadows, a value of `false` disables them.

What this doesn't yet do:

* Existing windows aren't automatically rerendered with/without shadows as appropriate when the preference's value is changed. I know I need to add a new branch to the conditional in `prefs_changed_callback()` in `src/core/display.c` that checks whether changes were made to `META_PREF_COMPOSITING_SHADOWS`, but I'm not familiar enough with Marco to know what exactly needs to be done in that case. (I've already tried a few things that didn't work.)
* Shadows are still rendered beneath tooltips when the preference's value is set to `false`. (This also seems to be the case even when the `META_DEBUG_NO_SHADOW` environment variable is set, so this might actually be a separate issue unrelated to this patch.)
* An appropriate checkbox needs to be added to *Window Preferences → General → Compositing Manager* to control the preference in a more user-friendly way. I can write that patch against mate-control-center when this patch is complete.

Even with this patch, shadows are still rendered beneath GTK+3 windows with client-side decorations, but of course there's nothing Marco can do about that.

Any help with fixing items 1 and 2 in the list above would be appreciated!