### PR TITLE
ui: always set the frame background to None

### DIFF
--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -113,11 +113,6 @@ meta_window_ensure_frame (MetaWindow *window)
 
   meta_display_register_x_window (window->display, &frame->xwindow, window);
 
-  /* Now that frame->xwindow is registered with window, we can set its
-   * background.
-   */
-  meta_ui_reset_frame_bg (window->screen->ui, frame->xwindow);
-
   /* Reparent the client window; it may be destroyed,
    * thus the error trap. We'll get a destroy notify later
    * and free everything. Comment in FVWM source code says
@@ -354,11 +349,6 @@ meta_frame_sync_to_window (MetaFrame *frame,
   /* set bg to none to avoid flicker */
   if (need_resize)
     {
-      meta_ui_unflicker_frame_bg (frame->window->screen->ui,
-                                  frame->xwindow,
-                                  frame->rect.width,
-                                  frame->rect.height);
-
       /* we need new shape if we're resized */
       frame->need_reapply_frame_shape = TRUE;
     }
@@ -380,9 +370,6 @@ meta_frame_sync_to_window (MetaFrame *frame,
 
   if (need_resize)
     {
-      meta_ui_reset_frame_bg (frame->window->screen->ui,
-                              frame->xwindow);
-
       /* If we're interactively resizing the frame, repaint
        * it immediately so we don't start to lag.
        */

--- a/src/include/ui.h
+++ b/src/include/ui.h
@@ -95,13 +95,6 @@ void meta_ui_map_frame   (MetaUI *ui,
 void meta_ui_unmap_frame (MetaUI *ui,
                           Window  xwindow);
 
-void meta_ui_unflicker_frame_bg (MetaUI *ui,
-                                 Window  xwindow,
-                                 int     target_width,
-                                 int     target_height);
-void meta_ui_reset_frame_bg     (MetaUI *ui,
-                                 Window  xwindow);
-
 void meta_ui_apply_frame_shape  (MetaUI  *ui,
                                  Window   xwindow,
                                  int      new_window_width,

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -79,9 +79,6 @@ static void meta_frames_paint_to_drawable (MetaFrames   *frames,
                                            MetaUIFrame  *frame,
                                            cairo_t      *cr);
 
-static void meta_frames_set_window_background (MetaFrames   *frames,
-                                               MetaUIFrame  *frame);
-
 static void meta_frames_calc_geometry (MetaFrames        *frames,
                                        MetaUIFrame         *frame,
                                        MetaFrameGeometry *fgeom);
@@ -341,12 +338,6 @@ queue_recalc_func (gpointer key, gpointer value, gpointer data)
   frames = META_FRAMES (data);
   frame = value;
 
-  /* If a resize occurs it will cause a redraw, but the
-   * resize may not actually be needed so we always redraw
-   * in case of color change.
-   */
-  meta_frames_set_window_background (frames, frame);
-
   invalidate_whole_window (frames, frame);
   meta_core_queue_frame_resize (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()),
                                 frame->xwindow);
@@ -385,12 +376,6 @@ queue_draw_func (gpointer key, gpointer value, gpointer data)
 
   frames = META_FRAMES (data);
   frame = value;
-
-  /* If a resize occurs it will cause a redraw, but the
-   * resize may not actually be needed so we always redraw
-   * in case of color change.
-   */
-  meta_frames_set_window_background (frames, frame);
 
   invalidate_whole_window (frames, frame);
 }
@@ -607,11 +592,6 @@ meta_frames_manage_window (MetaFrames *frames,
   frame->shape_applied = FALSE;
   frame->prelit_control = META_FRAME_CONTROL_NONE;
 
-  /* Don't set the window background yet; we need frame->xwindow to be
-   * registered with its MetaWindow, which happens after this function
-   * and meta_ui_create_frame_window() return to meta_window_ensure_frame().
-   */
-
   meta_core_grab_buttons (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), frame->xwindow);
 
   g_hash_table_replace (frames->frames, &frame->xwindow, frame);
@@ -730,52 +710,6 @@ meta_frames_get_geometry (MetaFrames *frames,
   *bottom_height *= scale;
   *left_width *= scale;
   *right_width *= scale;
-}
-
-void
-meta_frames_reset_bg (MetaFrames *frames,
-                      Window  xwindow)
-{
-  MetaUIFrame *frame;
-
-  frame = meta_frames_lookup_window (frames, xwindow);
-
-  meta_frames_set_window_background (frames, frame);
-}
-
-static void
-set_background_none (Display *xdisplay,
-                     Window   xwindow)
-{
-  XSetWindowAttributes attrs;
-
-  attrs.background_pixmap = None;
-  XChangeWindowAttributes (xdisplay, xwindow,
-                           CWBackPixmap, &attrs);
-}
-
-void
-meta_frames_unflicker_bg (MetaFrames *frames,
-                          Window      xwindow,
-                          int         target_width,
-                          int         target_height)
-{
-  MetaUIFrame *frame;
-
-  frame = meta_frames_lookup_window (frames, xwindow);
-  g_return_if_fail (frame != NULL);
-
-#if 0
-  pixmap = gdk_pixmap_new (frame->window,
-                           width, height,
-                           -1);
-
-  /* Oops, no way to get the background here */
-
-  meta_frames_paint_to_drawable (frames, frame, pixmap);
-#endif
-
-  set_background_none (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), frame->xwindow);
 }
 
 #ifdef HAVE_SHAPE
@@ -2505,52 +2439,6 @@ meta_frames_paint_to_drawable (MetaFrames   *frames,
                                     button_states,
                                     mini_icon, icon);
 }
