### PR TITLE
Add invisible resize borders

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -83,6 +83,7 @@ marco_SOURCES = \
 	core/workspace.h \
 	core/xprops.c \
 	include/xprops.h \
+	core/common.c \
 	include/common.h \
 	include/core.h \
 	include/ui.h \
@@ -117,6 +118,7 @@ libmarco_private_la_SOURCES = \
 	ui/gradient.h \
 	core/util.c \
 	include/util.h \
+	core/common.c \
 	include/common.h \
 	ui/preview-widget.c \
 	ui/preview-widget.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,6 +14,13 @@ AM_CPPFLAGS = \
 	@MARCO_CFLAGS@
 
 marco_SOURCES = \
+	core/main.c \
+	include/main.h
+
+# by setting libmarco_private_la_CFLAGS, the files shared with
+# marco proper will be compiled with different names.
+libmarco_private_la_CFLAGS =
+libmarco_private_la_SOURCES = \
 	core/async-getprop.c \
 	core/async-getprop.h \
 	core/atomnames.h \
@@ -95,6 +102,8 @@ marco_SOURCES = \
 	ui/menu.h \
 	ui/metaaccellabel.c \
 	ui/metaaccellabel.h \
+	ui/preview-widget.c \
+	ui/preview-widget.h \
 	ui/resizepopup.c \
 	include/resizepopup.h \
 	ui/tabpopup.c \
@@ -107,25 +116,6 @@ marco_SOURCES = \
 	ui/theme.h \
 	ui/ui.c \
 	include/all-keybindings.h
-
-# by setting libmarco_private_la_CFLAGS, the files shared with
-# marco proper will be compiled with different names.
-libmarco_private_la_CFLAGS =
-libmarco_private_la_SOURCES = \
-	core/boxes.c \
-	include/boxes.h \
-	ui/gradient.c \
-	ui/gradient.h \
-	core/util.c \
-	include/util.h \
-	core/common.c \
-	include/common.h \
-	ui/preview-widget.c \
-	ui/preview-widget.h \
-	ui/theme-parser.c \
-	ui/theme-parser.h \
-	ui/theme.c \
-	ui/theme.h
 
 libmarco_private_la_LDFLAGS = -no-undefined -version-info 1:0:0
 libmarco_private_la_LIBADD = @MARCO_LIBS@
@@ -142,13 +132,13 @@ libmarcoinclude_HEADERS = \
 	ui/theme.h
 
 marco_theme_viewer_SOURCES= \
+	ui/preview-widget.c \
+	ui/preview-widget.h \
 	ui/theme-viewer.c
 
 bin_PROGRAMS=marco marco-theme-viewer
 
-EFENCE=
-marco_LDADD=@MARCO_LIBS@ $(EFENCE)
-
+marco_LDADD=@MARCO_LIBS@ libmarco-private.la
 marco_theme_viewer_LDADD= @MARCO_LIBS@ libmarco-private.la
 
 testboxes_SOURCES=include/util.h core/util.c include/boxes.h core/boxes.c core/testboxes.c

--- a/src/compositor/compositor-xrender.c
+++ b/src/compositor/compositor-xrender.c
@@ -199,6 +199,7 @@ typedef struct _MetaCompWindow
   Picture shadow_pict;
 
   XserverRegion border_size;
+  XserverRegion window_size;
   XserverRegion extents;
 
   Picture shadow;
@@ -1146,6 +1147,27 @@ border_size (MetaCompWindow *cw)
   MetaScreen *screen = cw->screen;
   MetaDisplay *display = meta_screen_get_display (screen);
   Display *xdisplay = meta_display_get_xdisplay (display);
+  XserverRegion border;
+
+  meta_error_trap_push (display);
+  border = XFixesCreateRegionFromWindow (xdisplay, cw->id,
+                                         WindowRegionBounding);
+  meta_error_trap_pop (display, FALSE);
+
+  g_return_val_if_fail (border != None, None);
+  XFixesTranslateRegion (xdisplay, border,
+                         cw->attrs.x + cw->attrs.border_width,
+                         cw->attrs.y + cw->attrs.border_width);
+
+  return border;
+}
+
+static XserverRegion
+window_size (MetaCompWindow *cw)
+{
+  MetaScreen *screen = cw->screen;
+  MetaDisplay *display = meta_screen_get_display (screen);
+  Display *xdisplay = meta_display_get_xdisplay (display);
   cairo_region_t *visible_region;
   XserverRegion visible = None;
   XserverRegion border;
@@ -1158,15 +1180,7 @@ border_size (MetaCompWindow *cw)
         visible = cairo_region_to_xserver_region (xdisplay, visible_region);
     }
 
