### PR TITLE
tab popup improvements

### DIFF
--- a/src/core/keybindings.c
+++ b/src/core/keybindings.c
@@ -3419,6 +3419,10 @@ handle_workspace_switch_or_move  (MetaDisplay    *display,
 
   g_assert (motion < 0);
 
+  /* Don't show the ws switcher if we get just one ws */
+  if (meta_screen_get_n_workspaces(screen) == 1)
+    return;
+
   meta_topic (META_DEBUG_KEYBINDINGS,
               "Starting tab between workspaces, showing popup\n");
 

--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -1358,42 +1358,20 @@ meta_screen_ensure_tab_popup (MetaScreen      *screen,
        * edge.
        */
        if (border & BORDER_OUTLINE_WINDOW)
-         {
-           const gint border_outline_width = 5;
+       {
+#define OUTLINE_WIDTH 5
+         /* Top side */
+         entries[i].inner_rect.y = OUTLINE_WIDTH;
 
-           /* Top side */
-           if (!entries[i].hidden &&
-                window->frame && window->frame->bottom_height > 0 &&
-                window->frame->child_y >= window->frame->bottom_height)
-             entries[i].inner_rect.y = window->frame->bottom_height;
-           else
-              entries[i].inner_rect.y = border_outline_width;
+         /* Bottom side */
+         entries[i].inner_rect.height = r.height - entries[i].inner_rect.y - OUTLINE_WIDTH;
 
-            /* Bottom side */
-            if (!entries[i].hidden &&
-                window->frame && window->frame->bottom_height != 0)
-              entries[i].inner_rect.height = r.height
-                - entries[i].inner_rect.y - window->frame->bottom_height;
-            else
-              entries[i].inner_rect.height = r.height
-                - entries[i].inner_rect.y - border_outline_width;
+         /* Left side */
+         entries[i].inner_rect.x = OUTLINE_WIDTH;
 
-            /* Left side */
-            if (!entries[i].hidden && window->frame && window->frame->child_x != 0)
-                entries[i].inner_rect.x = window->frame->child_x;
-            else
-                entries[i].inner_rect.x = border_outline_width;
-
-            /* Right side */
-            if (!entries[i].hidden &&
-                    window->frame && window->frame->right_width != 0)
-              entries[i].inner_rect.width = r.width
-                - entries[i].inner_rect.x - window->frame->right_width;
-            else
-              entries[i].inner_rect.width = r.width
-                - entries[i].inner_rect.x - border_outline_width;
-        }
-
+         /* Right side */
+         entries[i].inner_rect.width = r.width - entries[i].inner_rect.x - OUTLINE_WIDTH;
+       }
 
       ++i;
       tmp = tmp->next;


### PR DESCRIPTION
These are some improvements to the workspace and alt+tab switchers:
* If there's only one workspace, don't show the pop-up if the user presses the shortcut (Ctrl+Alt+arrows)
* When switching apps with Alt+Tab, the shadow now shows up immediately, rather than on the second Tab press. It also adds a border around it so that it doesn't look cut-off, and prevents the outline from being created if we don't need it