### PR TITLE
Allow use of up/down arrow keys in alt+tab popup

### DIFF
--- a/src/core/keybindings.c
+++ b/src/core/keybindings.c
@@ -2052,7 +2052,7 @@ process_tab_grab (MetaDisplay *display,
 {
   MetaKeyBindingAction action;
   gboolean popup_not_showing;
-  gboolean backward;
+  enum { NEXT, PREV, UP, DOWN, LEFT, RIGHT } direction;
   gboolean key_used;
   Window      prev_xwindow;
   MetaWindow *prev_window;
@@ -2198,7 +2198,7 @@ process_tab_grab (MetaDisplay *display,
 
   popup_not_showing = FALSE;
   key_used = FALSE;
-  backward = FALSE;
+  direction = NEXT;
 
   switch (action)
     {
@@ -2213,7 +2213,7 @@ process_tab_grab (MetaDisplay *display,
     case META_KEYBINDING_ACTION_CYCLE_GROUP_BACKWARD:
       popup_not_showing = TRUE;
       key_used = TRUE;
-      backward = TRUE;
+      direction = PREV;
       break;
     case META_KEYBINDING_ACTION_SWITCH_PANELS:
     case META_KEYBINDING_ACTION_SWITCH_WINDOWS:
@@ -2226,7 +2226,7 @@ process_tab_grab (MetaDisplay *display,
     case META_KEYBINDING_ACTION_SWITCH_WINDOWS_ALL_BACKWARD:
     case META_KEYBINDING_ACTION_SWITCH_GROUP_BACKWARD:
       key_used = TRUE;
-      backward = TRUE;
+      direction = PREV;
       break;
     default:
       break;
@@ -2234,11 +2234,24 @@ process_tab_grab (MetaDisplay *display,
 
   /* Allow use of arrows while in window switching mode */
   if (event->xkey.keycode == ARROW_RIGHT || event->xkey.keycode == ARROW_RIGHT_PAD)
-    key_used = TRUE;
+    {
+      key_used = TRUE;
+      direction = RIGHT;
+    }
   else if (event->xkey.keycode == ARROW_LEFT || event->xkey.keycode == ARROW_LEFT_PAD)
     {
       key_used = TRUE;
-      backward = TRUE;
+      direction = LEFT;
+    }
+  else if (event->xkey.keycode == ARROW_UP || event->xkey.keycode == ARROW_UP_PAD)
+    {
+      key_used = TRUE;
+      direction = UP;
+    }
+  else if (event->xkey.keycode == ARROW_DOWN || event->xkey.keycode == ARROW_DOWN_PAD)
+    {
+      key_used = TRUE;
+      direction = DOWN;
     }
 
   if (key_used)
@@ -2246,13 +2259,17 @@ process_tab_grab (MetaDisplay *display,
       meta_topic (META_DEBUG_KEYBINDINGS,
                   "Key pressed, moving tab focus in popup\n");
 
-      if (event->xkey.state & ShiftMask)
-        backward = !backward;
+      if ((event->xkey.state & ShiftMask) && (direction == NEXT || direction == PREV))
+        direction = (direction == NEXT) ? PREV : NEXT;
 
-      if (backward)
+      if (direction == PREV || direction == LEFT)
         meta_ui_tab_popup_backward (screen->tab_popup);
-      else
+      else if (direction == NEXT || direction == RIGHT)
         meta_ui_tab_popup_forward (screen->tab_popup);
+      else if (direction == DOWN)
+        meta_ui_tab_popup_down (screen->tab_popup);
+      else if (direction == UP)
+        meta_ui_tab_popup_up (screen->tab_popup);
 
       if (popup_not_showing)
         {

--- a/src/core/keybindings.h
+++ b/src/core/keybindings.h
@@ -35,6 +35,13 @@
 #define ARROW_RIGHT 114
 #define ARROW_RIGHT_PAD 85
 
+#define ARROW_UP 111
+#define ARROW_UP_PAD 80
+
+#define ARROW_DOWN 116
+#define ARROW_DOWN_PAD 88
+
+
 #include "display-private.h"
 #include "window.h"
 

--- a/src/include/tabpopup.h
+++ b/src/include/tabpopup.h
@@ -64,6 +64,8 @@ void            meta_ui_tab_popup_set_showing  (MetaTabPopup       *popup,
                                                 gboolean            showing);
 void            meta_ui_tab_popup_forward      (MetaTabPopup       *popup);
 void            meta_ui_tab_popup_backward     (MetaTabPopup       *popup);
+void            meta_ui_tab_popup_down         (MetaTabPopup       *popup);
+void            meta_ui_tab_popup_up           (MetaTabPopup       *popup);
 MetaTabEntryKey meta_ui_tab_popup_get_selected (MetaTabPopup      *popup);
 void            meta_ui_tab_popup_select       (MetaTabPopup       *popup,
                                                 MetaTabEntryKey     key);

--- a/src/ui/tabpopup.c
+++ b/src/ui/tabpopup.c
@@ -46,6 +46,8 @@ struct _TabEntry
 {
   MetaTabEntryKey  key;
   char            *title;
+  gint             grid_left;
+  gint             grid_top;
   GdkPixbuf       *icon, *dimmed_icon;
   GtkWidget       *widget;
   GdkRectangle     rect;
@@ -56,6 +58,7 @@ struct _TabEntry
 struct _MetaTabPopup
 {
   GtkWidget *window;
+  GtkWidget *grid;
   GtkWidget *label;
   GList *current;
   GList *entries;
@@ -291,7 +294,8 @@ meta_ui_tab_popup_new (const MetaTabEntry *entries,
 
   vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
 
-  grid = gtk_grid_new ();
+  popup->grid = gtk_grid_new ();
+  grid = popup->grid;
 
   frame = gtk_frame_new (NULL);
   gtk_frame_set_shadow_type (GTK_FRAME (frame), GTK_SHADOW_OUT);
@@ -366,7 +370,8 @@ meta_ui_tab_popup_new (const MetaTabEntry *entries,
             }
 
           te->widget = image;
-
+          te->grid_left = left;
+          te->grid_top  = top;
           gtk_grid_attach (GTK_GRID (grid), te->widget, left, top, 1, 1);
 
           /* Efficiency rules! */
@@ -543,6 +548,50 @@ meta_ui_tab_popup_backward (MetaTabPopup *popup)
       te = popup->current->data;
 
       display_entry (popup, te);
+    }
+}
+
+static void
+display_widget (MetaTabPopup *popup,
+                GtkWidget    *w)
+{
+  if (w != NULL) 
+    {
+      GList *c = popup->entries;
+      while (c != NULL && ((TabEntry*)c->data)->widget != w)
+        c = c->next;
+      if (c != NULL) 
+        {
+          popup->current = c;
+          TabEntry *te = c->data;
+          display_entry (popup, te);
+        }
+    }
+}
+
+void
+meta_ui_tab_popup_down (MetaTabPopup *popup)
+{
+  if (popup->current != NULL)
+    {
+      TabEntry *te = popup->current->data;
+      GtkWidget* w = gtk_grid_get_child_at (GTK_GRID(popup->grid), 
+                                            te->grid_left,
+                                            te->grid_top + 1);
+      display_widget (popup, w);
+    }
+}
+
+void
+meta_ui_tab_popup_up (MetaTabPopup *popup)
+{
+  if (popup->current != NULL)
+    {
+      TabEntry *te = popup->current->data;
+      GtkWidget* w = gtk_grid_get_child_at (GTK_GRID(popup->grid), 
+                                            te->grid_left,
+                                            te->grid_top - 1);
+      display_widget (popup, w);
     }
 }
 


### PR DESCRIPTION
Now also the up/down arrow keys can be used in the alt+tab popup, not only left/right arrow keys. 
See also #330