### PR TITLE
MATE uses header bars windows problematic

### DIFF
--- a/src/core/constraints.c
+++ b/src/core/constraints.c
@@ -1528,7 +1528,6 @@ constrain_titlebar_visible (MetaWindow         *window,
       window->type == META_WINDOW_DOCK    ||
       window->fullscreen                  ||
       !window->require_titlebar_visible   ||
-      !window->decorated                  ||
       unconstrained_user_action)
     return TRUE;
 


### PR DESCRIPTION
I don't understand why we should judge whether the window is decorated or not.I think it would be better to remove this judgment so that problems with header-bar windows can be avoided.