### PR TITLE
Use rounded values instead of truncate them

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,6 +29,8 @@ m4_define([lt_version_info], [lt_current:lt_revision:lt_age])
 
 AC_SUBST([LT_VERSION_INFO], [lt_version_info])
 
+AC_CHECK_LIB(m, round)
+
 # Honor aclocal flags
 AC_SUBST(ACLOCAL_AMFLAGS, "\${ACLOCAL_FLAGS}")
 

--- a/src/core/constraints.c
+++ b/src/core/constraints.c
@@ -23,6 +23,8 @@
  * 02110-1301, USA.
  */
 
+#define _GNU_SOURCE
+
 #include <config.h>
 #include "constraints.h"
 #include "workspace.h"
@@ -1327,9 +1329,8 @@ constrain_aspect_ratio (MetaWindow         *window,
                                                       new_width, new_height,
                                                       &best_width, &best_height);
 
-      /* Yeah, I suck for doing implicit rounding -- sue me */
-      new_width  = best_width;
-      new_height = best_height;
+      new_width  = round (best_width);
+      new_height = round (best_height);
 
       break;
     }


### PR DESCRIPTION
If the decimal value is from .1 to .5, round(arg) returns
the integer value less than the argument. Otherwise, if
the decimal value is from .6 to .9, it returns the
integer value greater than the arg.