### PR TITLE
window: make docks and spashscreens appear focused

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -8661,7 +8661,15 @@ meta_window_appears_focused (MetaWindow *window)
       meta_window_foreach_transient (window, transient_has_focus, &focus);
       return focus;
     }
-  return window->has_focus;
+
+  if (window->has_focus)
+    return TRUE;
+
+  if (window->type == META_WINDOW_DOCK ||
+      window->type == META_WINDOW_SPLASHSCREEN)
+    return TRUE;
+
+  return FALSE;
 }
 
 gboolean

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -1322,7 +1322,7 @@ set_net_wm_state (MetaWindow *window)
       data[i] = window->display->atom__NET_WM_STATE_STICKY;
       ++i;
     }
-  if (window->has_focus)
+  if (meta_window_appears_focused (window))
     {
       data[i] = window->display->atom__NET_WM_STATE_FOCUSED;
       ++i;


### PR DESCRIPTION
Fix for https://bugzilla.redhat.com/show_bug.cgi?id=1701799
MATE Menu Bar often has unreadable text with none MATE themes, which support backdrop state.

Set the NET_WM_STATE_FOCUSED property on windows of type dock or
spashscreen so that they don't get the state GTK_STATE_FLAG_BACKDROP
set by default.

Based on:
https://gitlab.gnome.org/GNOME/metacity/commit/b3ef887
origin xfwm4 commit:
https://git.xfce.org/xfce/xfwm4/commit/?id=0feb29e78bb3

For testing use adwaita theme which has backdrop state support.