### PR TITLE
Enable Clang Static Analyzer for marco

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,14 @@ deploy:
 
 after_success:
   - 'if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" && "$TRAVIS_PULL_REQUEST" != "false" && ${DISTRO} =~ ^fedora.*$ ]]; then
-        COMMENT="[Notification]: Clang Analyzer results of $TRAVIS_COMMIT at https://mate-desktop.github.io/${TRAVIS_REPO_SLUG#*/}/";
-        curl -H "Authorization: token $GITHUB_TOKEN" -X POST -d "{\"body\": \"$COMMENT\"}" "https://api.github.com/repos/${TRAVIS_REPO_SLUG}/issues/${TRAVIS_PULL_REQUEST}/comments" >/dev/null;
-    fi'
+        REPO_SLUG_ARRAY=(${TRAVIS_REPO_SLUG//\// });
+        REPO_NAME=${REPO_SLUG_ARRAY[1]};
+        URL="https://${REPO_NAME}.mate-desktop.dev";
+        COMMENT="Code analysis completed";
+        curl -H "Authorization: token $GITHUB_TOKEN" -X POST
+           -d "{\"state\": \"success\", \"description\": \"$COMMENT\", \"context\":\"scan-build\", \"target_url\": \"$URL\"}"
+           https://api.github.com/repos/${TRAVIS_REPO_SLUG}/statuses/${TRAVIS_PULL_REQUEST_SHA};
+     fi'
 
 env:
   - DISTRO="archlinux/base"

--- a/.travis.yml
+++ b/.travis.yml
@@ -180,7 +180,11 @@ variables:
 build_scripts:
   - ./autogen.sh
   - scan-build $CHECKERS ./configure
-  - scan-build $CHECKERS --keep-cc -o html-report make
+  - if [ $CPU_COUNT -gt 1 ]; then
+  -     scan-build $CHECKERS --keep-cc -o html-report make -j $CPU_COUNT
+  - else
+  -     scan-build $CHECKERS --keep-cc -o html-report make
+  - fi
 
 after_scripts:
   - if [ ${DISTRO_NAME} == "fedora" ];then

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,15 @@ language: bash
 services:
   - docker
 
+branches:
+  except:
+  - gh-pages
+
 before_install:
-  - curl -Ls -o docker-build https://github.com/mate-desktop/mate-dev-scripts/raw/master/travis/docker-build
-  - chmod +x docker-build
- 
+  - curl -Ls -o docker-build https://github.com/mate-desktop/mate-dev-scripts/raw/travis/travis/docker-build
+  - curl -Ls -o gen-index https://github.com/mate-desktop/mate-dev-scripts/raw/travis/travis/gen-index.sh
+  - chmod +x docker-build gen-index
+
 install:
   - sudo apt-get install -y python3-pip python3-setuptools
   - sudo pip3 install --upgrade pip
@@ -16,7 +21,25 @@ install:
   - ./docker-build --name ${DISTRO} --config .travis.yml --install
 
 script:
-  - ./docker-build --name ${DISTRO} --verbose --config .travis.yml --build autotools
+  - ./docker-build --name ${DISTRO} --verbose --config .travis.yml --build scripts
+
+deploy:
+  provider: pages
+  github-token: $GITHUB_TOKEN
+  #keep-history: true
+  skip_cleanup: true
+  committer-from-gh: true
+  target-branch: gh-pages
+  local-dir: html-report
+  on:
+    all_branches: true
+    condition: ${DISTRO} =~ ^fedora.*$
+
+after_success:
+  - 'if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" && "$TRAVIS_PULL_REQUEST" != "false" && ${DISTRO} =~ ^fedora.*$ ]]; then
+        COMMENT="[Notification]: Clang Analyzer results of $TRAVIS_COMMIT at https://mate-desktop.github.io/${TRAVIS_REPO_SLUG#*/}/";
+        curl -H "Authorization: token $GITHUB_TOKEN" -X POST -d "{\"body\": \"$COMMENT\"}" "https://api.github.com/repos/${TRAVIS_REPO_SLUG}/issues/${TRAVIS_PULL_REQUEST}/comments" >/dev/null;
+    fi'
 
 env:
   - DISTRO="archlinux/base"
@@ -29,7 +52,8 @@ env:
 ##########################################################
 requires:
   archlinux:
-    # Useful URL: https://git.archlinux.org/svntogit/community.git/tree/trunk?h=packages/marco
+    # Useful URL: https://git.archlinux.org/svntogit/community.git/tree/marco/trunk/PKGBUILD
+    - clang
     - gcc
     - git
     - glib2
@@ -48,6 +72,9 @@ requires:
   debian:
     # Useful URL: https://github.com/mate-desktop/debian-packages
     # Useful URL: https://salsa.debian.org/debian-mate-team/marco
+    - clang
+    - clang-tools
+    - gcc
     - git
     - intltool
     - libcanberra-gtk3-dev
@@ -77,6 +104,8 @@ requires:
 
   fedora:
     # Useful URL: https://src.fedoraproject.org/cgit/rpms/marco.git
+    - clang-analyzer
+    - clang
     - desktop-file-utils
     - gcc
     - git
@@ -96,6 +125,8 @@ requires:
     - zenity
 
   ubuntu:
+    - clang
+    - clang-tools
     - git
     - intltool
     - libcanberra-gtk3-dev
@@ -125,6 +156,29 @@ requires:
 
 variables:
   - CFLAGS="-Wall -Werror=format-security"
+  - 'CHECKERS="
+    -enable-checker deadcode.DeadStores
+    -enable-checker alpha.core.CastSize
+    -enable-checker alpha.core.CastToStruct
+    -enable-checker alpha.core.IdenticalExpr
+    -enable-checker alpha.core.SizeofPtr
+    -enable-checker alpha.security.ArrayBoundV2
+    -enable-checker alpha.security.MallocOverflow
+    -enable-checker alpha.security.ReturnPtrRange
+    -enable-checker alpha.unix.SimpleStream
+    -enable-checker alpha.unix.cstring.BufferOverlap
+    -enable-checker alpha.unix.cstring.NotNullTerminated
+    -enable-checker alpha.unix.cstring.OutOfBounds
+    -enable-checker alpha.core.FixedAddr
+    -enable-checker security.insecureAPI.strcpy"'
+
+build_scripts:
+  - ./autogen.sh
+  - scan-build $CHECKERS ./configure
+  - scan-build $CHECKERS --keep-cc -o html-report make
 
 after_scripts:
+  - if [ ${DISTRO_NAME} == "fedora" ];then
+  -   ./gen-index -i https://github.com/${OWNER_NAME}/mate-icon-theme/raw/master/mate/16x16/apps/preferences-system-windows.png
+  - fi
   - make distcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ branches:
   - gh-pages
 
 before_install:
-  - curl -Ls -o docker-build https://github.com/mate-desktop/mate-dev-scripts/raw/travis/travis/docker-build
-  - curl -Ls -o gen-index https://github.com/mate-desktop/mate-dev-scripts/raw/travis/travis/gen-index.sh
+  - curl -Ls -o docker-build https://github.com/mate-desktop/mate-dev-scripts/raw/master/travis/docker-build
+  - curl -Ls -o gen-index https://github.com/mate-desktop/mate-dev-scripts/raw/master/travis/gen-index.sh
   - chmod +x docker-build gen-index
 
 install:


### PR DESCRIPTION
The Travis document https://docs.travis-ci.com/user/deployment/#pull-requests said that:
>Pull Requests #
>Note that pull request builds skip the deployment step altogether.

Only commit can trigger the deploy, so create new branch for test.

@raveit65 

Can you set marco to use `gh-pages` branch as the page source?
That branch is ready: https://github.com/mate-desktop/marco/tree/gh-pages