### PR TITLE
Increase icon size on tab and workspace popups

### DIFF
--- a/src/core/screen-private.h
+++ b/src/core/screen-private.h
@@ -36,7 +36,6 @@
 #include "display-private.h"
 #include "screen.h"
 #include <X11/Xutil.h>
-#include <gdk/gdk.h>
 #include "ui.h"
 
 typedef struct _MetaXineramaScreenInfo MetaXineramaScreenInfo;
@@ -193,8 +192,6 @@ void          meta_screen_get_natural_xinerama_list (MetaScreen *screen,
 void          meta_screen_update_workspace_layout (MetaScreen             *screen);
 void          meta_screen_update_workspace_names  (MetaScreen             *screen);
 void          meta_screen_queue_workarea_recalc   (MetaScreen             *screen);
-
-GdkMonitor* meta_screen_get_current_monitor (void);
 
 Window meta_create_offscreen_window (Display *xdisplay,
                                      Window   parent,

--- a/src/core/screen-private.h
+++ b/src/core/screen-private.h
@@ -36,6 +36,7 @@
 #include "display-private.h"
 #include "screen.h"
 #include <X11/Xutil.h>
+#include <gdk/gdk.h>
 #include "ui.h"
 
 typedef struct _MetaXineramaScreenInfo MetaXineramaScreenInfo;
@@ -192,6 +193,8 @@ void          meta_screen_get_natural_xinerama_list (MetaScreen *screen,
 void          meta_screen_update_workspace_layout (MetaScreen             *screen);
 void          meta_screen_update_workspace_names  (MetaScreen             *screen);
 void          meta_screen_queue_workarea_recalc   (MetaScreen             *screen);
+
+GdkMonitor* meta_screen_get_current_monitor (void);
 
 Window meta_create_offscreen_window (Display *xdisplay,
                                      Window   parent,

--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -1224,8 +1224,7 @@ get_window_pixbuf (MetaWindow *window,
   MetaDisplay *display;
   cairo_surface_t *surface;
   GdkPixbuf *pixbuf, *scaled;
-  GdkMonitor *monitor;
-  GdkRectangle rect;
+  const MetaXineramaScreenInfo *current;
   double ratio;
 
   display = window->display;
@@ -1248,28 +1247,19 @@ get_window_pixbuf (MetaWindow *window,
   *width = gdk_pixbuf_get_width (pixbuf);
   *height = gdk_pixbuf_get_height (pixbuf);
 
-  monitor = meta_screen_get_current_monitor ();
-  if (monitor != NULL)
-  {
-    gdk_monitor_get_geometry (monitor, &rect);
-  }
-  else
-  {
-    rect.width = window->screen->rect.width;
-    rect.height = window->screen->rect.height;
-  }
+  current = meta_screen_get_current_xinerama (window->screen);
 
   /* Scale pixbuf to max dimension based on monitor size */
   if (*width > *height)
     {
-      int max_preview_width = rect.width / MAX_PREVIEW_SCALE;
+      int max_preview_width = current->rect.width / MAX_PREVIEW_SCALE;
       ratio = ((double) *width) / max_preview_width;
       *width = (int) max_preview_width;
       *height = (int) (((double) *height) / ratio);
     }
   else
     {
-      int max_preview_height = rect.height / MAX_PREVIEW_SCALE;
+      int max_preview_height = current->rect.height / MAX_PREVIEW_SCALE;
       ratio = ((double) *height) / max_preview_height;
       *height = (int) max_preview_height;
       *width = (int) (((double) *width) / ratio);
@@ -1810,29 +1800,6 @@ meta_screen_get_current_xinerama (MetaScreen *screen)
     }
 
   return &screen->xinerama_infos[screen->last_xinerama_index];
-}
-
-GdkMonitor *
-meta_screen_get_current_monitor ()
-{
-  GdkDisplay *display;
-  GdkSeat *seat;
-  GdkDevice *device;
-  GdkMonitor *current;
-  gint x, y;
-
-  display = gdk_display_get_default ();
-  seat = gdk_display_get_default_seat (display);
-  device = gdk_seat_get_pointer (seat);
-
-  gdk_device_get_position (device, NULL, &x, &y);
-  current = gdk_display_get_monitor_at_point (display, x, y);
-
-  if (current != NULL) {
-    return current;
-  }
-
-  return gdk_display_get_primary_monitor (display);
 }
 
 #define _NET_WM_ORIENTATION_HORZ 0

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -7197,8 +7197,8 @@ update_move (MetaWindow  *window,
        * inside edge, because we don't want to force users to maximize
        * windows they are placing near the top of their screens.
        *
-       * The "current" idea of meta_window_get_work_area_current_monitor() and
-       * meta_screen_get_current_monitor() is slightly different: the former
+       * The "current" idea of meta_window_get_work_area_for_xinerama() and
+       * meta_screen_get_current_xinerama() is slightly different: the former
        * refers to the monitor which contains the largest part of the window,
        * the latter to the one where the pointer is located.
        */

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -301,8 +301,8 @@ struct _MetaButtonLayout
 };
 
 /* should investigate changing these to whatever most apps use */
-#define META_ICON_WIDTH 32
-#define META_ICON_HEIGHT 32
+#define META_ICON_WIDTH 48
+#define META_ICON_HEIGHT 48
 #define META_MINI_ICON_WIDTH 16
 #define META_MINI_ICON_HEIGHT 16
 

--- a/src/ui/tabpopup.c
+++ b/src/ui/tabpopup.c
@@ -760,34 +760,24 @@ static GtkWidget*
 selectable_workspace_new (MetaWorkspace *workspace, int entry_count)
 {
   GtkWidget *widget;
-  GdkMonitor *monitor;
-  GdkRectangle rect;
+  const MetaXineramaScreenInfo *current;
   int mini_workspace_width, mini_workspace_height;
   double mini_workspace_ratio;
 
   widget = g_object_new (meta_select_workspace_get_type (), NULL);
 
-  monitor = meta_screen_get_current_monitor ();
-  if (monitor != NULL)
-  {
-    gdk_monitor_get_geometry (monitor, &rect);
-  }
-  else
-  {
-    rect.width = workspace->screen->rect.width;
-    rect.height = workspace->screen->rect.height;
-  }
+  current = meta_screen_get_current_xinerama (workspace->screen);
 
   if (workspace->screen->rect.width < workspace->screen->rect.height)
   {
     mini_workspace_ratio = (double) workspace->screen->rect.width / (double) workspace->screen->rect.height;
-    mini_workspace_height = (int) ((double) rect.height / entry_count - SELECT_OUTLINE_WIDTH * 2);
+    mini_workspace_height = (int) ((double) current->rect.height / entry_count - SELECT_OUTLINE_WIDTH * 2);
     mini_workspace_width = (int) ((double) mini_workspace_height * mini_workspace_ratio);
   }
   else
   {
     mini_workspace_ratio = (double) workspace->screen->rect.height / (double) workspace->screen->rect.width;
-    mini_workspace_width = (int) ((double) rect.width / entry_count - SELECT_OUTLINE_WIDTH * 2);
+    mini_workspace_width = (int) ((double) current->rect.width / entry_count - SELECT_OUTLINE_WIDTH * 2);
     mini_workspace_height = (int) ((double) mini_workspace_width * mini_workspace_ratio);
   }
 

--- a/src/ui/theme.c
+++ b/src/ui/theme.c
@@ -5341,9 +5341,12 @@ meta_theme_load_image (MetaTheme  *theme,
                        GError    **error)
 {
   GdkPixbuf *pixbuf;
+  int scale;
 
   pixbuf = g_hash_table_lookup (theme->images_by_filename,
                                 filename);
+
+  scale = gdk_window_get_scale_factor (gdk_get_default_root_window ());
 
   if (pixbuf == NULL)
     {
@@ -5351,10 +5354,11 @@ meta_theme_load_image (MetaTheme  *theme,
       if (g_str_has_prefix (filename, "theme:") &&
           META_THEME_ALLOWS (theme, META_THEME_IMAGES_FROM_ICON_THEMES))
         {
-          pixbuf = gtk_icon_theme_load_icon (
+          pixbuf = gtk_icon_theme_load_icon_for_scale (
               gtk_icon_theme_get_default (),
               filename+6,
               size_of_theme_icons,
+              scale,
               0,
               error);
           if (pixbuf == NULL) return NULL;

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -569,7 +569,7 @@ meta_ui_pop_delay_exposes  (MetaUI *ui)
 }
 
 static GdkPixbuf *
-load_default_window_icon (int size)
+load_default_window_icon (int size, int scale)
 {
   GtkIconTheme *theme = gtk_icon_theme_get_default ();
   const char *icon_name;
@@ -579,17 +579,19 @@ load_default_window_icon (int size)
   else
     icon_name = "image-missing";
 
-  return gtk_icon_theme_load_icon (theme, icon_name, size, 0, NULL);
+  return gtk_icon_theme_load_icon_for_scale (theme, icon_name, size, scale, 0, NULL);
 }
 
 GdkPixbuf*
 meta_ui_get_default_window_icon (MetaUI *ui)
 {
   static GdkPixbuf *default_icon = NULL;
+  int scale;
 
   if (default_icon == NULL)
     {
-      default_icon = load_default_window_icon (META_ICON_WIDTH);
+      scale = gtk_widget_get_scale_factor (GTK_WIDGET (ui->frames));
+      default_icon = load_default_window_icon (META_ICON_WIDTH, scale);
       g_assert (default_icon);
     }
 
@@ -602,29 +604,12 @@ GdkPixbuf*
 meta_ui_get_default_mini_icon (MetaUI *ui)
 {
   static GdkPixbuf *default_icon = NULL;
+  int scale;
 
   if (default_icon == NULL)
     {
-      GtkIconTheme *theme;
-      gboolean icon_exists;
-
-      theme = gtk_icon_theme_get_default ();
-
-      icon_exists = gtk_icon_theme_has_icon (theme, META_DEFAULT_ICON_NAME);
-
-      if (icon_exists)
-          default_icon = gtk_icon_theme_load_icon (theme,
-                                                   META_DEFAULT_ICON_NAME,
-                                                   META_MINI_ICON_WIDTH,
-                                                   0,
-                                                   NULL);
-      else
-          default_icon = gtk_icon_theme_load_icon (theme,
-                                                   "image-missing",
-                                                   META_MINI_ICON_WIDTH,
-                                                   0,
-                                                   NULL);
-
+      scale = gtk_widget_get_scale_factor (GTK_WIDGET (ui->frames));
+      default_icon = load_default_window_icon (META_MINI_ICON_WIDTH, scale);
       g_assert (default_icon);
     }
 


### PR DESCRIPTION
Alt+Tab and Workspace popups should be sized relative to the screen size.
This way they look nice and large regardless of the display resolution.

Also, given much larger modern resolutions, icon sizes should be larger by default.

Fixes #333 
Fixes #363 
