### PR TITLE
Handle mouse clicks in Alt+Tab Popup

### DIFF
--- a/src/core/display-private.h
+++ b/src/core/display-private.h
@@ -128,6 +128,8 @@ struct _MetaDisplay {
 
 	guint static_gravity_works: 1;
 
+        guint tab_popup_mouse_pressed : 1;
+
 	/*< private-ish >*/
 	guint error_trap_synced_at_last_pop: 1;
 	MetaEventQueue* events;

--- a/src/core/display.c
+++ b/src/core/display.c
@@ -1611,18 +1611,30 @@ mouse_event_is_in_tab_popup (MetaDisplay *display,
                                             event_window, event_window,
                                             event_x, event_y,
                                             &x, &y, &child1);
+
+      GtkWidget *popup_widget = meta_ui_tab_popup_get_widget (screen->tab_popup);
+      if (ok1 && popup_widget != NULL) 
+        {
+          Window popup_xid = gdk_x11_window_get_xid (gtk_widget_get_window (popup_widget));
   
-      Window popup_xid = meta_ui_tab_popup_get_xid(screen->tab_popup);
-  
-      gboolean ok2 = XTranslateCoordinates (display->xdisplay,
-                                            event_window, popup_xid,
-                                            event_x, event_y,
-                                            popup_x, popup_y, &child2);
+          gboolean ok2 = XTranslateCoordinates (display->xdisplay,
+                                                event_window, popup_xid,
+                                                event_x, event_y,
+                                                popup_x, popup_y, &child2);
     
-      return (ok1 && ok2 && child1 == popup_xid);
+          if (ok2 && child1 == popup_xid)
+            {
+              int scale = gtk_widget_get_scale_factor (popup_widget);
+              if (scale != 0)
+                {
+                  *popup_x /= scale;
+                  *popup_y /= scale;
+                }
+              return TRUE;
+            }
+        }
     }
-  else
-    return FALSE;
+  return FALSE;
 }
 
 /**

--- a/src/include/tabpopup.h
+++ b/src/include/tabpopup.h
@@ -31,6 +31,7 @@
 #include <X11/Xlib.h>
 #include <glib.h>
 #include <gdk-pixbuf/gdk-pixbuf.h>
+#include <gtk/gtk.h>
 
 typedef struct _MetaTabEntry MetaTabEntry;
 typedef struct _MetaTabPopup MetaTabPopup;
@@ -67,7 +68,7 @@ void            meta_ui_tab_popup_backward     (MetaTabPopup       *popup);
 MetaTabEntryKey meta_ui_tab_popup_get_selected (MetaTabPopup      *popup);
 void            meta_ui_tab_popup_select       (MetaTabPopup       *popup,
                                                 MetaTabEntryKey     key);
-Window          meta_ui_tab_popup_get_xid      (MetaTabPopup       *popup);
+GtkWidget*      meta_ui_tab_popup_get_widget   (MetaTabPopup       *popup);
 void            meta_ui_tab_popup_mouse_press  (MetaTabPopup       *popup,
                                                 gint                x,
                                                 gint                y);

--- a/src/include/tabpopup.h
+++ b/src/include/tabpopup.h
@@ -67,7 +67,10 @@ void            meta_ui_tab_popup_backward     (MetaTabPopup       *popup);
 MetaTabEntryKey meta_ui_tab_popup_get_selected (MetaTabPopup      *popup);
 void            meta_ui_tab_popup_select       (MetaTabPopup       *popup,
                                                 MetaTabEntryKey     key);
-
+Window          meta_ui_tab_popup_get_xid      (MetaTabPopup       *popup);
+void            meta_ui_tab_popup_mouse_press  (MetaTabPopup       *popup,
+                                                gint                x,
+                                                gint                y);
 
 #endif
 

--- a/src/ui/tabpopup.c
+++ b/src/ui/tabpopup.c
@@ -591,6 +591,46 @@ meta_ui_tab_popup_select (MetaTabPopup *popup,
     }
 }
 
+Window
+meta_ui_tab_popup_get_xid (MetaTabPopup *popup)
+{
+  if (popup != NULL && popup->window != NULL) 
+    return gdk_x11_window_get_xid(gtk_widget_get_window(popup->window)); 
+  else
+    return 0;
+}
+
+void
+meta_ui_tab_popup_mouse_press (MetaTabPopup       *popup,
+                               gint                x,
+                               gint                y)
+{
+  GList *tmp = popup->entries;
+  gboolean found = FALSE;
+  while (tmp != NULL && !found)
+    {
+      TabEntry *te = tmp->data;
+      gint wx, wy;
+      if (gtk_widget_translate_coordinates(popup->window,
+                                           te->widget, 
+                                           x, y, 
+                                           &wx, &wy))
+        {
+          GtkAllocation alloc;
+          gtk_widget_get_allocation(te->widget, &alloc);
+          found = (0 <= wx && wx < alloc.width &&
+                   0 <= wy && wy < alloc.height);
+          if (found)
+            {
+              popup->current = tmp;
+              display_entry (popup, te);
+            }
+        }
+      tmp = tmp->next;
+    }
+}
+
+
 #define META_TYPE_SELECT_IMAGE            (meta_select_image_get_type ())
 #define META_SELECT_IMAGE(obj)            (G_TYPE_CHECK_INSTANCE_CAST ((obj), META_TYPE_SELECT_IMAGE, MetaSelectImage))
 

--- a/src/ui/tabpopup.c
+++ b/src/ui/tabpopup.c
@@ -591,13 +591,13 @@ meta_ui_tab_popup_select (MetaTabPopup *popup,
     }
 }
 
-Window
-meta_ui_tab_popup_get_xid (MetaTabPopup *popup)
+GtkWidget*
+meta_ui_tab_popup_get_widget (MetaTabPopup *popup)
 {
-  if (popup != NULL && popup->window != NULL) 
-    return gdk_x11_window_get_xid(gtk_widget_get_window(popup->window)); 
+  if (popup != NULL) 
+    return popup->window; 
   else
-    return 0;
+    return NULL;
 }
 
 void


### PR DESCRIPTION
Now it's possible to move the focus rectangle in the alt+tab popup by mouse clicks.
Fixes #364.