### PR TITLE
Fix frame geometry to avoid stuck resize cursor

### DIFF
--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -549,11 +549,6 @@ meta_frames_calc_geometry (MetaFrames        *frames,
                             width / scale, height / scale,
                             &button_layout,
                             fgeom);
-
-  fgeom->top_height *= scale;
-  fgeom->bottom_height *= scale;
-  fgeom->left_width *= scale;
-  fgeom->right_width *= scale;
 }
 
 MetaFrames*


### PR DESCRIPTION
This seems to fix the resize cursor being stuck in the wrong image. I went through my checklist from when I added the scaling to marco and couldn't find any regressions, but please test to make sure it works for you.