### PR TITLE
Fix Could not parse desktop file marco.desktop

### DIFF
--- a/src/marco.desktop.in
+++ b/src/marco.desktop.in
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-_Name=Marco
+Name=Marco
 Exec=marco
 NoDisplay=true
 # name of loadable control center module


### PR DESCRIPTION
mate-session[1210]: WARNING: Could not parse desktop file /usr/share/applications/marco.desktop: El fitxer de claus no conté una clau «Name» en el grup «Desktop Entry»
mate-session[1210]: GLib-GObject-CRITICAL: object GsmAutostartApp 0x7f158800ede0 finalized while still in-construction
mate-session[1210]: GLib-GObject-CRITICAL: Custom constructor for class GsmAutostartApp returned NULL (which is invalid). Please use GInitable instead.
mate-session[1210]: WARNING: could not read /usr/share/applications/marco.desktop