### PR TITLE
errors.c: avoid deprecated 'gdk_error_trap...' functions:

### DIFF
--- a/src/core/display.c
+++ b/src/core/display.c
@@ -3405,7 +3405,7 @@ meta_display_set_grab_op_cursor (MetaDisplay *display,
 
   if (change_pointer)
     {
-      meta_error_trap_push_with_return (display);
+      meta_error_trap_push (display);
       XChangeActivePointerGrab (display->xdisplay,
                                 GRAB_MASK,
                                 cursor,
@@ -3617,7 +3617,7 @@ meta_display_begin_grab_op (MetaDisplay *display,
           XSyncAlarmAttributes values;
 	  XSyncValue init;
 
-          meta_error_trap_push_with_return (display);
+          meta_error_trap_push (display);
 
 	  /* Set the counter to 0, so we know that the application's
 	   * responses to the client messages will always trigger
@@ -3934,7 +3934,7 @@ meta_change_button_grab (MetaDisplay *display,
         }
 
       if (meta_is_debugging ())
-        meta_error_trap_push_with_return (display);
+        meta_error_trap_push (display);
 
       /* GrabModeSync means freeze until XAllowEvents */
 
@@ -4877,7 +4877,7 @@ convert_property (MetaDisplay *display,
   conversion_targets[2] = display->atom_TIMESTAMP;
   conversion_targets[3] = display->atom_VERSION;
 
-  meta_error_trap_push_with_return (display);
+  meta_error_trap_push (display);
   if (target == display->atom_TARGETS)
     XChangeProperty (display->xdisplay, w, property,
 		     XA_ATOM, 32, PropModeReplace,
@@ -4955,7 +4955,7 @@ process_selection_request (MetaDisplay   *display,
           unsigned long num, rest;
           unsigned char *data;
 
-          meta_error_trap_push_with_return (display);
+          meta_error_trap_push (display);
           if (XGetWindowProperty (display->xdisplay,
                                   event->xselectionrequest.requestor,
                                   event->xselectionrequest.property, 0, 256, False,

--- a/src/core/errors.c
+++ b/src/core/errors.c
@@ -28,31 +28,32 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <gdk/gdk.h>
+#include <gdk/gdkx.h>
 #include <gtk/gtk.h>
 
 void
 meta_error_trap_push (MetaDisplay *display)
 {
-  gdk_error_trap_push ();
+  gdk_x11_display_error_trap_push (gdk_x11_lookup_xdisplay (meta_display_get_xdisplay (display)));
 }
 
 void
 meta_error_trap_pop (MetaDisplay *display,
                      gboolean     last_request_was_roundtrip)
 {
-  gdk_error_trap_pop_ignored ();
+  gdk_x11_display_error_trap_pop_ignored (gdk_x11_lookup_xdisplay (meta_display_get_xdisplay (display)));
 }
 
 void
 meta_error_trap_push_with_return (MetaDisplay *display)
 {
-  gdk_error_trap_push ();
+  gdk_x11_display_error_trap_push (gdk_x11_lookup_xdisplay (meta_display_get_xdisplay (display)));
 }
 
 int
 meta_error_trap_pop_with_return  (MetaDisplay *display,
                                   gboolean     last_request_was_roundtrip)
 {
-  return gdk_error_trap_pop ();
+  return gdk_x11_display_error_trap_pop (gdk_x11_lookup_xdisplay (meta_display_get_xdisplay (display)));
 }
 

--- a/src/core/errors.c
+++ b/src/core/errors.c
@@ -44,12 +44,6 @@ meta_error_trap_pop (MetaDisplay *display,
   gdk_x11_display_error_trap_pop_ignored (gdk_x11_lookup_xdisplay (meta_display_get_xdisplay (display)));
 }
 
-void
-meta_error_trap_push_with_return (MetaDisplay *display)
-{
-  gdk_x11_display_error_trap_push (gdk_x11_lookup_xdisplay (meta_display_get_xdisplay (display)));
-}
-
 int
 meta_error_trap_pop_with_return  (MetaDisplay *display,
                                   gboolean     last_request_was_roundtrip)

--- a/src/core/iconcache.c
+++ b/src/core/iconcache.c
@@ -232,7 +232,7 @@ read_rgb_icon (MetaDisplay   *display,
   int mini_w, mini_h;
   gulong *data_as_long;
 
-  meta_error_trap_push_with_return (display);
+  meta_error_trap_push (display);
   type = None;
   data = NULL;
   result = XGetWindowProperty (display->xdisplay,
@@ -473,7 +473,7 @@ get_kwm_win_icon (MetaDisplay *display,
   *pixmap = None;
   *mask = None;
 
-  meta_error_trap_push_with_return (display);
+  meta_error_trap_push (display);
   icons = NULL;
   result = XGetWindowProperty (display->xdisplay, xwindow,
                                display->atom__KWM_WIN_ICON,

--- a/src/core/keybindings.c
+++ b/src/core/keybindings.c
@@ -698,7 +698,8 @@ meta_change_keygrab (MetaDisplay *display,
         }
 
       if (meta_is_debugging ())
-        meta_error_trap_push_with_return (display);
+        meta_error_trap_push (display);
+
       if (grab)
         XGrabKey (display->xdisplay, keycode,
                   modmask | ignored_mask,
@@ -779,10 +780,7 @@ static void
 ungrab_all_keys (MetaDisplay *display,
                  Window       xwindow)
 {
-  if (meta_is_debugging ())
-    meta_error_trap_push_with_return (display);
-  else
-    meta_error_trap_push (display);
+  meta_error_trap_push (display);
 
   XUngrabKey (display->xdisplay, AnyKey, AnyModifier,
               xwindow);
@@ -913,7 +911,7 @@ grab_keyboard (MetaDisplay *display,
   /* Grab the keyboard, so we get key releases and all key
    * presses
    */
-  meta_error_trap_push_with_return (display);
+  meta_error_trap_push (display);
 
   grab_status = XGrabKeyboard (display->xdisplay,
                                xwindow, True,

--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -379,7 +379,7 @@ meta_screen_new (MetaDisplay *display,
         }
 
       /* We want to find out when the current selection owner dies */
-      meta_error_trap_push_with_return (display);
+      meta_error_trap_push (display);
       attrs.event_mask = StructureNotifyMask;
       XChangeWindowAttributes (xdisplay,
                                current_wm_sn_owner, CWEventMask, &attrs);
@@ -438,7 +438,7 @@ meta_screen_new (MetaDisplay *display,
     }
 
   /* select our root window events */
-  meta_error_trap_push_with_return (display);
+  meta_error_trap_push (display);
 
   /* We need to or with the existing event mask since
    * gtk+ may be interested in other events.
@@ -669,7 +669,7 @@ meta_screen_free (MetaScreen *screen,
 
   meta_stack_free (screen->stack);
 
-  meta_error_trap_push_with_return (screen->display);
+  meta_error_trap_push (screen->display);
   XSelectInput (screen->display->xdisplay, screen->xroot, 0);
   if (meta_error_trap_pop_with_return (screen->display, FALSE) != Success)
     meta_warning (_("Could not release screen %d on display \"%s\"\n"),
@@ -735,7 +735,7 @@ list_windows (MetaScreen *screen)
     {
       WindowInfo *info = g_new0 (WindowInfo, 1);
 
-      meta_error_trap_push_with_return (screen->display);
+      meta_error_trap_push (screen->display);
 
       XGetWindowAttributes (screen->display->xdisplay,
                             children[i], &info->attrs);

--- a/src/core/stack.c
+++ b/src/core/stack.c
@@ -964,7 +964,7 @@ raise_window_relative_to_managed_windows (MetaScreen *screen,
    * or restack any windows before using the XQueryTree results.
    */
 
-  meta_error_trap_push_with_return (screen->display);
+  meta_error_trap_push (screen->display);
 
   XQueryTree (screen->display->xdisplay,
               screen->xroot,

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -220,7 +220,7 @@ meta_window_new (MetaDisplay *display,
                                    * creation, to reduce XSync() calls
                                    */
 
-  meta_error_trap_push_with_return (display);
+  meta_error_trap_push (display);
 
   if (XGetWindowAttributes (display->xdisplay,xwindow, &attrs))
    {
@@ -328,7 +328,7 @@ meta_window_new_with_attrs (MetaDisplay       *display,
                     wm_state_to_string (existing_wm_state));
     }
 
-  meta_error_trap_push_with_return (display);
+  meta_error_trap_push (display);
 
   XAddToSaveSet (display->xdisplay, xwindow);
 
@@ -5101,12 +5101,12 @@ meta_window_client_message (MetaWindow *window,
           char *str1;
           char *str2;
 
-          meta_error_trap_push_with_return (display);
+          meta_error_trap_push (display);
           str1 = XGetAtomName (display->xdisplay, first);
           if (meta_error_trap_pop_with_return (display, TRUE) != Success)
             str1 = NULL;
 
-          meta_error_trap_push_with_return (display);
+          meta_error_trap_push (display);
           str2 = XGetAtomName (display->xdisplay, second);
           if (meta_error_trap_pop_with_return (display, TRUE) != Success)
             str2 = NULL;
@@ -8348,7 +8348,7 @@ warp_grab_pointer (MetaWindow          *window,
   *x = CLAMP (*x, 0, window->screen->rect.width-1);
   *y = CLAMP (*y, 0, window->screen->rect.height-1);
 
-  meta_error_trap_push_with_return (display);
+  meta_error_trap_push (display);
 
   meta_topic (META_DEBUG_WINDOW_OPS,
               "Warping pointer to %d,%d with window at %d,%d\n",

--- a/src/core/xprops.c
+++ b/src/core/xprops.c
@@ -193,7 +193,7 @@ get_property (MetaDisplay        *display,
   results->bytes_after = 0;
   results->format = 0;
 
-  meta_error_trap_push_with_return (display);
+  meta_error_trap_push (display);
   if (XGetWindowProperty (display->xdisplay, xwindow, xatom,
                           0, G_MAXLONG,
                           False, req_type, &results->type, &results->format,

--- a/src/include/errors.h
+++ b/src/include/errors.h
@@ -41,7 +41,6 @@ void      meta_error_trap_push (MetaDisplay *display);
 void      meta_error_trap_pop  (MetaDisplay *display,
                                 gboolean     last_request_was_roundtrip);
 
-void      meta_error_trap_push_with_return (MetaDisplay *display);
 /* returns X error code, or 0 for no error */
 int       meta_error_trap_pop_with_return  (MetaDisplay *display,
                                             gboolean     last_request_was_roundtrip);


### PR DESCRIPTION
avoid deprecated:

gdk_error_trap_push
gdk_error_trap_pop_ignored
gdk_error_trap_pop