### PR TITLE
screen: Fix use of memory after it is freed

### DIFF
--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -749,9 +749,8 @@ list_windows (MetaScreen *screen)
       else
         {
 	  info->xwindow = children[i];
+          result = g_list_prepend (result, info);
 	}
-
-      result = g_list_prepend (result, info);
     }
 
   if (children)


### PR DESCRIPTION
Fixes Clang static analyzer warning:

```
core/screen.c:754:16: warning: Use of memory after it is freed
      result = g_list_prepend (result, info);
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```