-  meta_error_trap_push (display);
-  border = XFixesCreateRegionFromWindow (xdisplay, cw->id,
-                                         WindowRegionBounding);
-  meta_error_trap_pop (display, FALSE);
-
-  g_return_val_if_fail (border != None, None);
-  XFixesTranslateRegion (xdisplay, border,
-                         cw->attrs.x + cw->attrs.border_width,
-                         cw->attrs.y + cw->attrs.border_width);
+  border = border_size (cw);
 
   if (visible != None)
     {
@@ -1408,6 +1422,12 @@ paint_windows (MetaScreen   *screen,
               cw->border_size = None;
             }
 
+          if (cw->window_size)
+            {
+              XFixesDestroyRegion (xdisplay, cw->window_size);
+              cw->window_size = None;
+            }
+
 #if 0
           if (cw->extents)
             {
@@ -1419,6 +1439,9 @@ paint_windows (MetaScreen   *screen,
 
       if (cw->border_size == None)
         cw->border_size = border_size (cw);
+
+      if (cw->window_size == None)
+        cw->window_size = window_size (cw);
 
       if (cw->extents == None)
         cw->extents = win_extents (cw);
@@ -1485,7 +1508,7 @@ paint_windows (MetaScreen   *screen,
 
               shadow_clip = XFixesCreateRegion (xdisplay, NULL, 0);
               XFixesSubtractRegion (xdisplay, shadow_clip, cw->border_clip,
-                                    cw->border_size);
+                                    cw->window_size);
               XFixesSetPictureClipRegion (xdisplay, root_buffer, 0, 0,
                                           shadow_clip);
 
@@ -1825,6 +1848,12 @@ free_win (MetaCompWindow *cw,
       cw->border_size = None;
     }
 
+  if (cw->window_size)
+    {
+      XFixesDestroyRegion (xdisplay, cw->window_size);
+      cw->window_size = None;
+    }
+
   if (cw->border_clip)
     {
       XFixesDestroyRegion (xdisplay, cw->border_clip);
@@ -2093,6 +2122,7 @@ add_win (MetaScreen *screen,
   cw->alpha_pict = None;
   cw->shadow_pict = None;
   cw->border_size = None;
+  cw->window_size = None;
   cw->extents = None;
   cw->shadow = None;
   cw->shadow_dx = 0;

--- a/src/compositor/compositor-xrender.c
+++ b/src/compositor/compositor-xrender.c
@@ -627,51 +627,54 @@ cairo_region_to_xserver_region (Display        *xdisplay,
 }
 
 static void
-shadow_clip (Display          *xdisplay,
-             Picture           shadow_picture,
-             XImage           *shadow_image,
-             MetaShadowType    shadow_type,
-             MetaFrameBorders  borders,
-             int               width,
-             int               height)
+shadow_picture_clip (Display          *xdisplay,
+                     Picture           shadow_picture,
+                     MetaCompWindow   *cw,
+                     MetaFrameBorders  borders,
+                     int               width,
+                     int               height)
 {
-  int shadow_dx = -1 * (int) shadow_offsets_x [shadow_type] - borders.invisible.left;
-  int shadow_dy = -1 * (int) shadow_offsets_y [shadow_type] - borders.invisible.top;
-  XRectangle clip[4];
+  int shadow_dx;
+  int shadow_dy;
+  cairo_region_t *visible_region;
+  XRectangle rect;
+  XserverRegion region1;
+  XserverRegion region2;
 
-  /* Top */
-  clip[0].x      = 0;
-  clip[0].y      = 0;
-  clip[0].width  = shadow_image->width;
-  clip[0].height = shadow_dy + borders.visible.top;
+  if (!cw->window)
+    return;
 
-  /* Bottom */
-  clip[1].x      = 0;
-  clip[1].y      = shadow_dy + (height - borders.visible.bottom);
-  clip[1].width  = shadow_image->width;
-  clip[1].height = shadow_image->height - (shadow_dy + (height - borders.visible.bottom));
+  visible_region = meta_window_get_frame_bounds (cw->window);
 
-  /* Left */
-  clip[2].x      = 0;
-  clip[2].y      = shadow_dy + borders.visible.top;
-  clip[2].width  = shadow_dx + borders.visible.left;
-  clip[2].height = height - borders.visible.top - borders.visible.bottom;
+  if (!visible_region)
+    return;
 
-  /* Right */
-  clip[3].x      = width + shadow_dx;
-  clip[3].y      = shadow_dy + borders.visible.top;
-  clip[3].width  = shadow_image->width - (width + shadow_dx);
-  clip[3].height = height - borders.visible.top - borders.visible.bottom;
+  shadow_dx = -1 * (int) shadow_offsets_x [cw->shadow_type] - borders.invisible.left;
+  shadow_dy = -1 * (int) shadow_offsets_y [cw->shadow_type] - borders.invisible.top;
 
-  XRenderSetPictureClipRectangles (xdisplay, shadow_picture, 0, 0, clip, 4);
+  rect.x = 0;
+  rect.y = 0;
+  rect.width = width;
+  rect.height = height;
+
+  region1 = XFixesCreateRegion (xdisplay, &rect, 1);
+  region2 = cairo_region_to_xserver_region (xdisplay, visible_region);
+
+  XFixesTranslateRegion (xdisplay, region2,
+                         shadow_dx, shadow_dy);
+
+  XFixesSubtractRegion (xdisplay, region1, region1, region2);
+  XFixesSetPictureClipRegion (xdisplay, shadow_picture, 0, 0, region1);
+
+  XFixesDestroyRegion (xdisplay, region1);
+  XFixesDestroyRegion (xdisplay, region2);
 }
 
 static Picture
 shadow_picture (MetaDisplay     *display,
                 MetaScreen      *screen,
-                MetaShadowType   shadow_type,
+                MetaCompWindow  *cw,
                 double           opacity,
-                Picture          alpha_pict,
                 MetaFrameBorders borders,
                 int              width,
                 int              height,
@@ -685,7 +688,7 @@ shadow_picture (MetaDisplay     *display,
   Window xroot = meta_screen_get_xroot (screen);
   GC gc;
 
-  shadow_image = make_shadow (display, screen, shadow_type,
+  shadow_image = make_shadow (display, screen, cw->shadow_type,
                               opacity, width, height);
   if (!shadow_image)
     return None;
@@ -708,10 +711,8 @@ shadow_picture (MetaDisplay     *display,
       return None;
     }
 
-  shadow_clip (xdisplay,
-               shadow_picture, shadow_image, shadow_type,
-               borders,
-               width, height);
+  shadow_picture_clip (xdisplay, shadow_picture, cw, borders,
+                       shadow_image->width, shadow_image->height);
 
   gc = XCreateGC (xdisplay, shadow_pixmap, 0, 0);
   if (!gc)
@@ -1106,9 +1107,7 @@ win_extents (MetaCompWindow *cw)
           if (cw->opacity != (guint) OPAQUE)
             opacity = opacity * ((double) cw->opacity) / ((double) OPAQUE);
 
-          cw->shadow = shadow_picture (display, screen, cw->shadow_type,
-                                       opacity, cw->alpha_pict,
-                                       borders,
+          cw->shadow = shadow_picture (display, screen, cw, opacity, borders,
                                        cw->attrs.width - invisible_width + cw->attrs.border_width * 2,
                                        cw->attrs.height - invisible_height + cw->attrs.border_width * 2,
                                        &cw->shadow_width, &cw->shadow_height);

--- a/src/compositor/compositor-xrender.c
+++ b/src/compositor/compositor-xrender.c
@@ -605,8 +605,8 @@ shadow_clip (Display          *xdisplay,
              int               width,
              int               height)
 {
-  int shadow_dx = -1 * shadow_offsets_x [shadow_type];
-  int shadow_dy = -1 * shadow_offsets_y [shadow_type];
+  int shadow_dx = -1 * (int) shadow_offsets_x [shadow_type] - borders.invisible.left;
+  int shadow_dy = -1 * (int) shadow_offsets_y [shadow_type] - borders.invisible.top;
   XRectangle clip[4];
 
   /* Top */
@@ -1064,20 +1064,23 @@ win_extents (MetaCompWindow *cw)
             meta_frame_calc_borders (frame, &borders);
         }
 
-      cw->shadow_dx = shadow_offsets_x [cw->shadow_type];
-      cw->shadow_dy = shadow_offsets_y [cw->shadow_type];
+      cw->shadow_dx = (int) shadow_offsets_x [cw->shadow_type] + borders.invisible.left;
+      cw->shadow_dy = (int) shadow_offsets_y [cw->shadow_type] + borders.invisible.top;
 
       if (!cw->shadow)
         {
           double opacity = SHADOW_OPACITY;
+          int invisible_width = borders.invisible.left + borders.invisible.right;
+          int invisible_height = borders.invisible.top + borders.invisible.bottom;
+
           if (cw->opacity != (guint) OPAQUE)
             opacity = opacity * ((double) cw->opacity) / ((double) OPAQUE);
 
           cw->shadow = shadow_picture (display, screen, cw->shadow_type,
                                        opacity, cw->alpha_pict,
                                        borders,
-                                       cw->attrs.width + cw->attrs.border_width * 2,
-                                       cw->attrs.height + cw->attrs.border_width * 2,
+                                       cw->attrs.width - invisible_width + cw->attrs.border_width * 2,
+                                       cw->attrs.height - invisible_height + cw->attrs.border_width * 2,
                                        &cw->shadow_width, &cw->shadow_height);
         }
 

--- a/src/compositor/compositor-xrender.c
+++ b/src/compositor/compositor-xrender.c
@@ -589,16 +589,64 @@ make_shadow (MetaDisplay   *display,
   return ximage;
 }
 
+double shadow_offsets_x[LAST_SHADOW_TYPE] = {SHADOW_SMALL_OFFSET_X,
+                                             SHADOW_MEDIUM_OFFSET_X,
+                                             SHADOW_LARGE_OFFSET_X};
+double shadow_offsets_y[LAST_SHADOW_TYPE] = {SHADOW_SMALL_OFFSET_Y,
+                                             SHADOW_MEDIUM_OFFSET_Y,
+                                             SHADOW_LARGE_OFFSET_Y};
+
+static void
+shadow_clip (Display          *xdisplay,
+             Picture           shadow_picture,
+             XImage           *shadow_image,
+             MetaShadowType    shadow_type,
+             MetaFrameBorders  borders,
+             int               width,
+             int               height)
+{
+  int shadow_dx = -1 * shadow_offsets_x [shadow_type];
+  int shadow_dy = -1 * shadow_offsets_y [shadow_type];
+  XRectangle clip[4];
+
+  /* Top */
+  clip[0].x      = 0;
+  clip[0].y      = 0;
+  clip[0].width  = shadow_image->width;
+  clip[0].height = shadow_dy + borders.visible.top;
+
+  /* Bottom */
+  clip[1].x      = 0;
+  clip[1].y      = shadow_dy + (height - borders.visible.bottom);
+  clip[1].width  = shadow_image->width;
+  clip[1].height = shadow_image->height - (shadow_dy + (height - borders.visible.bottom));
+
+  /* Left */
+  clip[2].x      = 0;
+  clip[2].y      = shadow_dy + borders.visible.top;
+  clip[2].width  = shadow_dx + borders.visible.left;
+  clip[2].height = height - borders.visible.top - borders.visible.bottom;
+
+  /* Right */
+  clip[3].x      = width + shadow_dx;
+  clip[3].y      = shadow_dy + borders.visible.top;
+  clip[3].width  = shadow_image->width - (width + shadow_dx);
+  clip[3].height = height - borders.visible.top - borders.visible.bottom;
+
+  XRenderSetPictureClipRectangles (xdisplay, shadow_picture, 0, 0, clip, 4);
+}
+
 static Picture
-shadow_picture (MetaDisplay   *display,
-                MetaScreen    *screen,
-                MetaShadowType shadow_type,
-                double         opacity,
-                Picture        alpha_pict,
-                int            width,
-                int            height,
-                int           *wp,
-                int           *hp)
+shadow_picture (MetaDisplay     *display,
+                MetaScreen      *screen,
+                MetaShadowType   shadow_type,
+                double           opacity,
+                Picture          alpha_pict,
+                MetaFrameBorders borders,
+                int              width,
+                int              height,
+                int             *wp,
+                int             *hp)
 {
   Display *xdisplay = meta_display_get_xdisplay (display);
   XImage *shadow_image;
@@ -621,8 +669,7 @@ shadow_picture (MetaDisplay   *display,
     }
 
   shadow_picture = XRenderCreatePicture (xdisplay, shadow_pixmap,
-                                         XRenderFindStandardFormat (xdisplay,
-PictStandardA8),
+                                         XRenderFindStandardFormat (xdisplay, PictStandardA8),
                                          0, 0);
   if (!shadow_picture)
     {
@@ -630,6 +677,11 @@ PictStandardA8),
       XFreePixmap (xdisplay, shadow_pixmap);
       return None;
     }
+
+  shadow_clip (xdisplay,
+               shadow_picture, shadow_image, shadow_type,
+               borders,
+               width, height);
 
   gc = XCreateGC (xdisplay, shadow_pixmap, 0, 0);
   if (!gc)
@@ -984,12 +1036,6 @@ window_has_shadow (MetaCompWindow *cw)
   return FALSE;
 }
 
-double shadow_offsets_x[LAST_SHADOW_TYPE] = {SHADOW_SMALL_OFFSET_X,
-                                             SHADOW_MEDIUM_OFFSET_X,
-                                             SHADOW_LARGE_OFFSET_X};
-double shadow_offsets_y[LAST_SHADOW_TYPE] = {SHADOW_SMALL_OFFSET_Y,
-                                             SHADOW_MEDIUM_OFFSET_Y,
-                                             SHADOW_LARGE_OFFSET_Y};
 static XserverRegion
 win_extents (MetaCompWindow *cw)
 {
@@ -1005,7 +1051,18 @@ win_extents (MetaCompWindow *cw)
 
   if (cw->needs_shadow)
     {
+      MetaFrameBorders borders;
       XRectangle sr;
+
+      meta_frame_borders_clear (&borders);
+
+      if (cw->window)
+        {
+          MetaFrame *frame = meta_window_get_frame (cw->window);
+
+          if (frame)
+            meta_frame_calc_borders (frame, &borders);
+        }
 
       cw->shadow_dx = shadow_offsets_x [cw->shadow_type];
       cw->shadow_dy = shadow_offsets_y [cw->shadow_type];
@@ -1018,6 +1075,7 @@ win_extents (MetaCompWindow *cw)
 
           cw->shadow = shadow_picture (display, screen, cw->shadow_type,
                                        opacity, cw->alpha_pict,
+                                       borders,
                                        cw->attrs.width + cw->attrs.border_width * 2,
                                        cw->attrs.height + cw->attrs.border_width * 2,
                                        &cw->shadow_width, &cw->shadow_height);

--- a/src/compositor/compositor-xrender.c
+++ b/src/compositor/compositor-xrender.c
@@ -596,6 +596,35 @@ double shadow_offsets_y[LAST_SHADOW_TYPE] = {SHADOW_SMALL_OFFSET_Y,
                                              SHADOW_MEDIUM_OFFSET_Y,
                                              SHADOW_LARGE_OFFSET_Y};
 
+static XserverRegion
+cairo_region_to_xserver_region (Display        *xdisplay,
+                                cairo_region_t *region)
+{
+  int n_rects, i;
+  XRectangle *rects;
+  XserverRegion xregion;
+
+  n_rects = cairo_region_num_rectangles (region);
+  rects = g_new (XRectangle, n_rects);
+
+  for (i = 0; i < n_rects; i++)
+    {
+      cairo_rectangle_int_t rect;
+
+      cairo_region_get_rectangle (region, i, &rect);
+
+      rects[i].x = rect.x;
+      rects[i].y = rect.y;
+      rects[i].width = rect.width;
+      rects[i].height = rect.height;
+    }
+
+  xregion = XFixesCreateRegion (xdisplay, rects, n_rects);
+  g_free (rects);
+
+  return xregion;
+}
+
 static void
 shadow_clip (Display          *xdisplay,
              Picture           shadow_picture,
@@ -1117,7 +1146,17 @@ border_size (MetaCompWindow *cw)
   MetaScreen *screen = cw->screen;
   MetaDisplay *display = meta_screen_get_display (screen);
   Display *xdisplay = meta_display_get_xdisplay (display);
+  cairo_region_t *visible_region;
+  XserverRegion visible = None;
   XserverRegion border;
+
+  if (cw->window)
+    {
+      visible_region = meta_window_get_frame_bounds (cw->window);
+
+      if (visible_region)
+        visible = cairo_region_to_xserver_region (xdisplay, visible_region);
+    }
 
   meta_error_trap_push (display);
   border = XFixesCreateRegionFromWindow (xdisplay, cw->id,
@@ -1128,6 +1167,19 @@ border_size (MetaCompWindow *cw)
   XFixesTranslateRegion (xdisplay, border,
                          cw->attrs.x + cw->attrs.border_width,
                          cw->attrs.y + cw->attrs.border_width);
+
+  if (visible != None)
+    {
+      XFixesTranslateRegion (xdisplay, visible,
+                         cw->attrs.x + cw->attrs.border_width,
+                         cw->attrs.y + cw->attrs.border_width);
+
+      XFixesIntersectRegion (xdisplay, visible, visible, border);
+      XFixesDestroyRegion (xdisplay, border);
+
+      return visible;
+    }
+
   return border;
 }
 

--- a/src/core/common.c
+++ b/src/core/common.c
@@ -1,0 +1,35 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+
+/* Marco X window decorations */
+
+/*
+ * Copyright (C) 2001 Havoc Pennington
+ * Copyright (C) 2003, 2004 Red Hat, Inc.
+ * Copyright (C) 2005 Elijah Newren
+ * Copyright (C) 2019 The MATE Developers
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+#include "common.h"
+
+void
+meta_frame_borders_clear (MetaFrameBorders *self)
+{
+  self->visible.top = 0;
+  self->visible.bottom = 0;
+  self->visible.left = 0;
+  self->visible.right = 0;
+}

--- a/src/core/common.c
+++ b/src/core/common.c
@@ -28,8 +28,8 @@
 void
 meta_frame_borders_clear (MetaFrameBorders *self)
 {
-  self->visible.top = 0;
-  self->visible.bottom = 0;
-  self->visible.left = 0;
-  self->visible.right = 0;
+  self->visible.top = self->invisible.top = self->total.top = 0;
+  self->visible.bottom = self->invisible.bottom = self->total.bottom = 0;
+  self->visible.left = self->invisible.left = self->total.left = 0;
+  self->visible.right = self->invisible.right = self->total.right = 0;
 }

--- a/src/core/common.c
+++ b/src/core/common.c
@@ -33,3 +33,19 @@ meta_frame_borders_clear (MetaFrameBorders *self)
   self->visible.left = self->invisible.left = self->total.left = 0;
   self->visible.right = self->invisible.right = self->total.right = 0;
 }
+
+int
+get_window_scaling_factor (void)
+{
+  GdkScreen *screen;
+  GValue value = G_VALUE_INIT;
+
+  screen = gdk_screen_get_default ();
+
+  g_value_init (&value, G_TYPE_INT);
+
+  if (gdk_screen_get_setting (screen, "gdk-window-scaling-factor", &value))
+    return g_value_get_int (&value);
+  else
+    return 1;
+}

--- a/src/core/constraints.c
+++ b/src/core/constraints.c
@@ -810,7 +810,7 @@ constrain_modal_dialog (MetaWindow         *window,
       y += parent->frame->rect.y;
 
       meta_frame_calc_borders (parent->frame, &borders);
-      y += borders.visible.top;
+      y += borders.total.top;
 
       y += info->borders->visible.top;
    }

--- a/src/core/constraints.h
+++ b/src/core/constraints.h
@@ -39,7 +39,7 @@ typedef enum
 } MetaMoveResizeFlags;
 
 void meta_window_constrain (MetaWindow          *window,
-                            MetaFrameGeometry   *orig_fgeom,
+                            MetaFrameBorders    *orig_borders,
                             MetaMoveResizeFlags  flags,
                             int                  resize_gravity,
                             const MetaRectangle *orig,

--- a/src/core/display.c
+++ b/src/core/display.c
@@ -4386,11 +4386,7 @@ process_request_frame_extents (MetaDisplay    *display,
                                          &hints);
   if ((hints_set && hints->decorations) || !hints_set)
     {
-      int top = 0;
-      int bottom = 0;
-      int left = 0;
-      int right = 0;
-
+      MetaFrameBorders borders;
       MetaScreen *screen;
 
       screen = meta_display_screen_for_xwindow (display,
@@ -4408,15 +4404,12 @@ process_request_frame_extents (MetaDisplay    *display,
       meta_ui_theme_get_frame_borders (screen->ui,
                                        META_FRAME_TYPE_NORMAL,
                                        0,
-                                       &top,
-                                       &bottom,
-                                       &left,
-                                       &right);
+                                       &borders);
 
-      data[0] = left;
-      data[1] = right;
-      data[2] = top;
-      data[3] = bottom;
+      data[0] = borders.visible.left;
+      data[1] = borders.visible.right;
+      data[2] = borders.visible.top;
+      data[3] = borders.visible.bottom;
     }
 
   meta_topic (META_DEBUG_GEOMETRY,

--- a/src/core/frame-private.h
+++ b/src/core/frame-private.h
@@ -62,10 +62,13 @@ MetaFrameFlags meta_frame_get_flags (MetaFrame *frame);
 /* These should ONLY be called from meta_window_move_resize_internal */
 void meta_frame_calc_borders      (MetaFrame        *frame,
                                    MetaFrameBorders *borders);
-void meta_frame_sync_to_window    (MetaFrame        *frame,
-                                   int               gravity,
-                                   gboolean          need_move,
-                                   gboolean          need_resize);
+
+gboolean meta_frame_sync_to_window (MetaFrame       *frame,
+                                    int              gravity,
+                                    gboolean         need_move,
+                                    gboolean         need_resize);
+
+cairo_region_t *meta_frame_get_frame_bounds (MetaFrame *frame);
 
 void meta_frame_set_screen_cursor (MetaFrame        *frame,
                                    MetaCursor        cursor);

--- a/src/core/frame-private.h
+++ b/src/core/frame-private.h
@@ -66,6 +66,9 @@ gboolean meta_frame_sync_to_window (MetaFrame       *frame,
 
 cairo_region_t *meta_frame_get_frame_bounds (MetaFrame *frame);
 
+void meta_frame_get_mask (MetaFrame *frame,
+                          cairo_t   *cr);
+
 void meta_frame_set_screen_cursor (MetaFrame        *frame,
                                    MetaCursor        cursor);
 

--- a/src/core/frame-private.h
+++ b/src/core/frame-private.h
@@ -59,10 +59,6 @@ void     meta_frame_queue_draw              (MetaFrame  *frame);
 
 MetaFrameFlags meta_frame_get_flags (MetaFrame *frame);
 
-/* These should ONLY be called from meta_window_move_resize_internal */
-void meta_frame_calc_borders      (MetaFrame        *frame,
-                                   MetaFrameBorders *borders);
-
 gboolean meta_frame_sync_to_window (MetaFrame       *frame,
                                     int              gravity,
                                     gboolean         need_move,

--- a/src/core/frame-private.h
+++ b/src/core/frame-private.h
@@ -27,17 +27,6 @@
 #include "frame.h"
 #include "window-private.h"
 
-typedef struct _MetaFrameGeometry MetaFrameGeometry;
-
-struct _MetaFrameGeometry
-{
-  /* border sizes (space between frame and child) */
-  int left_width;
-  int right_width;
-  int top_height;
-  int bottom_height;
-};
-
 struct _MetaFrame
 {
   /* window we frame */
@@ -71,15 +60,15 @@ void     meta_frame_queue_draw              (MetaFrame  *frame);
 MetaFrameFlags meta_frame_get_flags (MetaFrame *frame);
 
 /* These should ONLY be called from meta_window_move_resize_internal */
-void meta_frame_calc_geometry      (MetaFrame         *frame,
-                                    MetaFrameGeometry *geomp);
-void meta_frame_sync_to_window     (MetaFrame         *frame,
-                                    int                gravity,
-                                    gboolean           need_move,
-                                    gboolean           need_resize);
+void meta_frame_calc_borders      (MetaFrame        *frame,
+                                   MetaFrameBorders *borders);
+void meta_frame_sync_to_window    (MetaFrame        *frame,
+                                   int               gravity,
+                                   gboolean          need_move,
+                                   gboolean          need_resize);
 
-void meta_frame_set_screen_cursor (MetaFrame	*frame,
-				   MetaCursor	cursor);
+void meta_frame_set_screen_cursor (MetaFrame        *frame,
+                                   MetaCursor        cursor);
 
 #endif
 

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -303,7 +303,7 @@ meta_frame_calc_borders (MetaFrame        *frame,
                              borders);
 }
 
-static void
+static gboolean
 update_shape (MetaFrame *frame)
 {
   if (frame->need_reapply_frame_shape)
@@ -314,10 +314,14 @@ update_shape (MetaFrame *frame)
                                  frame->rect.height,
                                  frame->window->has_shape);
       frame->need_reapply_frame_shape = FALSE;
+
+      return TRUE;
     }
+  else
+    return FALSE;
 }
 
-void
+gboolean
 meta_frame_sync_to_window (MetaFrame *frame,
                            int        resize_gravity,
                            gboolean   need_move,
@@ -325,8 +329,7 @@ meta_frame_sync_to_window (MetaFrame *frame,
 {
   if (!(need_move || need_resize))
     {
-      update_shape (frame);
-      return;
+      return update_shape (frame);
     }
 
   meta_topic (META_DEBUG_GEOMETRY,
@@ -368,6 +371,17 @@ meta_frame_sync_to_window (MetaFrame *frame,
         meta_ui_repaint_frame (frame->window->screen->ui,
                                frame->xwindow);
     }
+
+  return need_resize;
+}
+
+cairo_region_t *
+meta_frame_get_frame_bounds (MetaFrame *frame)
+{
+  return meta_ui_get_frame_bounds (frame->window->screen->ui,
+                                   frame->xwindow,
+                                   frame->rect.width,
+                                   frame->rect.height);
 }
 
 void

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -295,22 +295,12 @@ meta_frame_get_flags (MetaFrame *frame)
 }
 
 void
-meta_frame_calc_geometry (MetaFrame         *frame,
-                          MetaFrameGeometry *geomp)
+meta_frame_calc_borders (MetaFrame        *frame,
+                         MetaFrameBorders *borders)
 {
-  MetaFrameGeometry geom;
-  MetaWindow *window;
-
-  window = frame->window;
-
-  meta_ui_get_frame_geometry (window->screen->ui,
-                              frame->xwindow,
-                              &geom.top_height,
-                              &geom.bottom_height,
-                              &geom.left_width,
-                              &geom.right_width);
-
-  *geomp = geom;
+  meta_ui_get_frame_borders (frame->window->screen->ui,
+                             frame->xwindow,
+                             borders);
 }
 
 static void

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -169,6 +169,7 @@ void
 meta_window_destroy_frame (MetaWindow *window)
 {
   MetaFrame *frame;
+  MetaFrameBorders borders;
 
   if (window->frame == NULL)
     return;
@@ -176,6 +177,8 @@ meta_window_destroy_frame (MetaWindow *window)
   meta_verbose ("Unframing window %s\n", window->desc);
 
   frame = window->frame;
+
+  meta_frame_calc_borders (frame, &borders);
 
   meta_bell_notify_frame_destroy (frame);
 
@@ -200,8 +203,8 @@ meta_window_destroy_frame (MetaWindow *window)
                     * coordinates here means we'll need to ensure a configure
                     * notify event is sent; see bug 399552.
                     */
-                   window->frame->rect.x,
-                   window->frame->rect.y);
+                   window->frame->rect.x + borders.invisible.left,
+                   window->frame->rect.y + borders.invisible.top);
   meta_error_trap_pop (window->display, FALSE);
 
   meta_ui_destroy_frame_window (window->screen->ui, frame->xwindow);

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -422,6 +422,14 @@ meta_frame_get_frame_bounds (MetaFrame *frame)
 }
 
 void
+meta_frame_get_mask (MetaFrame *frame,
+                     cairo_t   *cr)
+{
+  meta_ui_get_frame_mask (frame->window->screen->ui, frame->xwindow,
+                          frame->rect.width, frame->rect.height, cr);
+}
+
+void
 meta_frame_queue_draw (MetaFrame *frame)
 {
   meta_ui_queue_frame_draw (frame->window->screen->ui,

--- a/src/core/place.c
+++ b/src/core/place.c
@@ -88,8 +88,8 @@ northwestcmp (gconstpointer a, gconstpointer b)
 }
 
 static gboolean
-place_by_pointer(MetaWindow *window,
-                 MetaFrameGeometry *fgeom,
+place_by_pointer(MetaWindow       *window,
+                 MetaFrameBorders *borders,
                  MetaPlacementMode placement_mode,
                  int *new_x,
                  int *new_y)
@@ -113,9 +113,9 @@ place_by_pointer(MetaWindow *window,
   window_width = window->frame ? window->frame->rect.width : window->rect.width;
   window_height = window->frame ? window->frame->rect.height : window->rect.height;
 
-  if (fgeom) {
-    *new_x = root_x_return + fgeom->left_width - window_width / 2;
-    *new_y = root_y_return + fgeom->top_height - window_height / 2;
+  if (borders) {
+    *new_x = root_x_return + borders->visible.left - window_width / 2;
+    *new_y = root_y_return + borders->visible.top - window_height / 2;
   }
   else {
     *new_x = root_x_return - window_width / 2;
@@ -129,14 +129,14 @@ place_by_pointer(MetaWindow *window,
 }
 
 static void
-find_next_cascade (MetaWindow *window,
-                   MetaFrameGeometry *fgeom,
+find_next_cascade (MetaWindow       *window,
+                   MetaFrameBorders *borders,
                    /* visible windows on relevant workspaces */
-                   GList      *windows,
-                   int         x,
-                   int         y,
-                   int        *new_x,
-                   int        *new_y)
+                   GList            *windows,
+                   int               x,
+                   int               y,
+                   int              *new_x,
+                   int              *new_y)
 {
   GList *tmp;
   GList *sorted;
@@ -160,10 +160,10 @@ find_next_cascade (MetaWindow *window,
    * manually cascade.
    */
 #define CASCADE_FUZZ 15
-  if (fgeom)
+  if (borders)
     {
-      x_threshold = MAX (fgeom->left_width, CASCADE_FUZZ);
-      y_threshold = MAX (fgeom->top_height, CASCADE_FUZZ);
+      x_threshold = MAX (borders->visible.left, CASCADE_FUZZ);
+      y_threshold = MAX (borders->visible.top, CASCADE_FUZZ);
     }
   else
     {
@@ -264,27 +264,27 @@ find_next_cascade (MetaWindow *window,
   g_list_free (sorted);
 
   /* Convert coords to position of window, not position of frame. */
-  if (fgeom == NULL)
+  if (borders == NULL)
     {
       *new_x = cascade_x;
       *new_y = cascade_y;
     }
   else
     {
-      *new_x = cascade_x + fgeom->left_width;
-      *new_y = cascade_y + fgeom->top_height;
+      *new_x = cascade_x + borders->visible.left;
+      *new_y = cascade_y + borders->visible.top;
     }
 }
 
 static void
-find_most_freespace (MetaWindow *window,
-                     MetaFrameGeometry *fgeom,
+find_most_freespace (MetaWindow       *window,
+                     MetaFrameBorders *borders,
                      /* visible windows on relevant workspaces */
-                     MetaWindow *focus_window,
-                     int         x,
-                     int         y,
-                     int        *new_x,
-                     int        *new_y)
+                     MetaWindow       *focus_window,
+                     int               x,
+                     int               y,
+                     int              *new_x,
+                     int              *new_y)
 {
   MetaWindowDirection side;
   int max_area;
@@ -295,8 +295,8 @@ find_most_freespace (MetaWindow *window,
   MetaRectangle avoid;
   MetaRectangle outer;
 
-  frame_size_left = fgeom ? fgeom->left_width : 0;
-  frame_size_top  = fgeom ? fgeom->top_height : 0;
+  frame_size_left = borders ? borders->visible.left : 0;
+  frame_size_top  = borders ? borders->visible.top : 0;
 
   meta_window_get_work_area_current_xinerama (focus_window, &work_area);
   meta_window_get_outer_rect (focus_window, &avoid);
@@ -375,10 +375,10 @@ find_most_freespace (MetaWindow *window,
 }
 
 static void
-avoid_being_obscured_as_second_modal_dialog (MetaWindow *window,
-                                             MetaFrameGeometry *fgeom,
-                                             int        *x,
-                                             int        *y)
+avoid_being_obscured_as_second_modal_dialog (MetaWindow       *window,
+                                             MetaFrameBorders *borders,
+                                             int              *x,
+                                             int              *y)
 {
   /* We can't center this dialog if it was denied focus and it
    * overlaps with the focus window and this dialog is modal and this
@@ -406,7 +406,7 @@ avoid_being_obscured_as_second_modal_dialog (MetaWindow *window,
                                 &focus_window->rect,
                                 &overlap))
     {
-      find_most_freespace (window, fgeom, focus_window, *x, *y, x, y);
+      find_most_freespace (window, borders, focus_window, *x, *y, x, y);
       meta_topic (META_DEBUG_PLACEMENT,
                   "Dialog window %s was denied focus but may be modal "
                   "to the focus window; had to move it to avoid the "
@@ -545,15 +545,15 @@ center_rect_in_area (MetaRectangle *rect,
  * don't want to create a 1x1 Emacs.
  */
 static gboolean
-find_first_fit (MetaWindow *window,
-                MetaFrameGeometry *fgeom,
+find_first_fit (MetaWindow       *window,
+                MetaFrameBorders *borders,
                 /* visible windows on relevant workspaces */
-                GList      *windows,
-		int         xinerama,
-                int         x,
-                int         y,
-                int        *new_x,
-                int        *new_y)
+                GList            *windows,
+		int               xinerama,
+                int               x,
+                int               y,
+                int              *new_x,
+                int              *new_y)
 {
   /* This algorithm is limited - it just brute-force tries
    * to fit the window in a small number of locations that are aligned
@@ -584,10 +584,10 @@ find_first_fit (MetaWindow *window,
   rect.width = window->rect.width;
   rect.height = window->rect.height;
 
-  if (fgeom)
+  if (borders)
     {
-      rect.width += fgeom->left_width + fgeom->right_width;
-      rect.height += fgeom->top_height + fgeom->bottom_height;
+      rect.width += borders->visible.left + borders->visible.right;
+      rect.height += borders->visible.top + borders->visible.bottom;
     }
 
 #ifdef WITH_VERBOSE_MODE
@@ -614,10 +614,10 @@ find_first_fit (MetaWindow *window,
       {
         *new_x = rect.x;
         *new_y = rect.y;
-        if (fgeom)
+        if (borders)
           {
-            *new_x += fgeom->left_width;
-            *new_y += fgeom->top_height;
+            *new_x += borders->visible.left;
+            *new_y += borders->visible.top;
           }
 
         retval = TRUE;
@@ -642,10 +642,10 @@ find_first_fit (MetaWindow *window,
           {
             *new_x = rect.x;
             *new_y = rect.y;
-            if (fgeom)
+            if (borders)
               {
-                *new_x += fgeom->left_width;
-                *new_y += fgeom->top_height;
+                *new_x += borders->visible.left;
+                *new_y += borders->visible.top;
               }
 
             retval = TRUE;
@@ -673,10 +673,10 @@ find_first_fit (MetaWindow *window,
           {
             *new_x = rect.x;
             *new_y = rect.y;
-            if (fgeom)
+            if (borders)
               {
-                *new_x += fgeom->left_width;
-                *new_y += fgeom->top_height;
+                *new_x += borders->visible.left;
+                *new_y += borders->visible.top;
               }
 
             retval = TRUE;
@@ -695,19 +695,19 @@ find_first_fit (MetaWindow *window,
 }
 
 void
-meta_window_place (MetaWindow        *window,
-                   MetaFrameGeometry *fgeom,
-                   int                x,
-                   int                y,
-                   int               *new_x,
-                   int               *new_y)
+meta_window_place (MetaWindow       *window,
+                   MetaFrameBorders *borders,
+                   int               x,
+                   int               y,
+                   int              *new_x,
+                   int              *new_y)
 {
   GList *windows;
   const MetaXineramaScreenInfo *xi;
   MetaPlacementMode placement_mode;
 
   /* frame member variables should NEVER be used in here, only
-   * MetaFrameGeometry. But remember fgeom == NULL
+   * MetaFrameBorders. But remember borders == NULL
    * for undecorated windows. Also, this function should
    * NEVER have side effects other than computing the
    * placement coordinates.
@@ -785,7 +785,7 @@ meta_window_place (MetaWindow        *window,
         {
           meta_topic (META_DEBUG_PLACEMENT,
                       "Not placing window with PPosition or USPosition set\n");
-          avoid_being_obscured_as_second_modal_dialog (window, fgeom, &x, &y);
+          avoid_being_obscured_as_second_modal_dialog (window, borders, &x, &y);
           goto done_no_constraints;
         }
     }
@@ -820,13 +820,13 @@ meta_window_place (MetaWindow        *window,
           y += (parent->rect.height - window->rect.height)/3;
 
           /* put top of child's frame, not top of child's client */
-          if (fgeom)
-            y += fgeom->top_height;
+          if (borders)
+            y += borders->visible.top;
 
           meta_topic (META_DEBUG_PLACEMENT, "Centered window %s over transient parent\n",
                       window->desc);
 
-          avoid_being_obscured_as_second_modal_dialog (window, fgeom, &x, &y);
+          avoid_being_obscured_as_second_modal_dialog (window, borders, &x, &y);
 
           goto done;
         }
@@ -901,11 +901,11 @@ meta_window_place (MetaWindow        *window,
   if (placement_mode == META_PLACEMENT_MODE_POINTER ||
       placement_mode == META_PLACEMENT_MODE_MANUAL)
     {
-      if (place_by_pointer (window, fgeom, placement_mode, &x, &y))
+      if (place_by_pointer (window, borders, placement_mode, &x, &y))
         goto done_check_denied_focus;
     }
 
-  if (find_first_fit (window, fgeom, windows,
+  if (find_first_fit (window, borders, windows,
                       xi->number,
                       x, y, &x, &y))
     goto done_check_denied_focus;
@@ -939,7 +939,7 @@ meta_window_place (MetaWindow        *window,
    * fully overlapping window (e.g. starting multiple terminals)
    * */
   if (!meta_prefs_get_center_new_windows() && (x == xi->rect.x && y == xi->rect.y))
-    find_next_cascade (window, fgeom, windows, x, y, &x, &y);
+    find_next_cascade (window, borders, windows, x, y, &x, &y);
 
  done_check_denied_focus:
   /* If the window is being denied focus and isn't a transient of the
@@ -973,7 +973,7 @@ meta_window_place (MetaWindow        *window,
           x = xi->rect.x;
           y = xi->rect.y;
 
-          found_fit = find_first_fit (window, fgeom, focus_window_list,
+          found_fit = find_first_fit (window, borders, focus_window_list,
                                       xi->number,
                                       x, y, &x, &y);
           g_list_free (focus_window_list);
@@ -983,7 +983,7 @@ meta_window_place (MetaWindow        *window,
        * as possible.
        */
       if (!found_fit)
-        find_most_freespace (window, fgeom, focus_window, x, y, &x, &y);
+        find_most_freespace (window, borders, focus_window, x, y, &x, &y);
     }
 
  done:

--- a/src/core/place.h
+++ b/src/core/place.h
@@ -27,11 +27,11 @@
 #include "window-private.h"
 #include "frame-private.h"
 
-void meta_window_place (MetaWindow *window,
-                        MetaFrameGeometry *fgeom,
-                        int         x,
-                        int         y,
-                        int        *new_x,
-                        int        *new_y);
+void meta_window_place (MetaWindow       *window,
+                        MetaFrameBorders *borders,
+                        int               x,
+                        int               y,
+                        int              *new_x,
+                        int              *new_y);
 
 #endif

--- a/src/core/prefs.c
+++ b/src/core/prefs.c
@@ -27,7 +27,6 @@
 #include "prefs.h"
 #include "ui.h"
 #include "util.h"
-#include <gdk/gdk.h>
 #include <gio/gio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -1113,16 +1112,13 @@ meta_prefs_get_cursor_theme (void)
 int
 meta_prefs_get_cursor_size (void)
 {
-  GdkWindow *window = gdk_get_default_root_window ();
-  gint scale = gdk_window_get_scale_factor (window);
-
-  return cursor_size * scale;
+  return cursor_size * get_window_scaling_factor ();
 }
 
 int
 meta_prefs_get_icon_size (void)
 {
-  return icon_size;
+  return icon_size * get_window_scaling_factor ();
 }
 
 gboolean

--- a/src/core/window-private.h
+++ b/src/core/window-private.h
@@ -41,6 +41,7 @@
 #include "stack.h"
 #include "iconcache.h"
 #include <X11/Xutil.h>
+#include <cairo.h>
 #include <gdk-pixbuf/gdk-pixbuf.h>
 #include <gtk/gtk.h>
 
@@ -322,6 +323,9 @@ struct _MetaWindow
 
   /* if TRUE, application is buggy and SYNC resizing is turned off */
   guint disable_sync : 1;
+
+  /* if non-NULL, the bounds of the window frame */
+  cairo_region_t *frame_bounds;
 
   /* Note: can be NULL */
   GSList *struts;

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -4604,14 +4604,17 @@ update_net_frame_extents (MetaWindow *window)
 
   if (window->frame)
     {
+      MetaFrameBorders borders;
+
+      meta_frame_calc_borders (window->frame, &borders);
       /* Left */
-      data[0] = window->frame->child_x;
+      data[0] = borders.visible.left;
       /* Right */
-      data[1] = window->frame->right_width;
+      data[1] = borders.visible.right;
       /* Top */
-      data[2] = window->frame->child_y;
+      data[2] = borders.visible.top;
       /* Bottom */
-      data[3] = window->frame->bottom_height;
+      data[3] = borders.visible.bottom;
     }
 
   meta_topic (META_DEBUG_GEOMETRY,

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -3263,10 +3263,10 @@ adjust_for_gravity (MetaWindow       *window,
 
   if (borders)
     {
-      child_x = borders->visible.left;
-      child_y = borders->visible.top;
-      frame_width = child_x + rect->width + borders->visible.right;
-      frame_height = child_y + rect->height + borders->visible.bottom;
+      child_x = borders->total.left;
+      child_y = borders->total.top;
+      frame_width = child_x + rect->width + borders->total.right;
+      frame_height = child_y + rect->height + borders->total.bottom;
     }
   else
     {
@@ -3585,12 +3585,12 @@ meta_window_move_resize_internal (MetaWindow          *window,
     {
       int frame_size_dx, frame_size_dy, new_w, new_h;
 
-      new_w = window->rect.width + borders.visible.left + borders.visible.right;
+      new_w = window->rect.width + borders.total.left + borders.total.right;
 
       if (window->shaded)
-        new_h = borders.visible.top;
+        new_h = borders.total.top;
       else
-        new_h = window->rect.height + borders.visible.top + borders.visible.bottom;
+        new_h = window->rect.height + borders.total.top + borders.total.bottom;
 
       frame_size_dx = new_w - window->frame->rect.width;
       frame_size_dy = new_h - window->frame->rect.height;
@@ -3627,8 +3627,8 @@ meta_window_move_resize_internal (MetaWindow          *window,
       int frame_pos_dx, frame_pos_dy;
 
       /* Compute new frame coords */
-      new_x = root_x_nw - borders.visible.left;
-      new_y = root_y_nw - borders.visible.top;
+      new_x = root_x_nw - borders.total.left;
+      new_y = root_y_nw - borders.total.top;
 
       frame_pos_dx = new_x - window->frame->rect.x;
       frame_pos_dy = new_y - window->frame->rect.y;
@@ -3651,8 +3651,8 @@ meta_window_move_resize_internal (MetaWindow          *window,
        * remember they are the server coords
        */
 
-      new_x = borders.visible.left;
-      new_y = borders.visible.top;
+      new_x = borders.total.left;
+      new_y = borders.total.top;
 
       if (need_resize_frame && need_move_frame &&
           static_gravity_works (window->display))
@@ -3723,15 +3723,15 @@ meta_window_move_resize_internal (MetaWindow          *window,
   /* If frame extents have changed, fill in other frame fields and
      change frame's extents property. */
   if (have_window_frame &&
-      (window->frame->child_x != borders.visible.left ||
-       window->frame->child_y != borders.visible.top ||
-       window->frame->right_width != borders.visible.right ||
-       window->frame->bottom_height != borders.visible.bottom))
+      (window->frame->child_x != borders.total.left ||
+       window->frame->child_y != borders.total.top ||
+       window->frame->right_width != borders.total.right ||
+       window->frame->bottom_height != borders.total.bottom))
     {
-      window->frame->child_x = borders.visible.left;
-      window->frame->child_y = borders.visible.top;
-      window->frame->right_width = borders.visible.right;
-      window->frame->bottom_height = borders.visible.bottom;
+      window->frame->child_x = borders.total.left;
+      window->frame->child_y = borders.total.top;
+      window->frame->right_width = borders.total.right;
+      window->frame->bottom_height = borders.total.bottom;
 
       update_net_frame_extents (window);
     }

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -3263,10 +3263,10 @@ adjust_for_gravity (MetaWindow       *window,
 
   if (borders)
     {
-      child_x = borders->total.left;
-      child_y = borders->total.top;
-      frame_width = child_x + rect->width + borders->total.right;
-      frame_height = child_y + rect->height + borders->total.bottom;
+      child_x = borders->visible.left;
+      child_y = borders->visible.top;
+      frame_width = child_x + rect->width + borders->visible.right;
+      frame_height = child_y + rect->height + borders->visible.bottom;
     }
   else
     {

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -8143,11 +8143,8 @@ meta_window_refresh_resize_popup (MetaWindow *window)
 
   if (window->display->grab_resize_popup == NULL)
     {
-      gint scale = gdk_window_get_scale_factor (gdk_get_default_root_window ());
-      /* Display the resize popup only for windows that report an
-       * increment hint that's larger than the scale factor. */
-      if (window->size_hints.width_inc > scale ||
-          window->size_hints.height_inc > scale)
+      if (window->size_hints.width_inc ||
+          window->size_hints.height_inc)
         window->display->grab_resize_popup =
           meta_ui_resize_popup_new (window->display->xdisplay,
                                     window->screen->number);

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -522,6 +522,7 @@ meta_window_new_with_attrs (MetaDisplay       *display,
   window->shaken_loose = FALSE;
   window->have_focus_click_grab = FALSE;
   window->disable_sync = FALSE;
+  window->frame_bounds = NULL;
 
   window->unmaps_pending = 0;
 
@@ -1217,6 +1218,9 @@ meta_window_free (MetaWindow  *window,
 
   if (window->mini_icon)
     g_object_unref (G_OBJECT (window->mini_icon));
+
+  if (window->frame_bounds)
+    cairo_region_destroy (window->frame_bounds);
 
   meta_icon_cache_free (&window->icon_cache);
 
@@ -3477,6 +3481,7 @@ meta_window_move_resize_internal (MetaWindow          *window,
   gboolean need_resize_frame = FALSE;
   int size_dx;
   int size_dy;
+  gboolean frame_shape_changed = FALSE;
   gboolean is_configure_request;
   gboolean do_gravity_adjust;
   gboolean is_user_action;
@@ -3778,9 +3783,10 @@ meta_window_move_resize_internal (MetaWindow          *window,
     meta_window_set_gravity (window, StaticGravity);
 
   if (configure_frame_first && have_window_frame)
-    meta_frame_sync_to_window (window->frame,
-                               gravity,
-                               need_move_frame, need_resize_frame);
+    frame_shape_changed = meta_frame_sync_to_window (window->frame,
+                                                     gravity,
+                                                     need_move_frame,
+                                                     need_resize_frame);
 
   values.border_width = 0;
   values.x = client_move_x;
@@ -3835,9 +3841,10 @@ meta_window_move_resize_internal (MetaWindow          *window,
     }
 
   if (!configure_frame_first && have_window_frame)
-    meta_frame_sync_to_window (window->frame,
-                               gravity,
-                               need_move_frame, need_resize_frame);
+    frame_shape_changed = meta_frame_sync_to_window (window->frame,
+                                                     gravity,
+                                                     need_move_frame,
+                                                     need_resize_frame);
 
   /* Put gravity back to be nice to lesser window managers */
   if (use_static_gravity)
@@ -3877,6 +3884,12 @@ meta_window_move_resize_internal (MetaWindow          *window,
    *      server-side size/pos of window->xwindow and frame->xwindow
    *   b) all constraints are obeyed by window->rect and frame->rect
    */
+
+  if (frame_shape_changed && window->frame_bounds)
+    {
+      cairo_region_destroy (window->frame_bounds);
+      window->frame_bounds = NULL;
+    }
 
   if (meta_prefs_get_attach_modal_dialogs ())
     meta_window_foreach_transient (window, move_attached_dialog, NULL);
@@ -8755,4 +8768,25 @@ meta_window_is_client_decorated (MetaWindow *window)
    * the window is maxized and has no invisible borders or shadows.
    */
   return window->has_custom_frame_extents;
+}
+
+/**
+ * meta_window_get_frame_bounds:
+ *
+ * Gets a region representing the outer bounds of the window's frame.
+ *
+ * Return value: (transfer none) (allow-none): a #cairo_region_t
+ * holding the outer bounds of the window, or %NULL if the window
+ * doesn't have a frame.
+ */
+cairo_region_t *
+meta_window_get_frame_bounds (MetaWindow *window)
+{
+  if (!window->frame_bounds)
+    {
+      if (window->frame)
+        window->frame_bounds = meta_frame_get_frame_bounds (window->frame);
+    }
+
+  return window->frame_bounds;
 }

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -2771,12 +2771,12 @@ meta_window_can_tile (MetaWindow *window)
 
   if (window->frame)
     {
-      MetaFrameGeometry fgeom;
+      MetaFrameBorders borders;
 
-      meta_frame_calc_geometry (window->frame, &fgeom);
+      meta_frame_calc_borders (window->frame, &borders);
 
-      tile_area.width  -= (fgeom.left_width + fgeom.right_width);
-      tile_area.height -= (fgeom.top_height + fgeom.bottom_height);
+      tile_area.width  -= (borders.visible.left + borders.visible.right);
+      tile_area.height -= (borders.visible.top + borders.visible.bottom);
     }
 
   return tile_area.width >= window->size_hints.min_width &&
@@ -3241,11 +3241,11 @@ meta_window_activate_with_workspace (MetaWindow     *window,
  * internal or client window).
  */
 static void
-adjust_for_gravity (MetaWindow        *window,
-                    MetaFrameGeometry *fgeom,
-                    gboolean           coords_assume_border,
-                    int                gravity,
-                    MetaRectangle     *rect)
+adjust_for_gravity (MetaWindow       *window,
+                    MetaFrameBorders *borders,
+                    gboolean          coords_assume_border,
+                    int               gravity,
+                    MetaRectangle    *rect)
 {
   int ref_x, ref_y;
   int bw;
@@ -3257,12 +3257,12 @@ adjust_for_gravity (MetaWindow        *window,
   else
     bw = 0;
 
-  if (fgeom)
+  if (borders)
     {
-      child_x = fgeom->left_width;
-      child_y = fgeom->top_height;
-      frame_width = child_x + rect->width + fgeom->right_width;
-      frame_height = child_y + rect->height + fgeom->bottom_height;
+      child_x = borders->visible.left;
+      child_y = borders->visible.top;
+      frame_width = child_x + rect->width + borders->visible.right;
+      frame_height = child_y + rect->height + borders->visible.bottom;
     }
   else
     {
@@ -3470,7 +3470,7 @@ meta_window_move_resize_internal (MetaWindow          *window,
   XWindowChanges values;
   unsigned int mask;
   gboolean need_configure_notify;
-  MetaFrameGeometry fgeom;
+  MetaFrameBorders borders;
   gboolean need_move_client = FALSE;
   gboolean need_move_frame = FALSE;
   gboolean need_resize_client = FALSE;
@@ -3516,8 +3516,7 @@ meta_window_move_resize_internal (MetaWindow          *window,
               old_rect.x, old_rect.y, old_rect.width, old_rect.height);
 
   if (have_window_frame)
-    meta_frame_calc_geometry (window->frame,
-                              &fgeom);
+    meta_frame_calc_borders (window->frame, &borders);
 
   new_rect.x = root_x_nw;
   new_rect.y = root_y_nw;
@@ -3544,7 +3543,7 @@ meta_window_move_resize_internal (MetaWindow          *window,
   else if (is_configure_request || do_gravity_adjust)
     {
       adjust_for_gravity (window,
-                          have_window_frame ? &fgeom : NULL,
+                          have_window_frame ? &borders : NULL,
                           /* configure request coords assume
                            * the border width existed
                            */
@@ -3559,7 +3558,7 @@ meta_window_move_resize_internal (MetaWindow          *window,
     }
 
   meta_window_constrain (window,
-                         have_window_frame ? &fgeom : NULL,
+                         have_window_frame ? &borders : NULL,
                          flags,
                          gravity,
                          &old_rect,
@@ -3581,12 +3580,12 @@ meta_window_move_resize_internal (MetaWindow          *window,
     {
       int frame_size_dx, frame_size_dy, new_w, new_h;
 
-      new_w = window->rect.width + fgeom.left_width + fgeom.right_width;
+      new_w = window->rect.width + borders.visible.left + borders.visible.right;
 
       if (window->shaded)
-        new_h = fgeom.top_height;
+        new_h = borders.visible.top;
       else
-        new_h = window->rect.height + fgeom.top_height + fgeom.bottom_height;
+        new_h = window->rect.height + borders.visible.top + borders.visible.bottom;
 
       frame_size_dx = new_w - window->frame->rect.width;
       frame_size_dy = new_h - window->frame->rect.height;
@@ -3623,8 +3622,8 @@ meta_window_move_resize_internal (MetaWindow          *window,
       int frame_pos_dx, frame_pos_dy;
 
       /* Compute new frame coords */
-      new_x = root_x_nw - fgeom.left_width;
-      new_y = root_y_nw - fgeom.top_height;
+      new_x = root_x_nw - borders.visible.left;
+      new_y = root_y_nw - borders.visible.top;
 
       frame_pos_dx = new_x - window->frame->rect.x;
       frame_pos_dy = new_y - window->frame->rect.y;
@@ -3647,8 +3646,8 @@ meta_window_move_resize_internal (MetaWindow          *window,
        * remember they are the server coords
        */
 
-      new_x = fgeom.left_width;
-      new_y = fgeom.top_height;
+      new_x = borders.visible.left;
+      new_y = borders.visible.top;
 
       if (need_resize_frame && need_move_frame &&
           static_gravity_works (window->display))
@@ -3719,15 +3718,15 @@ meta_window_move_resize_internal (MetaWindow          *window,
   /* If frame extents have changed, fill in other frame fields and
      change frame's extents property. */
   if (have_window_frame &&
-      (window->frame->child_x != fgeom.left_width ||
-       window->frame->child_y != fgeom.top_height ||
-       window->frame->right_width != fgeom.right_width ||
-       window->frame->bottom_height != fgeom.bottom_height))
+      (window->frame->child_x != borders.visible.left ||
+       window->frame->child_y != borders.visible.top ||
+       window->frame->right_width != borders.visible.right ||
+       window->frame->bottom_height != borders.visible.bottom))
     {
-      window->frame->child_x = fgeom.left_width;
-      window->frame->child_y = fgeom.top_height;
-      window->frame->right_width = fgeom.right_width;
-      window->frame->bottom_height = fgeom.bottom_height;
+      window->frame->child_x = borders.visible.left;
+      window->frame->child_y = borders.visible.top;
+      window->frame->right_width = borders.visible.right;
+      window->frame->bottom_height = borders.visible.bottom;
 
       update_net_frame_extents (window);
     }

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -5789,11 +5789,15 @@ send_configure_notify (MetaWindow *window)
     {
       if (window->withdrawn)
         {
-          /* WARNING: x & y need to be set to whatever the XReparentWindow
-           * call in meta_window_destroy_frame will use so that the window
-           * has the right coordinates.  Currently, that means no change to
-           * x & y.
+          MetaFrameBorders borders;
+          /* We reparent the client window and put it to the position
+           * where the visible top-left of the frame window currently is.
            */
+
+          meta_frame_calc_borders (window->frame, &borders);
+
+          event.xconfigure.x = window->frame->rect.x + borders.invisible.left;
+          event.xconfigure.y = window->frame->rect.y + borders.invisible.top;
         }
       else
         {

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -308,6 +308,11 @@ struct _MetaFrameBorders
    * and an outer portion that is invisible but responds to events.
    */
   GtkBorder visible;
+  GtkBorder invisible;
+
+  /* For convenience, we have a "total" border which is equal to the sum
+   * of the two borders above. */
+  GtkBorder total;
 };
 
 /* sets all dimensions to zero */

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -310,6 +310,9 @@ struct _MetaFrameBorders
   GtkBorder visible;
 };
 
+/* sets all dimensions to zero */
+void meta_frame_borders_clear (MetaFrameBorders *self);
+
 /* should investigate changing these to whatever most apps use */
 #define META_DEFAULT_ICON_SIZE 48
 #define META_MIN_ICON_SIZE 6

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -25,9 +25,10 @@
 #ifndef META_COMMON_H
 #define META_COMMON_H
 
-/* Don't include GTK or core headers here */
+/* Don't include core headers here */
 #include <X11/Xlib.h>
 #include <glib.h>
+#include <gtk/gtk.h>
 
 typedef struct _MetaResizePopup MetaResizePopup;
 
@@ -298,6 +299,15 @@ struct _MetaButtonLayout
   /* buttons in the group on the right side */
   MetaButtonFunction right_buttons[MAX_BUTTONS_PER_CORNER];
   gboolean right_buttons_has_spacer[MAX_BUTTONS_PER_CORNER];
+};
+
+typedef struct _MetaFrameBorders MetaFrameBorders;
+struct _MetaFrameBorders
+{
+  /* The frame border is made up of two pieces - an inner visible portion
+   * and an outer portion that is invisible but responds to events.
+   */
+  GtkBorder visible;
 };
 
 /* should investigate changing these to whatever most apps use */

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -347,4 +347,7 @@ typedef enum
   META_PLACEMENT_MODE_MANUAL
 } MetaPlacementMode;
 
+G_GNUC_INTERNAL
+int get_window_scaling_factor (void);
+
 #endif

--- a/src/include/frame.h
+++ b/src/include/frame.h
@@ -24,8 +24,13 @@
 
 #include <X11/Xlib.h>
 
+#include "common.h"
 #include "types.h"
 
 Window meta_frame_get_xwindow (MetaFrame *frame);
+
+void   meta_frame_calc_borders (MetaFrame        *frame,
+                                MetaFrameBorders *borders);
+
 
 #endif

--- a/src/include/ui.h
+++ b/src/include/ui.h
@@ -62,17 +62,13 @@ MetaUI* meta_ui_new (Display *xdisplay,
                      Screen  *screen);
 void    meta_ui_free (MetaUI *ui);
 
-void meta_ui_theme_get_frame_borders (MetaUI *ui,
-                                      MetaFrameType      type,
-                                      MetaFrameFlags     flags,
-                                      int               *top_height,
-                                      int               *bottom_height,
-                                      int               *left_width,
-                                      int               *right_width);
-void meta_ui_get_frame_geometry (MetaUI *ui,
-                                 Window frame_xwindow,
-                                 int *top_height, int *bottom_height,
-                                 int *left_width, int *right_width);
+void meta_ui_theme_get_frame_borders (MetaUI           *ui,
+                                      MetaFrameType     type,
+                                      MetaFrameFlags    flags,
+                                      MetaFrameBorders *borders);
+void meta_ui_get_frame_borders (MetaUI           *ui,
+                                Window            frame_xwindow,
+                                MetaFrameBorders *borders);
 Window meta_ui_create_frame_window (MetaUI *ui,
                                     Display *xdisplay,
                                     Visual *xvisual,

--- a/src/include/ui.h
+++ b/src/include/ui.h
@@ -69,6 +69,13 @@ void meta_ui_theme_get_frame_borders (MetaUI           *ui,
 void meta_ui_get_frame_borders (MetaUI           *ui,
                                 Window            frame_xwindow,
                                 MetaFrameBorders *borders);
+
+void meta_ui_get_frame_mask (MetaUI  *ui,
+                             Window   frame_xwindow,
+                             guint    width,
+                             guint    height,
+                             cairo_t *cr);
+
 Window meta_ui_create_frame_window (MetaUI *ui,
                                     Display *xdisplay,
                                     Visual *xvisual,

--- a/src/include/ui.h
+++ b/src/include/ui.h
@@ -28,9 +28,9 @@
 #include "common.h"
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
+#include <cairo.h>
 #include <glib.h>
 #include <gdk-pixbuf/gdk-pixbuf.h>
-#include <cairo/cairo.h>
 
 /* This is between GTK_PRIORITY_RESIZE (+10) and GDK_PRIORITY_REDRAW (+20) */
 #define META_PRIORITY_RESIZE    (G_PRIORITY_HIGH_IDLE + 15)
@@ -96,6 +96,11 @@ void meta_ui_apply_frame_shape  (MetaUI  *ui,
                                  int      new_window_width,
                                  int      new_window_height,
                                  gboolean window_has_shape);
+
+cairo_region_t *meta_ui_get_frame_bounds (MetaUI *ui,
+                                          Window  xwindow,
+                                          int     window_width,
+                                          int     window_height);
 
 void meta_ui_queue_frame_draw (MetaUI *ui,
                                Window xwindow);

--- a/src/include/window.h
+++ b/src/include/window.h
@@ -23,6 +23,7 @@
 #define META_WINDOW_H
 
 #include <glib.h>
+#include <cairo.h>
 #include <X11/Xlib.h>
 
 #include "boxes.h"
@@ -37,5 +38,7 @@ MetaDisplay *meta_window_get_display (MetaWindow *window);
 Window meta_window_get_xwindow (MetaWindow *window);
 MetaWindow *meta_window_get_transient_for (MetaWindow *window);
 gboolean meta_window_is_maximized (MetaWindow *window);
+
+cairo_region_t *meta_window_get_frame_bounds (MetaWindow *window);
 
 #endif

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -866,7 +866,7 @@ get_visible_region (MetaFrames        *frames,
       for (i=0; i<corner; i++)
         {
           const int width = floor(0.5 + radius - sqrt(radius*radius - (radius-(i+0.5))*(radius-(i+0.5))));
-          rect.x = frame_rect.x + frame_rect.width + width;
+          rect.x = frame_rect.x + frame_rect.width - width;
           rect.y = frame_rect.y + frame_rect.height - i - 1;
           rect.width = width;
           rect.height = 1;

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -2805,7 +2805,10 @@ get_control (MetaFrames *frames,
         return META_FRAME_CONTROL_RESIZE_E;
     }
 
-  return META_FRAME_CONTROL_NONE;
+  if (y >= fgeom.borders.total.top)
+    return META_FRAME_CONTROL_NONE;
+  else
+    return META_FRAME_CONTROL_TITLE;
 }
 
 void

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -2301,6 +2301,23 @@ cached_pixels_draw (CachedPixels   *pixels,
     }
 }
 
+void
+meta_frames_get_mask (MetaFrames *frames,
+                      Window      xwindow,
+                      guint       width,
+                      guint       height,
+                      cairo_t    *cr)
+{
+  MetaUIFrame *frame;
+
+  frame = meta_frames_lookup_window (frames, xwindow);
+
+  if (frame == NULL)
+    return;
+
+  meta_frames_paint_to_drawable (frames, frame, cr);
+}
+
 static void
 subtract_client_area (cairo_region_t *region, MetaUIFrame *frame)
 {

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -715,6 +715,11 @@ meta_frames_get_borders (MetaFrames       *frames,
   borders->visible.bottom *= scale;
   borders->visible.left *= scale;
   borders->visible.right *= scale;
+
+  borders->total.top *= scale;
+  borders->total.bottom *= scale;
+  borders->total.left *= scale;
+  borders->total.right *= scale;
 }
 
 #ifdef HAVE_SHAPE

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -2206,28 +2206,28 @@ populate_cache (MetaFrames *frames,
    * size without any border added. */
 
   /* top */
-  pixels->piece[0].rect.x = 0;
-  pixels->piece[0].rect.y = 0;
-  pixels->piece[0].rect.width = (width + borders.total.left + borders.total.right) * scale;
-  pixels->piece[0].rect.height = borders.total.top * scale;
+  pixels->piece[0].rect.x = borders.invisible.left / scale;
+  pixels->piece[0].rect.y = borders.invisible.top / scale;
+  pixels->piece[0].rect.width = (width + borders.visible.left + borders.visible.right) * scale;
+  pixels->piece[0].rect.height = borders.visible.top * scale;
 
   /* left */
-  pixels->piece[1].rect.x = 0;
+  pixels->piece[1].rect.x = borders.invisible.left / scale;
   pixels->piece[1].rect.y = borders.total.top / scale;
-  pixels->piece[1].rect.width = borders.total.left * scale;
+  pixels->piece[1].rect.width = borders.visible.left * scale;
   pixels->piece[1].rect.height = height * scale;
 
   /* right */
   pixels->piece[2].rect.x = (borders.total.left + width) / scale;
   pixels->piece[2].rect.y = borders.total.top / scale;
-  pixels->piece[2].rect.width = borders.total.right * scale;
+  pixels->piece[2].rect.width = borders.visible.right * scale;
   pixels->piece[2].rect.height = height * scale;
 
   /* bottom */
-  pixels->piece[3].rect.x = 0;
+  pixels->piece[3].rect.x = borders.invisible.left / scale;
   pixels->piece[3].rect.y = (borders.total.top + height) / scale;
-  pixels->piece[3].rect.width = (width + borders.total.left + borders.total.right) * scale;
-  pixels->piece[3].rect.height = borders.total.bottom * scale;
+  pixels->piece[3].rect.width = (width + borders.visible.left + borders.visible.right) * scale;
+  pixels->piece[3].rect.height = borders.visible.bottom * scale;
 
   for (i = 0; i < 4; i++)
     {

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -2140,7 +2140,7 @@ generate_pixmap (MetaFrames            *frames,
     return NULL;
 
   result = gdk_window_create_similar_surface (frame->window,
-                                              CAIRO_CONTENT_COLOR,
+                                              CAIRO_CONTENT_COLOR_ALPHA,
                                               rect->width, rect->height);
 
   cr = cairo_create (result);
@@ -2208,28 +2208,28 @@ populate_cache (MetaFrames *frames,
    * size without any border added. */
 
   /* top */
-  pixels->piece[0].rect.x = borders.invisible.left / scale;
-  pixels->piece[0].rect.y = borders.invisible.top / scale;
-  pixels->piece[0].rect.width = (width + borders.visible.left + borders.visible.right) * scale;
-  pixels->piece[0].rect.height = borders.visible.top * scale;
+  pixels->piece[0].rect.x = 0;
+  pixels->piece[0].rect.y = 0;
+  pixels->piece[0].rect.width = (width + borders.total.left + borders.total.right) * scale;
+  pixels->piece[0].rect.height = borders.total.top * scale;
 
   /* left */
-  pixels->piece[1].rect.x = borders.invisible.left / scale;
+  pixels->piece[1].rect.x = 0;
   pixels->piece[1].rect.y = borders.total.top / scale;
-  pixels->piece[1].rect.width = borders.visible.left * scale;
+  pixels->piece[1].rect.width = borders.total.left * scale;
   pixels->piece[1].rect.height = height * scale;
 
   /* right */
   pixels->piece[2].rect.x = (borders.total.left + width) / scale;
   pixels->piece[2].rect.y = borders.total.top / scale;
-  pixels->piece[2].rect.width = borders.visible.right * scale;
+  pixels->piece[2].rect.width = borders.total.right * scale;
   pixels->piece[2].rect.height = height * scale;
 
   /* bottom */
-  pixels->piece[3].rect.x = borders.invisible.left / scale;
+  pixels->piece[3].rect.x = 0;
   pixels->piece[3].rect.y = (borders.total.top + height) / scale;
-  pixels->piece[3].rect.width = (width + borders.visible.left + borders.visible.right) * scale;
-  pixels->piece[3].rect.height = borders.visible.bottom * scale;
+  pixels->piece[3].rect.width = (width + borders.total.left + borders.total.right) * scale;
+  pixels->piece[3].rect.height = borders.total.bottom * scale;
 
   for (i = 0; i < 4; i++)
     {

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -668,10 +668,9 @@ meta_frames_lookup_window (MetaFrames *frames,
 }
 
 void
-meta_frames_get_geometry (MetaFrames *frames,
-                          Window xwindow,
-                          int *top_height, int *bottom_height,
-                          int *left_width, int *right_width)
+meta_frames_get_borders (MetaFrames       *frames,
+                         Window            xwindow,
+                         MetaFrameBorders *borders)
 {
   MetaFrameFlags flags;
   MetaUIFrame *frame;
@@ -702,14 +701,13 @@ meta_frames_get_geometry (MetaFrames *frames,
                                 type,
                                 frame->text_height,
                                 flags,
-                                top_height, bottom_height,
-                                left_width, right_width);
+                                borders);
 
   /* Scale frame geometry to ensure proper frame position */
-  *top_height *= scale;
-  *bottom_height *= scale;
-  *left_width *= scale;
-  *right_width *= scale;
+  borders->visible.top *= scale;
+  borders->visible.bottom *= scale;
+  borders->visible.left *= scale;
+  borders->visible.right *= scale;
 }
 
 #ifdef HAVE_SHAPE
@@ -2060,6 +2058,7 @@ populate_cache (MetaFrames *frames,
                 MetaUIFrame *frame)
 {
   int top, bottom, left, right;
+  MetaFrameBorders borders;
   int width, height;
   int frame_width, frame_height, screen_width, screen_height;
   gint scale;
@@ -2090,7 +2089,12 @@ populate_cache (MetaFrames *frames,
                                 frame_type,
                                 frame->text_height,
                                 frame_flags,
-                                &top, &bottom, &left, &right);
+                                &borders);
+
+  top = borders.visible.top;
+  left = borders.visible.left;
+  right = borders.visible.right;
+  bottom = borders.visible.bottom;
 
   pixels = get_cache (frames, frame);
   scale = gdk_window_get_scale_factor (frame->window);
@@ -2195,6 +2199,7 @@ subtract_client_area (cairo_region_t *region, MetaUIFrame *frame)
   GdkRectangle area;
   MetaFrameFlags flags;
   MetaFrameType type;
+  MetaFrameBorders borders;
   cairo_region_t *tmp_region;
   Display *display;
   gint scale;
@@ -2210,13 +2215,13 @@ subtract_client_area (cairo_region_t *region, MetaUIFrame *frame)
                  META_CORE_GET_END);
 
   meta_theme_get_frame_borders (meta_theme_get_current (),
-                         type, frame->text_height, flags,
-                         &area.x, NULL, &area.y, NULL);
+                                type, frame->text_height, flags,
+                                &borders);
 
   area.width /= scale;
   area.height /= scale;
-  area.x /= scale;
-  area.y /= scale;
+  area.x = borders.visible.left / scale;
+  area.y = borders.visible.top / scale;
 
   tmp_region = cairo_region_create_rectangle (&area);
   cairo_region_subtract (region, tmp_region);

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -797,15 +797,13 @@ get_visible_region (MetaFrames        *frames,
   cairo_region_t *visible_region;
   cairo_rectangle_int_t rect;
   cairo_rectangle_int_t frame_rect;
-  gint scale;
 
   corners_region = cairo_region_create ();
   get_visible_frame_rect (fgeom, window_width, window_height, &frame_rect);
-  scale = gdk_window_get_scale_factor (frame->window);
 
   if (fgeom->top_left_corner_rounded_radius != 0)
     {
-      const int corner = fgeom->top_left_corner_rounded_radius * scale;
+      const int corner = fgeom->top_left_corner_rounded_radius;
       const float radius = sqrt(corner) + corner;
       int i;
 
@@ -823,7 +821,7 @@ get_visible_region (MetaFrames        *frames,
 
   if (fgeom->top_right_corner_rounded_radius != 0)
     {
-      const int corner = fgeom->top_right_corner_rounded_radius * scale;
+      const int corner = fgeom->top_right_corner_rounded_radius;
       const float radius = sqrt(corner) + corner;
       int i;
 
@@ -841,7 +839,7 @@ get_visible_region (MetaFrames        *frames,
 
   if (fgeom->bottom_left_corner_rounded_radius != 0)
     {
-      const int corner = fgeom->bottom_left_corner_rounded_radius * scale;
+      const int corner = fgeom->bottom_left_corner_rounded_radius;
       const float radius = sqrt(corner) + corner;
       int i;
 
@@ -859,7 +857,7 @@ get_visible_region (MetaFrames        *frames,
 
   if (fgeom->bottom_right_corner_rounded_radius != 0)
     {
-      const int corner = fgeom->bottom_right_corner_rounded_radius * scale;
+      const int corner = fgeom->bottom_right_corner_rounded_radius;
       const float radius = sqrt(corner) + corner;
       int i;
 
@@ -2359,6 +2357,7 @@ meta_frames_draw (GtkWidget *widget,
 {
   MetaUIFrame *frame;
   MetaFrames *frames;
+  MetaFrameGeometry fgeom;
   CachedPixels *pixels;
   cairo_region_t *region;
   cairo_rectangle_int_t clip;
@@ -2381,7 +2380,12 @@ meta_frames_draw (GtkWidget *widget,
 
   populate_cache (frames, frame);
 
-  region = cairo_region_create_rectangle (&clip);
+  meta_frames_calc_geometry (frames, frame, &fgeom);
+
+  region = get_visible_region (frames, frame, &fgeom, fgeom.width, fgeom.height);
+
+  gdk_cairo_region (cr, region);
+  cairo_clip(cr);
 
   pixels = get_cache (frames, frame);
 

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -183,6 +183,8 @@ prefs_changed_callback (MetaPreference pref,
 static void
 meta_frames_init (MetaFrames *frames)
 {
+  GtkWidgetPath *path;
+
   frames->text_heights = g_hash_table_new (NULL, NULL);
 
   frames->frames = g_hash_table_new (unsigned_long_hash, unsigned_long_equal);
@@ -194,6 +196,11 @@ meta_frames_init (MetaFrames *frames)
   frames->invalidate_cache_timeout_id = 0;
   frames->invalidate_frames = NULL;
   frames->cache = g_hash_table_new (g_direct_hash, g_direct_equal);
+
+  path = gtk_widget_path_new ();
+  gtk_widget_path_append_type (path, META_TYPE_FRAMES);
+  gtk_widget_path_iter_add_class (path, -1, GTK_STYLE_CLASS_BACKGROUND);
+  gtk_widget_path_unref (path);
 
   meta_prefs_add_listener (prefs_changed_callback, frames);
 }

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -750,19 +750,52 @@ apply_cairo_region_to_window (Display        *display,
 }
 #endif
 
+/* The client rectangle surrounds client window; it subtracts both
+ * the visible and invisible borders from the frame window's size.
+ */
+static void
+get_client_rect (MetaFrameGeometry     *fgeom,
+                 int                    window_width,
+                 int                    window_height,
+                 cairo_rectangle_int_t *rect)
+{
+  rect->x = fgeom->borders.total.left;
+  rect->y = fgeom->borders.total.top;
+  rect->width = window_width - fgeom->borders.total.right - rect->x;
+  rect->height = window_height - fgeom->borders.total.bottom - rect->y;
+}
+
+/* The visible frame rectangle surrounds the visible portion of the
+ * frame window; it subtracts only the invisible borders from the frame
+ * window's size.
+ */
+static void
+get_visible_frame_rect (MetaFrameGeometry     *fgeom,
+                        int                    window_width,
+                        int                    window_height,
+                        cairo_rectangle_int_t *rect)
+{
+  rect->x = fgeom->borders.invisible.left;
+  rect->y = fgeom->borders.invisible.top;
+  rect->width = window_width - fgeom->borders.invisible.right - rect->x;
+  rect->height = window_height - fgeom->borders.invisible.bottom - rect->y;
+}
+
 static cairo_region_t *
-get_bounds_region (MetaFrames        *frames,
-                   MetaUIFrame       *frame,
-                   MetaFrameGeometry *fgeom,
-                   int                window_width,
-                   int                window_height)
+get_visible_region (MetaFrames        *frames,
+                    MetaUIFrame       *frame,
+                    MetaFrameGeometry *fgeom,
+                    int                window_width,
+                    int                window_height)
 {
   cairo_region_t *corners_region;
-  cairo_region_t *bounds_region;
+  cairo_region_t *visible_region;
   cairo_rectangle_int_t rect;
+  cairo_rectangle_int_t frame_rect;
   gint scale;
 
   corners_region = cairo_region_create ();
+  get_visible_frame_rect (fgeom, window_width, window_height, &frame_rect);
   scale = gdk_window_get_scale_factor (frame->window);
 
   if (fgeom->top_left_corner_rounded_radius != 0)
@@ -774,8 +807,8 @@ get_bounds_region (MetaFrames        *frames,
       for (i=0; i<corner; i++)
         {
           const int width = floor(0.5 + radius - sqrt(radius*radius - (radius-(i+0.5))*(radius-(i+0.5))));
-          rect.x = 0;
-          rect.y = i;
+          rect.x = frame_rect.x;
+          rect.y = frame_rect.y + i;
           rect.width = width;
           rect.height = 1;
 
@@ -792,8 +825,8 @@ get_bounds_region (MetaFrames        *frames,
       for (i=0; i<corner; i++)
         {
           const int width = floor(0.5 + radius - sqrt(radius*radius - (radius-(i+0.5))*(radius-(i+0.5))));
-          rect.x = window_width - width;
-          rect.y = i;
+          rect.x = frame_rect.x + frame_rect.width - width;
+          rect.y = frame_rect.y + i;
           rect.width = width;
           rect.height = 1;
 
@@ -810,8 +843,8 @@ get_bounds_region (MetaFrames        *frames,
       for (i=0; i<corner; i++)
         {
           const int width = floor(0.5 + radius - sqrt(radius*radius - (radius-(i+0.5))*(radius-(i+0.5))));
-          rect.x = 0;
-          rect.y = window_height - i - 1;
+          rect.x = frame_rect.x;
+          rect.y = frame_rect.y + frame_rect.height - i - 1;
           rect.width = width;
           rect.height = 1;
 
@@ -828,8 +861,8 @@ get_bounds_region (MetaFrames        *frames,
       for (i=0; i<corner; i++)
         {
           const int width = floor(0.5 + radius - sqrt(radius*radius - (radius-(i+0.5))*(radius-(i+0.5))));
-          rect.x = window_width - width;
-          rect.y = window_height - i - 1;
+          rect.x = frame_rect.x + frame_rect.width + width;
+          rect.y = frame_rect.y + frame_rect.height - i - 1;
           rect.width = width;
           rect.height = 1;
 
@@ -837,20 +870,11 @@ get_bounds_region (MetaFrames        *frames,
         }
     }
 
-  bounds_region = cairo_region_create ();
-
-  rect.x = 0;
-  rect.y = 0;
-  rect.width = window_width;
-  rect.height = window_height;
-
-  cairo_region_union_rectangle (bounds_region, &rect);
-
-  cairo_region_subtract (bounds_region, corners_region);
-
+  visible_region = cairo_region_create_rectangle (&frame_rect);
+  cairo_region_subtract (visible_region, corners_region);
   cairo_region_destroy (corners_region);
 
-  return bounds_region;
+  return visible_region;
 }
 
 static cairo_region_t *
@@ -860,10 +884,10 @@ get_client_region (MetaFrameGeometry *fgeom,
 {
   cairo_rectangle_int_t rect;
 
-  rect.x = fgeom->left_width;
-  rect.y = fgeom->top_height;
-  rect.width = window_width - fgeom->right_width - rect.x;
-  rect.height = window_height - fgeom->bottom_height - rect.y;
+  rect.x = fgeom->borders.total.left;
+  rect.y = fgeom->borders.total.top;
+  rect.width = window_width - fgeom->borders.total.right - rect.x;
+  rect.height = window_height - fgeom->borders.total.bottom - rect.y;
 
   return cairo_region_create_rectangle (&rect);
 }
@@ -915,11 +939,11 @@ meta_frames_apply_shapes (MetaFrames *frames,
       return; /* nothing to do */
     }
 
-  window_region = get_bounds_region (frames,
-                                     frame,
-                                     &fgeom,
-                                     new_window_width,
-                                     new_window_height);
+  window_region = get_visible_region (frames,
+                                      frame,
+                                      &fgeom,
+                                      new_window_width,
+                                      new_window_height);
 
   if (window_has_shape)
     {
@@ -963,8 +987,8 @@ meta_frames_apply_shapes (MetaFrames *frames,
                      META_CORE_GET_END);
 
       XShapeCombineShape (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()), shape_window, ShapeBounding,
-                          fgeom.left_width,
-                          fgeom.top_height,
+                          fgeom.borders.total.left,
+                          fgeom.borders.total.top,
                           client_window,
                           ShapeBounding,
                           ShapeSet);
@@ -1024,11 +1048,11 @@ meta_frames_get_frame_bounds (MetaFrames *frames,
 
   meta_frames_calc_geometry (frames, frame, &fgeom);
 
-  return get_bounds_region (frames,
-                            frame,
-                            &fgeom,
-                            window_width,
-                            window_height);
+  return get_visible_region (frames,
+                             frame,
+                             &fgeom,
+                             window_width,
+                             window_height);
 }
 
 void
@@ -2116,7 +2140,6 @@ static void
 populate_cache (MetaFrames *frames,
                 MetaUIFrame *frame)
 {
-  int top, bottom, left, right;
   MetaFrameBorders borders;
   int width, height;
   int frame_width, frame_height, screen_width, screen_height;
@@ -2150,35 +2173,43 @@ populate_cache (MetaFrames *frames,
                                 frame_flags,
                                 &borders);
 
-  top = borders.visible.top;
-  left = borders.visible.left;
-  right = borders.visible.right;
-  bottom = borders.visible.bottom;
-
   pixels = get_cache (frames, frame);
   scale = gdk_window_get_scale_factor (frame->window);
 
-  /* Setup the rectangles for the four frame borders. First top, then
-     left, right and bottom. */
-  pixels->piece[0].rect.x = 0;
-  pixels->piece[0].rect.y = 0;
-  pixels->piece[0].rect.width = (left + width + right) * scale;
-  pixels->piece[0].rect.height = top * scale;
+  /* Setup the rectangles for the four visible frame borders. First top, then
+   * left, right and bottom. Top and bottom extend to the invisible borders
+   * while left and right snugly fit in between:
+   * -----
+   * | |
+   * -----
+   */
 
-  pixels->piece[1].rect.x = 0;
-  pixels->piece[1].rect.y = top / scale;
-  pixels->piece[1].rect.width = left * scale;
+  /* width and height refer to the client window's
+   * size without any border added. */
+
+  /* top */
+  pixels->piece[0].rect.x = borders.invisible.left / scale;
+  pixels->piece[0].rect.y = borders.invisible.top / scale;
+  pixels->piece[0].rect.width = (width + borders.visible.left + borders.visible.right) * scale;
+  pixels->piece[0].rect.height = borders.visible.top * scale;
+
+  /* left */
+  pixels->piece[1].rect.x = borders.invisible.left / scale;
+  pixels->piece[1].rect.y = borders.total.top / scale;
+  pixels->piece[1].rect.width = borders.visible.left * scale;
   pixels->piece[1].rect.height = height * scale;
 
-  pixels->piece[2].rect.x = (left + width) / scale;
-  pixels->piece[2].rect.y = top / scale;
-  pixels->piece[2].rect.width = right * scale;
+  /* right */
+  pixels->piece[2].rect.x = (borders.total.left + width) / scale;
+  pixels->piece[2].rect.y = borders.total.top / scale;
+  pixels->piece[2].rect.width = borders.visible.right * scale;
   pixels->piece[2].rect.height = height * scale;
 
-  pixels->piece[3].rect.x = 0;
-  pixels->piece[3].rect.y = (top + height) / scale;
-  pixels->piece[3].rect.width = (left + width + right) * scale;
-  pixels->piece[3].rect.height = bottom * scale;
+  /* bottom */
+  pixels->piece[3].rect.x = borders.invisible.left / scale;
+  pixels->piece[3].rect.y = (borders.total.top + height) / scale;
+  pixels->piece[3].rect.width = (width + borders.visible.left + borders.visible.right) * scale;
+  pixels->piece[3].rect.height = borders.visible.bottom * scale;
 
   for (i = 0; i < 4; i++)
     {
@@ -2279,8 +2310,8 @@ subtract_client_area (cairo_region_t *region, MetaUIFrame *frame)
 
   area.width /= scale;
   area.height /= scale;
-  area.x = borders.visible.left / scale;
-  area.y = borders.visible.top / scale;
+  area.x = borders.total.left / scale;
+  area.y = borders.total.top / scale;
 
   tmp_region = cairo_region_create_rectangle (&area);
   cairo_region_subtract (region, tmp_region);
@@ -2616,7 +2647,7 @@ control_rect (MetaFrameControl control,
 }
 
 #define RESIZE_EXTENDS 15
-#define TOP_RESIZE_HEIGHT 2
+#define TOP_RESIZE_HEIGHT 4
 static MetaFrameControl
 get_control (MetaFrames *frames,
              MetaUIFrame *frame,
@@ -2634,10 +2665,7 @@ get_control (MetaFrames *frames,
   x /= scale;
   y /= scale;
 
-  client.x = fgeom.left_width;
-  client.y = fgeom.top_height;
-  client.width = fgeom.width - fgeom.left_width - fgeom.right_width;
-  client.height = fgeom.height - fgeom.top_height - fgeom.bottom_height;
+  get_client_rect (&fgeom, fgeom.width, fgeom.height, &client);
 
   if (POINT_IN_RECT (x, y, client))
     return META_FRAME_CONTROL_CLIENT_AREA;
@@ -2711,8 +2739,8 @@ get_control (MetaFrames *frames,
    * in case of overlap.
    */
 
-  if (y >= (fgeom.height - fgeom.bottom_height - RESIZE_EXTENDS) &&
-      x >= (fgeom.width - fgeom.right_width - RESIZE_EXTENDS))
+  if (y >= (fgeom.height - fgeom.borders.total.bottom - RESIZE_EXTENDS) &&
+      x >= (fgeom.width - fgeom.borders.total.right - RESIZE_EXTENDS))
     {
       if (has_vert && has_horiz)
         return META_FRAME_CONTROL_RESIZE_SE;
@@ -2721,8 +2749,8 @@ get_control (MetaFrames *frames,
       else if (has_horiz)
         return META_FRAME_CONTROL_RESIZE_E;
     }
-  else if (y >= (fgeom.height - fgeom.bottom_height - RESIZE_EXTENDS) &&
-           x <= (fgeom.left_width + RESIZE_EXTENDS))
+  else if (y >= (fgeom.height - fgeom.borders.total.bottom - RESIZE_EXTENDS) &&
+           x <= (fgeom.borders.total.left + RESIZE_EXTENDS))
     {
       if (has_vert && has_horiz)
         return META_FRAME_CONTROL_RESIZE_SW;
@@ -2731,8 +2759,8 @@ get_control (MetaFrames *frames,
       else if (has_horiz)
         return META_FRAME_CONTROL_RESIZE_W;
     }
-  else if (y < (fgeom.top_height + RESIZE_EXTENDS) &&
-           x < RESIZE_EXTENDS)
+  else if (y < (fgeom.borders.invisible.top + RESIZE_EXTENDS) &&
+           x <= (fgeom.borders.total.left + RESIZE_EXTENDS))
     {
       if (has_vert && has_horiz)
         return META_FRAME_CONTROL_RESIZE_NW;
@@ -2741,8 +2769,8 @@ get_control (MetaFrames *frames,
       else if (has_horiz)
         return META_FRAME_CONTROL_RESIZE_W;
     }
-  else if (y < (fgeom.top_height + RESIZE_EXTENDS) &&
-           x >= (fgeom.width - RESIZE_EXTENDS))
+  else if (y < (fgeom.borders.invisible.top + RESIZE_EXTENDS) &&
+           x >= (fgeom.width - fgeom.borders.total.right - RESIZE_EXTENDS))
     {
       if (has_vert && has_horiz)
         return META_FRAME_CONTROL_RESIZE_NE;
@@ -2751,33 +2779,28 @@ get_control (MetaFrames *frames,
       else if (has_horiz)
         return META_FRAME_CONTROL_RESIZE_E;
     }
-  else if (y >= (fgeom.height - fgeom.bottom_height - RESIZE_EXTENDS))
+  else if (y <= fgeom.borders.invisible.top + TOP_RESIZE_HEIGHT * scale)
+    {
+      if (has_vert)
+        return META_FRAME_CONTROL_RESIZE_N;
+    }
+  else if (y >= (fgeom.height - fgeom.borders.total.bottom - RESIZE_EXTENDS))
     {
       if (has_vert)
         return META_FRAME_CONTROL_RESIZE_S;
     }
-  else if (y <= TOP_RESIZE_HEIGHT * scale)
-    {
-      if (has_vert)
-        return META_FRAME_CONTROL_RESIZE_N;
-      else if (has_horiz)
-        return META_FRAME_CONTROL_TITLE;
-    }
-  else if (x <= fgeom.left_width)
+  else if (x <= fgeom.borders.total.left + RESIZE_EXTENDS)
     {
       if (has_horiz)
         return META_FRAME_CONTROL_RESIZE_W;
     }
-  else if (x >= (fgeom.width - fgeom.right_width))
+  else if (x >= (fgeom.width - fgeom.borders.total.right - RESIZE_EXTENDS))
     {
       if (has_horiz)
         return META_FRAME_CONTROL_RESIZE_E;
     }
 
-  if (y >= fgeom.top_height)
-    return META_FRAME_CONTROL_NONE;
-  else
-    return META_FRAME_CONTROL_TITLE;
+  return META_FRAME_CONTROL_NONE;
 }
 
 void

--- a/src/ui/frames.h
+++ b/src/ui/frames.h
@@ -127,10 +127,9 @@ void meta_frames_set_title (MetaFrames *frames,
 void meta_frames_repaint_frame (MetaFrames *frames,
                                 Window      xwindow);
 
-void meta_frames_get_geometry (MetaFrames *frames,
-                               Window xwindow,
-                               int *top_height, int *bottom_height,
-                               int *left_width, int *right_width);
+void meta_frames_get_borders (MetaFrames       *frames,
+                              Window            xwindow,
+                              MetaFrameBorders *borders);
 
 void meta_frames_apply_shapes (MetaFrames *frames,
                                Window      xwindow,

--- a/src/ui/frames.h
+++ b/src/ui/frames.h
@@ -140,6 +140,11 @@ cairo_region_t *meta_frames_get_frame_bounds (MetaFrames *frames,
                                               Window      xwindow,
                                               int         window_width,
                                               int         window_height);
+void meta_frames_get_mask (MetaFrames *frames,
+                           Window      xwindow,
+                           guint       width,
+                           guint       height,
+                           cairo_t    *cr);
 void meta_frames_move_resize_frame (MetaFrames *frames,
 				    Window      xwindow,
 				    int         x,

--- a/src/ui/frames.h
+++ b/src/ui/frames.h
@@ -136,6 +136,10 @@ void meta_frames_apply_shapes (MetaFrames *frames,
                                int         new_window_width,
                                int         new_window_height,
                                gboolean    window_has_shape);
+cairo_region_t *meta_frames_get_frame_bounds (MetaFrames *frames,
+                                              Window      xwindow,
+                                              int         window_width,
+                                              int         window_height);
 void meta_frames_move_resize_frame (MetaFrames *frames,
 				    Window      xwindow,
 				    int         x,

--- a/src/ui/preview-widget.c
+++ b/src/ui/preview-widget.c
@@ -211,8 +211,8 @@ meta_preview_draw (GtkWidget *widget,
   border_width = gtk_container_get_border_width (GTK_CONTAINER (widget));
 
   gtk_widget_get_allocation (widget, &allocation);
-  client_width = allocation.width - preview->borders.visible.left - preview->borders.visible.right - border_width * 2;
-  client_height = allocation.height - preview->borders.visible.top - preview->borders.visible.bottom - border_width * 2;
+  client_width = allocation.width - preview->borders.total.left - preview->borders.total.right - border_width * 2;
+  client_height = allocation.height - preview->borders.total.top - preview->borders.total.bottom - border_width * 2;
 
   if (client_width < 0)
     client_width = 1;
@@ -254,7 +254,7 @@ meta_preview_get_preferred_width (GtkWidget *widget,
 
   ensure_info (preview);
 
-  *minimum = *natural = preview->borders.visible.left + preview->borders.visible.right;
+  *minimum = *natural = preview->borders.total.left + preview->borders.total.right;
 
   child = gtk_bin_get_child (GTK_BIN (preview));
   if (child && gtk_widget_get_visible (child))
@@ -290,7 +290,7 @@ meta_preview_get_preferred_height (GtkWidget *widget,
 
   ensure_info (preview);
 
-  *minimum = *natural = preview->borders.visible.top + preview->borders.visible.bottom;
+  *minimum = *natural = preview->borders.total.top + preview->borders.total.bottom;
 
   child = gtk_bin_get_child (GTK_BIN (preview));
   if (child && gtk_widget_get_visible (child))
@@ -335,11 +335,12 @@ meta_preview_size_allocate (GtkWidget         *widget,
       gtk_widget_get_visible (child))
     {
       gtk_widget_get_allocation (widget, &widget_allocation);
-      child_allocation.x = widget_allocation.x + border_width + preview->borders.visible.left;
-      child_allocation.y = widget_allocation.y + border_width + preview->borders.visible.top;
+      child_allocation.x = widget_allocation.x + border_width + preview->borders.total.left;
+      child_allocation.y = widget_allocation.y + border_width + preview->borders.total.top;
 
-      child_allocation.width = MAX (1, widget_allocation.width - border_width * 2 - preview->borders.visible.left - preview->borders.visible.right);
-      child_allocation.height = MAX (1, widget_allocation.height - border_width * 2 - preview->borders.visible.top - preview->borders.visible.bottom);
+      child_allocation.width = MAX (1, widget_allocation.width - border_width * 2 - preview->borders.total.left - preview->borders.total.right);
+      child_allocation.height = MAX (1, widget_allocation.height - border_width * 2 - preview->borders.total.top - preview->borders.total.bottom);
+
       gtk_widget_size_allocate (gtk_bin_get_child (GTK_BIN (widget)), &child_allocation);
     }
 }

--- a/src/ui/preview-widget.c
+++ b/src/ui/preview-widget.c
@@ -98,10 +98,10 @@ meta_preview_init (MetaPreview *preview)
     META_FRAME_ALLOWS_SHADE |
     META_FRAME_ALLOWS_MOVE;
 
-  preview->left_width = -1;
-  preview->right_width = -1;
-  preview->top_height = -1;
-  preview->bottom_height = -1;
+  preview->borders.visible.left = -1;
+  preview->borders.visible.right = -1;
+  preview->borders.visible.top = -1;
+  preview->borders.visible.bottom = -1;
 }
 
 GtkWidget*
@@ -172,7 +172,7 @@ ensure_info (MetaPreview *preview)
       pango_font_description_free (font_desc);
     }
 
-  if (preview->top_height < 0)
+  if (preview->borders.visible.top < 0)
     {
       if (preview->theme)
         {
@@ -180,17 +180,14 @@ ensure_info (MetaPreview *preview)
                                         preview->type,
                                         preview->text_height,
                                         preview->flags,
-                                        &preview->top_height,
-                                        &preview->bottom_height,
-                                        &preview->left_width,
-                                        &preview->right_width);
+                                        &preview->borders);
         }
       else
         {
-          preview->top_height = 0;
-          preview->bottom_height = 0;
-          preview->left_width = 0;
-          preview->right_width = 0;
+          preview->borders.visible.top = 0;
+          preview->borders.visible.bottom = 0;
+          preview->borders.visible.left = 0;
+          preview->borders.visible.right = 0;
         }
     }
 }
@@ -223,8 +220,8 @@ meta_preview_draw (GtkWidget *widget,
   border_width = gtk_container_get_border_width (GTK_CONTAINER (widget));
 
   gtk_widget_get_allocation (widget, &allocation);
-  client_width = allocation.width - preview->left_width - preview->right_width - border_width * 2;
-  client_height = allocation.height - preview->top_height - preview->bottom_height - border_width * 2;
+  client_width = allocation.width - preview->borders.visible.left - preview->borders.visible.right - border_width * 2;
+  client_height = allocation.height - preview->borders.visible.top - preview->borders.visible.bottom - border_width * 2;
 
   if (client_width < 0)
     client_width = 1;
@@ -266,7 +263,7 @@ meta_preview_get_preferred_width (GtkWidget *widget,
 
   ensure_info (preview);
 
-  *minimum = *natural = preview->left_width + preview->right_width;
+  *minimum = *natural = preview->borders.visible.left + preview->borders.visible.right;
 
   child = gtk_bin_get_child (GTK_BIN (preview));
   if (child && gtk_widget_get_visible (child))
@@ -302,7 +299,7 @@ meta_preview_get_preferred_height (GtkWidget *widget,
 
   ensure_info (preview);
 
-  *minimum = *natural = preview->top_height + preview->bottom_height;
+  *minimum = *natural = preview->borders.visible.top + preview->borders.visible.bottom;
 
   child = gtk_bin_get_child (GTK_BIN (preview));
   if (child && gtk_widget_get_visible (child))
@@ -347,11 +344,11 @@ meta_preview_size_allocate (GtkWidget         *widget,
       gtk_widget_get_visible (child))
     {
       gtk_widget_get_allocation (widget, &widget_allocation);
-      child_allocation.x = widget_allocation.x + border_width + preview->left_width;
-      child_allocation.y = widget_allocation.y + border_width + preview->top_height;
+      child_allocation.x = widget_allocation.x + border_width + preview->borders.visible.left;
+      child_allocation.y = widget_allocation.y + border_width + preview->borders.visible.top;
 
-      child_allocation.width = MAX (1, widget_allocation.width - border_width * 2 - preview->left_width - preview->right_width);
-      child_allocation.height = MAX (1, widget_allocation.height - border_width * 2 - preview->top_height - preview->bottom_height);
+      child_allocation.width = MAX (1, widget_allocation.width - border_width * 2 - preview->borders.visible.left - preview->borders.visible.right);
+      child_allocation.height = MAX (1, widget_allocation.height - border_width * 2 - preview->borders.visible.top - preview->borders.visible.bottom);
       gtk_widget_size_allocate (gtk_bin_get_child (GTK_BIN (widget)), &child_allocation);
     }
 }
@@ -365,10 +362,10 @@ clear_cache (MetaPreview *preview)
       preview->layout = NULL;
     }
 
-  preview->left_width = -1;
-  preview->right_width = -1;
-  preview->top_height = -1;
-  preview->bottom_height = -1;
+  preview->borders.visible.left = -1;
+  preview->borders.visible.right = -1;
+  preview->borders.visible.top = -1;
+  preview->borders.visible.bottom = -1;
 }
 
 void

--- a/src/ui/preview-widget.c
+++ b/src/ui/preview-widget.c
@@ -98,10 +98,7 @@ meta_preview_init (MetaPreview *preview)
     META_FRAME_ALLOWS_SHADE |
     META_FRAME_ALLOWS_MOVE;
 
-  preview->borders.visible.left = -1;
-  preview->borders.visible.right = -1;
-  preview->borders.visible.top = -1;
-  preview->borders.visible.bottom = -1;
+  preview->borders_cached = FALSE;
 }
 
 GtkWidget*
@@ -172,23 +169,17 @@ ensure_info (MetaPreview *preview)
       pango_font_description_free (font_desc);
     }
 
-  if (preview->borders.visible.top < 0)
+  if (!preview->borders_cached)
     {
       if (preview->theme)
-        {
-          meta_theme_get_frame_borders (preview->theme,
-                                        preview->type,
-                                        preview->text_height,
-                                        preview->flags,
-                                        &preview->borders);
-        }
+        meta_theme_get_frame_borders (preview->theme,
+                                      preview->type,
+                                      preview->text_height,
+                                      preview->flags,
+                                      &preview->borders);
       else
-        {
-          preview->borders.visible.top = 0;
-          preview->borders.visible.bottom = 0;
-          preview->borders.visible.left = 0;
-          preview->borders.visible.right = 0;
-        }
+        meta_frame_borders_clear (&preview->borders);
+      preview->borders_cached = TRUE;
     }
 }
 
@@ -362,10 +353,7 @@ clear_cache (MetaPreview *preview)
       preview->layout = NULL;
     }
 
-  preview->borders.visible.left = -1;
-  preview->borders.visible.right = -1;
-  preview->borders.visible.top = -1;
-  preview->borders.visible.bottom = -1;
+  preview->borders_cached = FALSE;
 }
 
 void

--- a/src/ui/preview-widget.h
+++ b/src/ui/preview-widget.h
@@ -50,11 +50,7 @@ struct _MetaPreview
   PangoLayout *layout;
   int text_height;
 
-  int left_width;
-  int right_width;
-  int top_height;
-  int bottom_height;
-
+  MetaFrameBorders borders;
   MetaButtonLayout button_layout;
 };
 

--- a/src/ui/preview-widget.h
+++ b/src/ui/preview-widget.h
@@ -51,6 +51,8 @@ struct _MetaPreview
   int text_height;
 
   MetaFrameBorders borders;
+  guint            borders_cached : 1;
+
   MetaButtonLayout button_layout;
 };
 

--- a/src/ui/resizepopup.c
+++ b/src/ui/resizepopup.c
@@ -106,11 +106,9 @@ update_size_window (MetaResizePopup *popup)
   char *str;
   int x, y;
   int width, height;
-  int scale;
 
   g_return_if_fail (popup->size_window != NULL);
 
-  scale = gtk_widget_get_scale_factor (GTK_WIDGET (popup->size_window));
   /* Translators: This represents the size of a window.  The first number is
    * the width of the window and the second is the height.
    */
@@ -126,12 +124,6 @@ update_size_window (MetaResizePopup *popup)
 
   x = popup->rect.x + (popup->rect.width - width) / 2;
   y = popup->rect.y + (popup->rect.height - height) / 2;
-
-  if (scale)
-    {
-      x = x / scale;
-      y = y / scale;
-    }
 
   if (gtk_widget_get_realized (popup->size_window))
     {

--- a/src/ui/tabpopup.c
+++ b/src/ui/tabpopup.c
@@ -149,8 +149,7 @@ dimm_icon (GdkPixbuf *pixbuf)
 
 static TabEntry*
 tab_entry_new (const MetaTabEntry *entry,
-               gboolean            outline,
-               gint                scale)
+               gboolean            outline)
 {
   TabEntry *te;
 
@@ -201,15 +200,15 @@ tab_entry_new (const MetaTabEntry *entry,
 
   if (outline)
     {
-      te->rect.x = entry->rect.x / scale;
-      te->rect.y = entry->rect.y / scale;
-      te->rect.width = entry->rect.width / scale;
-      te->rect.height = entry->rect.height / scale;
+      te->rect.x = entry->rect.x;
+      te->rect.y = entry->rect.y;
+      te->rect.width = entry->rect.width;
+      te->rect.height = entry->rect.height;
 
-      te->inner_rect.x = entry->inner_rect.x / scale;
-      te->inner_rect.y = entry->inner_rect.y / scale;
-      te->inner_rect.width = entry->inner_rect.width / scale;
-      te->inner_rect.height = entry->inner_rect.height / scale;
+      te->inner_rect.x = entry->inner_rect.x;
+      te->inner_rect.y = entry->inner_rect.y;
+      te->inner_rect.width = entry->inner_rect.width;
+      te->inner_rect.height = entry->inner_rect.height;
     }
   return te;
 }
@@ -230,7 +229,7 @@ meta_ui_tab_popup_new (const MetaTabEntry *entries,
   int max_label_width; /* the actual max width of the labels we create */
   AtkObject *obj;
   GdkScreen *screen;
-  int screen_width, scale;
+  int screen_width;
 
   popup = g_new (MetaTabPopup, 1);
 
@@ -274,11 +273,10 @@ meta_ui_tab_popup_new (const MetaTabEntry *entries,
   popup->current_selected_entry = NULL;
   popup->border = border;
 
-  scale = gtk_widget_get_scale_factor (GTK_WIDGET (popup->window));
   screen_width = WidthOfScreen (gdk_x11_screen_get_xscreen (screen));
   for (i = 0; i < entry_count; ++i)
     {
-      TabEntry* new_entry = tab_entry_new (&entries[i], border & BORDER_OUTLINE_WINDOW, scale);
+      TabEntry* new_entry = tab_entry_new (&entries[i], border & BORDER_OUTLINE_WINDOW);
       popup->entries = g_list_prepend (popup->entries, new_entry);
     }
 
@@ -764,11 +762,13 @@ selectable_workspace_new (MetaWorkspace *workspace, int entry_count)
   GtkWidget *widget;
   const MetaXineramaScreenInfo *current;
   int mini_workspace_width, mini_workspace_height;
+  int scale;
   double mini_workspace_ratio;
 
   widget = g_object_new (meta_select_workspace_get_type (), NULL);
 
   current = meta_screen_get_current_xinerama (workspace->screen);
+  scale = get_window_scaling_factor ();
 
   if (workspace->screen->rect.width < workspace->screen->rect.height)
   {
@@ -785,8 +785,8 @@ selectable_workspace_new (MetaWorkspace *workspace, int entry_count)
 
   /* account for select rect */
   gtk_widget_set_size_request (widget,
-                               mini_workspace_width / MINI_WORKSPACE_SCALE,
-                               mini_workspace_height / MINI_WORKSPACE_SCALE);
+                               mini_workspace_width * scale / MINI_WORKSPACE_SCALE,
+                               mini_workspace_height * scale / MINI_WORKSPACE_SCALE);
 
   META_SELECT_WORKSPACE (widget)->workspace = workspace;
 

--- a/src/ui/theme-parser.c
+++ b/src/ui/theme-parser.c
@@ -38,7 +38,7 @@
  * look out for.
  */
 #define THEME_MAJOR_VERSION 3
-#define THEME_MINOR_VERSION 5
+#define THEME_MINOR_VERSION 6
 #define THEME_VERSION (1000 * THEME_MAJOR_VERSION + THEME_MINOR_VERSION)
 
 #define MARCO_THEME_FILENAME_FORMAT "metacity-theme-%d.xml"
@@ -1570,6 +1570,8 @@ parse_border (GMarkupParseContext  *context,
     border = &info->layout->title_border;
   else if (strcmp (name, "button_border") == 0)
     border = &info->layout->button_border;
+  else if (strcmp (name, "invisible_border") == 0)
+    border = &info->layout->invisible_border;
 
   if (border == NULL)
     {

--- a/src/ui/theme-viewer.c
+++ b/src/ui/theme-viewer.c
@@ -1081,8 +1081,8 @@ run_theme_benchmark (void)
        */
       pixmap = gdk_window_create_similar_surface (gtk_widget_get_window (widget),
                                                   CAIRO_CONTENT_COLOR,
-                                                  client_width + borders.visible.left + borders.visible.right,
-                                                  client_height + borders.visible.top + borders.visible.bottom);
+                                                  client_width + borders.total.left + borders.total.right,
+                                                  client_height + borders.total.top + borders.total.bottom);
       cr = cairo_create (pixmap);
 
       meta_theme_draw_frame (global_theme,

--- a/src/ui/theme-viewer.c
+++ b/src/ui/theme-viewer.c
@@ -1020,7 +1020,7 @@ run_theme_benchmark (void)
   GtkWidget* widget;
   cairo_surface_t *pixmap;
   cairo_t *cr;
-  int top_height, bottom_height, left_width, right_width;
+  MetaFrameBorders borders;
   MetaButtonState button_states[META_BUTTON_TYPE_LAST] =
   {
     META_BUTTON_STATE_NORMAL,
@@ -1046,10 +1046,7 @@ run_theme_benchmark (void)
                                 META_FRAME_TYPE_NORMAL,
                                 get_text_height (widget),
                                 get_flags (widget),
-                                &top_height,
-                                &bottom_height,
-                                &left_width,
-                                &right_width);
+                                &borders);
 
   layout = create_title_layout (widget);
 
@@ -1084,8 +1081,8 @@ run_theme_benchmark (void)
        */
       pixmap = gdk_window_create_similar_surface (gtk_widget_get_window (widget),
                                                   CAIRO_CONTENT_COLOR,
-                                                  client_width + left_width + right_width,
-                                                  client_height + top_height + bottom_height);
+                                                  client_width + borders.visible.left + borders.visible.right,
+                                                  client_height + borders.visible.top + borders.visible.bottom);
       cr = cairo_create (pixmap);
 
       meta_theme_draw_frame (global_theme,

--- a/src/ui/theme.c
+++ b/src/ui/theme.c
@@ -433,6 +433,16 @@ meta_frame_layout_get_borders (const MetaFrameLayout *layout,
       meta_frame_borders_clear (borders);
       return;
     }
+
+  borders->invisible.left = layout->invisible_border.left;
+  borders->invisible.right = layout->invisible_border.right;
+  borders->invisible.bottom = layout->invisible_border.bottom;
+  borders->invisible.top = layout->invisible_border.top;
+
+  borders->total.left = borders->invisible.left + borders->visible.left;
+  borders->total.right = borders->invisible.right + borders->visible.right;
+  borders->total.bottom = borders->invisible.bottom + borders->visible.bottom;
+  borders->total.top = borders->invisible.top + borders->visible.top;
 }
 
 static MetaButtonType

--- a/src/ui/theme.c
+++ b/src/ui/theme.c
@@ -645,15 +645,12 @@ meta_frame_layout_calc_geometry (const MetaFrameLayout  *layout,
                                  flags,
                                  &borders);
 
-  fgeom->left_width = borders.visible.left;
-  fgeom->right_width = borders.visible.right;
-  fgeom->top_height = borders.visible.top;
-  fgeom->bottom_height = borders.visible.bottom;
+  fgeom->borders = borders;
 
-  width = client_width + fgeom->left_width + fgeom->right_width;
+  width = client_width + borders.total.left + borders.total.right;
 
   height = ((flags & META_FRAME_SHADED) ? 0: client_height) +
-    fgeom->top_height + fgeom->bottom_height;
+    borders.total.top + borders.total.bottom;
 
   fgeom->width = width;
   fgeom->height = height;
@@ -666,7 +663,7 @@ meta_frame_layout_calc_geometry (const MetaFrameLayout  *layout,
   switch (layout->button_sizing)
     {
     case META_BUTTON_SIZING_ASPECT:
-      button_height = fgeom->top_height - layout->button_border.top - layout->button_border.bottom;
+      button_height = borders.visible.top - layout->button_border.top - layout->button_border.bottom;
       button_width = button_height / layout->button_aspect;
       break;
     case META_BUTTON_SIZING_FIXED:
@@ -859,11 +856,11 @@ meta_frame_layout_calc_geometry (const MetaFrameLayout  *layout,
   fgeom->n_right_buttons = n_right;
 
   /* center buttons vertically */
-  button_y = (fgeom->top_height -
-              (button_height + layout->button_border.top + layout->button_border.bottom)) / 2 + layout->button_border.top;
+  button_y = (borders.visible.top -
+              (button_height + layout->button_border.top + layout->button_border.bottom)) / 2 + layout->button_border.top + borders.invisible.top;
 
   /* right edge of farthest-right button */
-  x = width - layout->right_titlebar_edge;
+  x = width - layout->right_titlebar_edge - borders.invisible.right;
 
   i = n_right - 1;
   while (i >= 0)
@@ -911,7 +908,7 @@ meta_frame_layout_calc_geometry (const MetaFrameLayout  *layout,
   /* Now x changes to be position from the left and we go through
    * the left-side buttons
    */
-  x = layout->left_titlebar_edge;
+  x = layout->left_titlebar_edge + borders.invisible.left;
   for (i = 0; i < n_left; i++)
     {
       MetaButtonSpace *rect;
@@ -944,9 +941,9 @@ meta_frame_layout_calc_geometry (const MetaFrameLayout  *layout,
    * rather than centering it like the buttons
    */
   fgeom->title_rect.x = x + layout->title_border.left;
-  fgeom->title_rect.y = layout->title_border.top;
+  fgeom->title_rect.y = layout->title_border.top + borders.invisible.top;
   fgeom->title_rect.width = title_right_edge - fgeom->title_rect.x;
-  fgeom->title_rect.height = fgeom->top_height - layout->title_border.top - layout->title_border.bottom;
+  fgeom->title_rect.height = borders.visible.top - layout->title_border.top - layout->title_border.bottom;
 
   /* Nuke title if it won't fit */
   if (fgeom->title_rect.width < 0 ||
@@ -966,14 +963,14 @@ meta_frame_layout_calc_geometry (const MetaFrameLayout  *layout,
   fgeom->bottom_left_corner_rounded_radius = 0;
   fgeom->bottom_right_corner_rounded_radius = 0;
 
-  if (fgeom->top_height + fgeom->left_width >= min_size_for_rounding)
+  if (borders.visible.top + borders.visible.left >= min_size_for_rounding)
     fgeom->top_left_corner_rounded_radius = layout->top_left_corner_rounded_radius;
-  if (fgeom->top_height + fgeom->right_width >= min_size_for_rounding)
+  if (borders.visible.top + borders.visible.right >= min_size_for_rounding)
     fgeom->top_right_corner_rounded_radius = layout->top_right_corner_rounded_radius;
 
-  if (fgeom->bottom_height + fgeom->left_width >= min_size_for_rounding)
+  if (borders.visible.bottom + borders.visible.left >= min_size_for_rounding)
     fgeom->bottom_left_corner_rounded_radius = layout->bottom_left_corner_rounded_radius;
-  if (fgeom->bottom_height + fgeom->right_width >= min_size_for_rounding)
+  if (borders.visible.bottom + borders.visible.right >= min_size_for_rounding)
     fgeom->bottom_right_corner_rounded_radius = layout->bottom_right_corner_rounded_radius;
 }
 
@@ -3588,10 +3585,10 @@ fill_env (MetaPositionExprEnv *env,
   env->object_height = -1;
   if (info->fgeom)
     {
-      env->left_width = info->fgeom->left_width;
-      env->right_width = info->fgeom->right_width;
-      env->top_height = info->fgeom->top_height;
-      env->bottom_height = info->fgeom->bottom_height;
+      env->left_width = info->fgeom->borders.visible.left;
+      env->right_width = info->fgeom->borders.visible.right;
+      env->top_height = info->fgeom->borders.visible.top;
+      env->bottom_height = info->fgeom->borders.visible.bottom;
       env->frame_x_center = info->fgeom->width / 2 - logical_region.x;
       env->frame_y_center = info->fgeom->height / 2 - logical_region.y;
     }
@@ -4662,8 +4659,8 @@ meta_frame_style_draw_with_style (MetaFrameStyle          *style,
                                   GdkPixbuf               *mini_icon,
                                   GdkPixbuf               *icon)
 {
-    /* BOOKMARK */
   int i, j;
+  GdkRectangle visible_rect;
   GdkRectangle titlebar_rect;
   GdkRectangle left_titlebar_edge;
   GdkRectangle right_titlebar_edge;
@@ -4672,11 +4669,19 @@ meta_frame_style_draw_with_style (MetaFrameStyle          *style,
   GdkRectangle left_edge, right_edge, bottom_edge;
   PangoRectangle extents;
   MetaDrawInfo draw_info;
+  const MetaFrameBorders *borders;
 
-  titlebar_rect.x = 0;
-  titlebar_rect.y = 0;
-  titlebar_rect.width = fgeom->width;
-  titlebar_rect.height = fgeom->top_height;
+  borders = &fgeom->borders;
+
+  visible_rect.x = borders->invisible.left;
+  visible_rect.y = borders->invisible.top;
+  visible_rect.width = fgeom->width - borders->invisible.left - borders->invisible.right;
+  visible_rect.height = fgeom->height - borders->invisible.top - borders->invisible.bottom;
+
+  titlebar_rect.x = visible_rect.x;
+  titlebar_rect.y = visible_rect.y;
+  titlebar_rect.width = visible_rect.width;
+  titlebar_rect.height = borders->visible.top;
 
   left_titlebar_edge.x = titlebar_rect.x;
   left_titlebar_edge.y = titlebar_rect.y + fgeom->top_titlebar_edge;
@@ -4698,20 +4703,20 @@ meta_frame_style_draw_with_style (MetaFrameStyle          *style,
   bottom_titlebar_edge.height = fgeom->bottom_titlebar_edge;
   bottom_titlebar_edge.y = titlebar_rect.y + titlebar_rect.height - bottom_titlebar_edge.height;
 
-  left_edge.x = 0;
-  left_edge.y = fgeom->top_height;
-  left_edge.width = fgeom->left_width;
-  left_edge.height = fgeom->height - fgeom->top_height - fgeom->bottom_height;
+  left_edge.x = visible_rect.x;
+  left_edge.y = visible_rect.y + borders->visible.top;
+  left_edge.width = borders->visible.left;
+  left_edge.height = visible_rect.height - borders->visible.top - borders->visible.bottom;
 
-  right_edge.x = fgeom->width - fgeom->right_width;
-  right_edge.y = fgeom->top_height;
-  right_edge.width = fgeom->right_width;
-  right_edge.height = fgeom->height - fgeom->top_height - fgeom->bottom_height;
+  right_edge.x = visible_rect.x + visible_rect.width - borders->visible.right;
+  right_edge.y = visible_rect.y + borders->visible.top;
+  right_edge.width = borders->visible.right;
+  right_edge.height = visible_rect.height - borders->visible.top - borders->visible.bottom;
 
-  bottom_edge.x = 0;
-  bottom_edge.y = fgeom->height - fgeom->bottom_height;
-  bottom_edge.width = fgeom->width;
-  bottom_edge.height = fgeom->bottom_height;
+  bottom_edge.x = visible_rect.x;
+  bottom_edge.y = visible_rect.y + visible_rect.height - borders->visible.bottom;
+  bottom_edge.width = visible_rect.width;
+  bottom_edge.height = borders->visible.bottom;
 
   if (title_layout)
     pango_layout_get_pixel_extents (title_layout,
@@ -4733,10 +4738,7 @@ meta_frame_style_draw_with_style (MetaFrameStyle          *style,
       switch ((MetaFramePiece) i)
         {
         case META_FRAME_PIECE_ENTIRE_BACKGROUND:
-          rect.x = 0;
-          rect.y = 0;
-          rect.width = fgeom->width;
-          rect.height = fgeom->height;
+          rect = visible_rect;
           break;
 
         case META_FRAME_PIECE_TITLEBAR:
@@ -4784,10 +4786,7 @@ meta_frame_style_draw_with_style (MetaFrameStyle          *style,
           break;
 
         case META_FRAME_PIECE_OVERLAY:
-          rect.x = 0;
-          rect.y = 0;
-          rect.width = fgeom->width;
-          rect.height = fgeom->height;
+          rect = visible_rect;
           break;
 
         case META_FRAME_PIECE_LAST:

--- a/src/ui/theme.c
+++ b/src/ui/theme.c
@@ -53,6 +53,7 @@
  */
 
 #include <config.h>
+#include "prefs.h"
 #include "theme.h"
 #include "theme-parser.h"
 #include "util.h"
@@ -442,6 +443,14 @@ meta_frame_layout_get_borders (const MetaFrameLayout *layout,
     {
       borders->invisible.bottom = layout->invisible_border.bottom;
       borders->invisible.top = layout->invisible_border.top;
+    }
+
+  if (!meta_prefs_get_compositing_manager ())
+    {
+      borders->invisible.left = 0;
+      borders->invisible.right = 0;
+      borders->invisible.top = 0;
+      borders->invisible.bottom = 0;
     }
 
   borders->total.left = borders->invisible.left + borders->visible.left;

--- a/src/ui/theme.c
+++ b/src/ui/theme.c
@@ -410,6 +410,12 @@ meta_frame_layout_get_borders (const MetaFrameLayout *layout,
 {
   int buttons_height, title_height;
 
+  meta_frame_borders_clear (borders);
+
+  /* For a full-screen window, we don't have any borders, visible or not. */
+  if (flags & META_FRAME_FULLSCREEN)
+    return;
+
   g_return_if_fail (layout != NULL);
 
   if (!layout->has_title)
@@ -426,19 +432,17 @@ meta_frame_layout_get_borders (const MetaFrameLayout *layout,
   borders->visible.right = layout->right_width;
   borders->visible.bottom = layout->bottom_height;
 
-  if (flags & META_FRAME_FULLSCREEN)
+  if (flags & META_FRAME_ALLOWS_HORIZONTAL_RESIZE)
     {
-      meta_frame_borders_clear (borders);
-      return;
+      borders->invisible.left = layout->invisible_border.left;
+      borders->invisible.right = layout->invisible_border.right;
     }
 
-  borders->invisible.left = layout->invisible_border.left;
-  borders->invisible.right = layout->invisible_border.right;
-  borders->invisible.bottom = layout->invisible_border.bottom;
-  borders->invisible.top = layout->invisible_border.top;
-
-  if (flags & META_FRAME_SHADED)
-    borders->visible.bottom = borders->invisible.bottom = 0;
+  if (flags & META_FRAME_ALLOWS_VERTICAL_RESIZE)
+    {
+      borders->invisible.bottom = layout->invisible_border.bottom;
+      borders->invisible.top = layout->invisible_border.top;
+    }
 
   borders->total.left = borders->invisible.left + borders->visible.left;
   borders->total.right = borders->invisible.right + borders->visible.right;

--- a/src/ui/theme.c
+++ b/src/ui/theme.c
@@ -219,10 +219,11 @@ meta_frame_layout_new  (void)
   layout->right_width = -1;
   layout->bottom_height = -1;
 
-  layout->invisible_border.left = 10;
-  layout->invisible_border.right = 10;
-  layout->invisible_border.bottom = 10;
-  layout->invisible_border.top = 10;
+  /* Default to 0 to avoid graphical glitches */
+  layout->invisible_border.left = 0;
+  layout->invisible_border.right = 0;
+  layout->invisible_border.bottom = 0;
+  layout->invisible_border.top = 0;
 
   init_border (&layout->title_border);
 

--- a/src/ui/theme.c
+++ b/src/ui/theme.c
@@ -405,10 +405,7 @@ void
 meta_frame_layout_get_borders (const MetaFrameLayout *layout,
                                int                    text_height,
                                MetaFrameFlags         flags,
-                               int                   *top_height,
-                               int                   *bottom_height,
-                               int                   *left_width,
-                               int                   *right_width)
+                               MetaFrameBorders      *borders)
 {
   int buttons_height, title_height;
 
@@ -423,34 +420,20 @@ meta_frame_layout_get_borders (const MetaFrameLayout *layout,
     layout->title_vertical_pad +
     layout->title_border.top + layout->title_border.bottom;
 
-  if (top_height)
-    {
-      *top_height = MAX (buttons_height, title_height);
-    }
-
-  if (left_width)
-    *left_width = layout->left_width;
-  if (right_width)
-    *right_width = layout->right_width;
-
-  if (bottom_height)
-    {
-      if (flags & META_FRAME_SHADED)
-        *bottom_height = 0;
-      else
-        *bottom_height = layout->bottom_height;
-    }
+  borders->visible.top = MAX (buttons_height, title_height);
+  borders->visible.left = layout->left_width;
+  borders->visible.right = layout->right_width;
+  if (flags & META_FRAME_SHADED)
+    borders->visible.bottom = 0;
+  else
+    borders->visible.bottom = layout->bottom_height;
 
   if (flags & META_FRAME_FULLSCREEN)
     {
-      if (top_height)
-        *top_height = 0;
-      if (bottom_height)
-        *bottom_height = 0;
-      if (left_width)
-        *left_width = 0;
-      if (right_width)
-        *right_width = 0;
+      borders->visible.top = 0;
+      borders->visible.bottom = 0;
+      borders->visible.left = 0;
+      borders->visible.right = 0;
     }
 }
 
@@ -647,12 +630,16 @@ meta_frame_layout_calc_geometry (const MetaFrameLayout  *layout,
   GdkRectangle *right_bg_rects[MAX_BUTTONS_PER_CORNER];
   gboolean right_buttons_has_spacer[MAX_BUTTONS_PER_CORNER];
 
+  MetaFrameBorders borders;
+
   meta_frame_layout_get_borders (layout, text_height,
                                  flags,
-                                 &fgeom->top_height,
-                                 &fgeom->bottom_height,
-                                 &fgeom->left_width,
-                                 &fgeom->right_width);
+                                 &borders);
+
+  fgeom->left_width = borders.visible.left;
+  fgeom->right_width = borders.visible.right;
+  fgeom->top_height = borders.visible.top;
+  fgeom->bottom_height = borders.visible.bottom;
 
   width = client_width + fgeom->left_width + fgeom->right_width;
 
@@ -5620,29 +5607,22 @@ meta_theme_draw_frame_by_name (MetaTheme              *theme,
 }
 
 void
-meta_theme_get_frame_borders (MetaTheme      *theme,
-                              MetaFrameType   type,
-                              int             text_height,
-                              MetaFrameFlags  flags,
-                              int            *top_height,
-                              int            *bottom_height,
-                              int            *left_width,
-                              int            *right_width)
+meta_theme_get_frame_borders (MetaTheme        *theme,
+                              MetaFrameType     type,
+                              int               text_height,
+                              MetaFrameFlags    flags,
+                              MetaFrameBorders *borders)
 {
   MetaFrameStyle *style;
 
   g_return_if_fail (type < META_FRAME_TYPE_LAST);
 
-  if (top_height)
-    *top_height = 0;
-  if (bottom_height)
-    *bottom_height = 0;
-  if (left_width)
-    *left_width = 0;
-  if (right_width)
-    *right_width = 0;
-
   style = theme_get_style (theme, type, flags);
+
+  borders->visible.top = 0;
+  borders->visible.left = 0;
+  borders->visible.right = 0;
+  borders->visible.bottom = 0;
 
   /* Parser is not supposed to allow this currently */
   if (style == NULL)
@@ -5651,8 +5631,7 @@ meta_theme_get_frame_borders (MetaTheme      *theme,
   meta_frame_layout_get_borders (style->layout,
                                  text_height,
                                  flags,
-                                 top_height, bottom_height,
-                                 left_width, right_width);
+                                 borders);
 }
 
 void

--- a/src/ui/theme.c
+++ b/src/ui/theme.c
@@ -430,10 +430,8 @@ meta_frame_layout_get_borders (const MetaFrameLayout *layout,
 
   if (flags & META_FRAME_FULLSCREEN)
     {
-      borders->visible.top = 0;
-      borders->visible.bottom = 0;
-      borders->visible.left = 0;
-      borders->visible.right = 0;
+      meta_frame_borders_clear (borders);
+      return;
     }
 }
 
@@ -5619,10 +5617,7 @@ meta_theme_get_frame_borders (MetaTheme        *theme,
 
   style = theme_get_style (theme, type, flags);
 
-  borders->visible.top = 0;
-  borders->visible.left = 0;
-  borders->visible.right = 0;
-  borders->visible.bottom = 0;
+  meta_frame_borders_clear (borders);
 
   /* Parser is not supposed to allow this currently */
   if (style == NULL)

--- a/src/ui/theme.c
+++ b/src/ui/theme.c
@@ -424,10 +424,7 @@ meta_frame_layout_get_borders (const MetaFrameLayout *layout,
   borders->visible.top = MAX (buttons_height, title_height);
   borders->visible.left = layout->left_width;
   borders->visible.right = layout->right_width;
-  if (flags & META_FRAME_SHADED)
-    borders->visible.bottom = 0;
-  else
-    borders->visible.bottom = layout->bottom_height;
+  borders->visible.bottom = layout->bottom_height;
 
   if (flags & META_FRAME_FULLSCREEN)
     {
@@ -439,6 +436,9 @@ meta_frame_layout_get_borders (const MetaFrameLayout *layout,
   borders->invisible.right = layout->invisible_border.right;
   borders->invisible.bottom = layout->invisible_border.bottom;
   borders->invisible.top = layout->invisible_border.top;
+
+  if (flags & META_FRAME_SHADED)
+    borders->visible.bottom = borders->invisible.bottom = 0;
 
   borders->total.left = borders->invisible.left + borders->visible.left;
   borders->total.right = borders->invisible.right + borders->visible.right;

--- a/src/ui/theme.h
+++ b/src/ui/theme.h
@@ -877,10 +877,7 @@ void             meta_frame_layout_unref         (MetaFrameLayout       *layout)
 void             meta_frame_layout_get_borders   (const MetaFrameLayout *layout,
                                                   int                    text_height,
                                                   MetaFrameFlags         flags,
-                                                  int                   *top_height,
-                                                  int                   *bottom_height,
-                                                  int                   *left_width,
-                                                  int                   *right_width);
+                                                  MetaFrameBorders      *borders);
 void             meta_frame_layout_calc_geometry (const MetaFrameLayout  *layout,
                                                   int                     text_height,
                                                   MetaFrameFlags          flags,
@@ -1076,10 +1073,7 @@ void meta_theme_get_frame_borders (MetaTheme         *theme,
                                    MetaFrameType      type,
                                    int                text_height,
                                    MetaFrameFlags     flags,
-                                   int               *top_height,
-                                   int               *bottom_height,
-                                   int               *left_width,
-                                   int               *right_width);
+                                   MetaFrameBorders  *borders);
 void meta_theme_calc_geometry (MetaTheme              *theme,
                                MetaFrameType           type,
                                int                     text_height,

--- a/src/ui/theme.h
+++ b/src/ui/theme.h
@@ -171,10 +171,7 @@ struct _MetaButtonSpace
  */
 struct _MetaFrameGeometry
 {
-  int left_width;
-  int right_width;
-  int top_height;
-  int bottom_height;
+  MetaFrameBorders borders;
 
   int width;
   int height;

--- a/src/ui/tile-preview.c
+++ b/src/ui/tile-preview.c
@@ -175,13 +175,6 @@ meta_tile_preview_show (MetaTilePreview *preview,
 {
   GdkWindow *window;
   GdkRectangle old_rect;
-  gint scale;
-
-  scale = gtk_widget_get_scale_factor (preview->preview_window);
-  tile_rect->x /= scale;
-  tile_rect->y /= scale;
-  tile_rect->width /= scale;
-  tile_rect->height /= scale;
 
   if (gtk_widget_get_visible (preview->preview_window)
       && preview->tile_rect.x == tile_rect->x

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -445,6 +445,18 @@ meta_ui_apply_frame_shape  (MetaUI  *ui,
                             window_has_shape);
 }
 
+cairo_region_t *
+meta_ui_get_frame_bounds (MetaUI *ui,
+                          Window  xwindow,
+                          int     window_width,
+                          int     window_height)
+{
+  return meta_frames_get_frame_bounds (ui->frames,
+                                       xwindow,
+                                       window_width,
+                                       window_height);
+}
+
 void
 meta_ui_queue_frame_draw (MetaUI *ui,
                           Window xwindow)

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -62,6 +62,11 @@ void meta_ui_init(int* argc, char*** argv)
 	{
 		meta_fatal ("Unable to open X display %s\n", XDisplayName (NULL));
 	}
+
+  /* We need to be able to fully trust that the window and monitor sizes
+   * that GDK reports corresponds to the X ones, so we disable the automatic
+   * scale handling */
+  gdk_x11_display_set_window_scale (gdk_display_get_default (), 1);
 }
 
 Display* meta_ui_get_display(void)
@@ -606,7 +611,7 @@ meta_ui_get_default_window_icon (MetaUI *ui)
   int scale;
   if (default_icon == NULL || current_icon_size != icon_size)
     {
-      scale = gtk_widget_get_scale_factor (GTK_WIDGET (ui->frames));
+      scale = get_window_scaling_factor ();
       default_icon = load_default_window_icon (current_icon_size, scale);
       g_assert (default_icon);
       icon_size = current_icon_size;
@@ -625,7 +630,7 @@ meta_ui_get_default_mini_icon (MetaUI *ui)
 
   if (default_icon == NULL)
     {
-      scale = gtk_widget_get_scale_factor (GTK_WIDGET (ui->frames));
+      scale = get_window_scaling_factor ();
       default_icon = load_default_window_icon (META_MINI_ICON_WIDTH, scale);
       g_assert (default_icon);
     }

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -685,10 +685,7 @@ meta_ui_theme_get_frame_borders (MetaUI           *ui,
     }
   else
     {
-      borders->visible.top = 0;
-      borders->visible.bottom = 0;
-      borders->visible.left = 0;
-      borders->visible.right = 0;
+      meta_frame_borders_clear (borders);
     }
 
   if (style != NULL)

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -295,6 +295,16 @@ meta_ui_free (MetaUI *ui)
 }
 
 void
+meta_ui_get_frame_mask (MetaUI  *ui,
+                        Window   frame_xwindow,
+                        guint    width,
+                        guint    height,
+                        cairo_t *cr)
+{
+  meta_frames_get_mask (ui->frames, frame_xwindow, width, height, cr);
+}
+
+void
 meta_ui_get_frame_borders (MetaUI *ui,
                            Window frame_xwindow,
                            MetaFrameBorders *borders)

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -295,14 +295,11 @@ meta_ui_free (MetaUI *ui)
 }
 
 void
-meta_ui_get_frame_geometry (MetaUI *ui,
-                            Window frame_xwindow,
-                            int *top_height, int *bottom_height,
-                            int *left_width, int *right_width)
+meta_ui_get_frame_borders (MetaUI *ui,
+                           Window frame_xwindow,
+                           MetaFrameBorders *borders)
 {
-  meta_frames_get_geometry (ui->frames, frame_xwindow,
-                            top_height, bottom_height,
-                            left_width, right_width);
+  meta_frames_get_borders (ui->frames, frame_xwindow, borders);
 }
 
 static void
@@ -637,13 +634,10 @@ meta_ui_window_should_not_cause_focus (Display *xdisplay,
 }
 
 void
-meta_ui_theme_get_frame_borders (MetaUI *ui,
-                                 MetaFrameType      type,
-                                 MetaFrameFlags     flags,
-                                 int               *top_height,
-                                 int               *bottom_height,
-                                 int               *left_width,
-                                 int               *right_width)
+meta_ui_theme_get_frame_borders (MetaUI           *ui,
+                                 MetaFrameType     type,
+                                 MetaFrameFlags    flags,
+                                 MetaFrameBorders *borders)
 {
   int text_height;
   GtkStyleContext *style = NULL;
@@ -684,15 +678,17 @@ meta_ui_theme_get_frame_borders (MetaUI *ui,
 
       meta_theme_get_frame_borders (meta_theme_get_current (),
                                     type, text_height, flags,
-                                    top_height, bottom_height,
-                                    left_width, right_width);
+                                    borders);
 
       if (free_font_desc)
         pango_font_description_free (free_font_desc);
     }
   else
     {
-      *top_height = *bottom_height = *left_width = *right_width = 0;
+      borders->visible.top = 0;
+      borders->visible.bottom = 0;
+      borders->visible.left = 0;
+      borders->visible.right = 0;
     }
 
   if (style != NULL)


### PR DESCRIPTION
This is mostly a bunch of backports, hacks, and undos from years past. The goal is to provide invisible resize borders. I had to refactor all the HiDPI handling stuff and use metacity's code to avoid graphical glitches with the window shadows...

Please **do not merge** this, as I would prefer to do this differently.