### PR TITLE
[Security] Use 'g_strlcpy' instead of 'strcpy'

### DIFF
--- a/src/core/testasyncgetprop.c
+++ b/src/core/testasyncgetprop.c
@@ -37,6 +37,7 @@
 #include <errno.h>
 #include <signal.h>
 #include <assert.h>
+#include <glib.h>
 
 #ifndef TRUE
 #define TRUE 1
@@ -138,7 +139,7 @@ my_strdup (const char *str)
       fprintf (stderr, "malloc failed\n");
       exit (1);
     }
-  strcpy (s, str);
+  g_strlcpy (s, str, (strlen (str) + 1));
 
   return s;
 }

--- a/src/core/xprops.c
+++ b/src/core/xprops.c
@@ -821,7 +821,7 @@ class_hint_from_results (GetPropertyResults *results,
       return FALSE;
     }
 
-  strcpy (class_hint->res_name, (char *)results->prop);
+  g_strlcpy (class_hint->res_name, (char *)results->prop, (len_name + 1));
 
   if (len_name == (int) results->n_items)
     len_name--;
@@ -837,7 +837,7 @@ class_hint_from_results (GetPropertyResults *results,
       return FALSE;
     }
 
-  strcpy (class_hint->res_class, (char *)results->prop + len_name + 1);
+  g_strlcpy (class_hint->res_class, (char *)results->prop + len_name + 1, (len_class + 1));
 
   XFree (results->prop);
   results->prop = NULL;
@@ -1133,7 +1133,7 @@ meta_prop_get_values (MetaDisplay   *display,
               xmalloc_new_str = ag_Xmalloc (strlen (new_str) + 1);
               if (xmalloc_new_str != NULL)
                 {
-                  strcpy (xmalloc_new_str, new_str);
+                  g_strlcpy (xmalloc_new_str, new_str, (strlen (new_str) + 1));
                   meta_XFree (values[i].v.str);
                   values[i].v.str = xmalloc_new_str;
                 }


### PR DESCRIPTION
Fixes Clang static analyzer warnings:

warning: Call to function 'strcpy' is insecure as it does not provide bounding of the memory buffer. Replace unbounded copy functions with analogous functions that support length arguments such as 'strlcpy'. CWE-119