### PR TITLE
Fix cast from non-struct type to struct type

### DIFF
--- a/src/core/async-getprop.c
+++ b/src/core/async-getprop.c
@@ -274,7 +274,7 @@ async_get_property_handler (Display *dpy,
 #endif
 
   /* (kind of a silly as we know sizeof(xGetPropertyReply) == sizeof(xReply)) */
-  reply = (xGetPropertyReply *)
+  reply = (xGetPropertyReply *) (void *)
     _XGetAsyncReply (dpy, (char *)&replbuf, rep, buf, len,
                      (SIZEOF (xGetPropertyReply) - bytes_read) >> 2, /* in 32-bit words */
                      False); /* False means expecting more data to follow,

--- a/src/core/xprops.c
+++ b/src/core/xprops.c
@@ -758,7 +758,7 @@ wm_hints_from_results (GetPropertyResults *results,
 
   hints = ag_Xmalloc0 (sizeof (XWMHints));
 
-  raw = (xPropWMHints*) results->prop;
+  raw = (xPropWMHints*) (gpointer) results->prop;
 
   hints->flags = raw->flags;
   hints->input = (raw->input ? True : False);
@@ -880,7 +880,7 @@ size_hints_from_results (GetPropertyResults *results,
   if (results->n_items < OldNumPropSizeElements)
     return FALSE;
 
-  raw = (xPropSizeHints*) results->prop;
+  raw = (xPropSizeHints*) (gpointer) results->prop;
 
   hints = ag_Xmalloc (sizeof (XSizeHints));
 


### PR DESCRIPTION
Fixes Clang static analyzer warnings:


```
core/xprops.c:761:9: warning: Casting a non-structure type to a structure type and accessing a field can lead to memory access errors or data corruption
  raw = (xPropWMHints*) results->prop;
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~

core/xprops.c:883:9: warning: Casting a non-structure type to a structure type and accessing a field can lead to memory access errors or data corruption
  raw = (xPropSizeHints*) results->prop;


core/async-getprop.c:277:11: warning: Casting a non-structure type to a structure type and accessing a field can lead to memory access errors or data corruption
  reply = (xGetPropertyReply *)
          ^~~~~~~~~~~~~~~~~~~~~
```