### PR TITLE
boxes: avoid false positive warning in Clang static analyzer

### DIFF
--- a/src/core/boxes.c
+++ b/src/core/boxes.c
@@ -472,6 +472,9 @@ merge_spanning_rects_in_region (GList *region)
                   a = compare->data;
                 }
 
+              /* avoid false positive warning in Clang static analyzer */
+              g_assert (a != delete_me->data);
+
               /* Okay, we can free it now */
               g_free (delete_me->data);
               region = g_list_delete_link (region, delete_me);


### PR DESCRIPTION
avoid Clang static analyzer warning:

```
core/boxes.c:412:15: warning: Use of memory after it is freed
          if (meta_rectangle_contains_rect (a, b))
              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

I am not sure if this is the correct way, but fixes the warning