### PR TITLE
compositor-xrender: Fix memory leak

### DIFF
--- a/src/compositor/compositor-xrender.c
+++ b/src/compositor/compositor-xrender.c
@@ -584,6 +584,8 @@ make_shadow (MetaDisplay   *display,
         }
     }
 
+  ximage->data = (char *) data;
+
   return ximage;
 }
 


### PR DESCRIPTION
Fixes Clang static analyzer warning:

```
compositor/compositor-xrender.c:587:10: warning: Potential leak of memory pointed to by 'data'
  return ximage;
         ^~~~~~
```