-
-static void
-meta_frames_set_window_background (MetaFrames   *frames,
-                                   MetaUIFrame  *frame)
-{
-  MetaFrameFlags flags;
-  MetaFrameType type;
-  MetaFrameStyle *style;
-  gboolean frame_exists;
-
-  meta_core_get (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), frame->xwindow,
-                 META_CORE_WINDOW_HAS_FRAME, &frame_exists,
-                 META_CORE_GET_FRAME_FLAGS, &flags,
-                 META_CORE_GET_FRAME_TYPE, &type,
-                 META_CORE_GET_END);
-
-  if (frame_exists)
-    {
-      style = meta_theme_get_frame_style (meta_theme_get_current (),
-                                          type, flags);
-    }
-
-  if (frame_exists && style->window_background_color != NULL)
-    {
-      GdkRGBA color;
-      GdkVisual *visual;
-
-      meta_color_spec_render (style->window_background_color,
-                              frame->style,
-                              &color);
-
-      /* Set A in ARGB to window_background_alpha, if we have ARGB */
-
-      visual = gtk_widget_get_visual (GTK_WIDGET (frames));
-      if (gdk_visual_get_depth (visual) == 32) /* we have ARGB */
-        {
-          color.alpha = style->window_background_alpha / 255.0;
-        }
-
-      gdk_window_set_background_rgba (frame->window, &color);
-    }
-  else
-    {
-      gtk_style_context_set_background (frame->style, frame->window);
-    }
- }
 
 static gboolean
 meta_frames_enter_notify_event      (GtkWidget           *widget,

--- a/src/ui/frames.h
+++ b/src/ui/frames.h
@@ -132,13 +132,6 @@ void meta_frames_get_geometry (MetaFrames *frames,
                                int *top_height, int *bottom_height,
                                int *left_width, int *right_width);
 
-void meta_frames_reset_bg     (MetaFrames *frames,
-                               Window      xwindow);
-void meta_frames_unflicker_bg (MetaFrames *frames,
-                               Window      xwindow,
-                               int         target_width,
-                               int         target_height);
-
 void meta_frames_apply_shapes (MetaFrames *frames,
                                Window      xwindow,
                                int         new_window_width,

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -305,6 +305,17 @@ meta_ui_get_frame_geometry (MetaUI *ui,
                             left_width, right_width);
 }
 
+static void
+set_background_none (Display *xdisplay,
+                     Window   xwindow)
+{
+  XSetWindowAttributes attrs;
+
+  attrs.background_pixmap = None;
+  XChangeWindowAttributes (xdisplay, xwindow,
+                           CWBackPixmap, &attrs);
+}
+
 Window
 meta_ui_create_frame_window (MetaUI *ui,
                              Display *xdisplay,
@@ -363,6 +374,7 @@ meta_ui_create_frame_window (MetaUI *ui,
 		    &attrs, attributes_mask);
 
   gdk_window_resize (window, width, height);
+  set_background_none (xdisplay, GDK_WINDOW_XID (window));
 
   meta_frames_manage_window (ui->frames, GDK_WINDOW_XID (window), window);
 
@@ -418,27 +430,10 @@ meta_ui_unmap_frame (MetaUI *ui,
 }
 
 void
-meta_ui_unflicker_frame_bg (MetaUI *ui,
-                            Window  xwindow,
-                            int     target_width,
-                            int     target_height)
-{
-  meta_frames_unflicker_bg (ui->frames, xwindow,
-                            target_width, target_height);
-}
-
-void
 meta_ui_repaint_frame (MetaUI *ui,
                        Window xwindow)
 {
   meta_frames_repaint_frame (ui->frames, xwindow);
-}
-
-void
-meta_ui_reset_frame_bg (MetaUI *ui,
-                        Window xwindow)
-{
-  meta_frames_reset_bg (ui->frames, xwindow);
 }
 
 void


### PR DESCRIPTION
From origin commit:

This way the xserver never paints the frame background, even if
the client window is destroyed. This allows us to have clean
destroy window animation.

There is no problem with interactive resizing because applications
are using the XSync protocol, so we're not painting unless the
client has redrawn.

https://bugzilla.gnome.org/show_bug.cgi?id=734054

origin commit:
https://gitlab.gnome.org/GNOME/metacity/commit/78c283c

Beside from that PR removes a deprecation: gtk_style_context_set_background