### PR TITLE
 bump LT_VERSION_INFO (soname version)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@ dnl **************************************************************************
 dnl Library version information
 dnl **************************************************************************
 
-m4_define([lt_current], [1])
+m4_define([lt_current], [2])
 m4_define([lt_revision], [0])
 m4_define([lt_age], [0])
 m4_define([lt_version_info], [lt_current:lt_revision:lt_age])

--- a/configure.ac
+++ b/configure.ac
@@ -16,6 +16,17 @@ AM_INIT_AUTOMAKE([subdir-objects no-dist-gzip dist-xz check-news])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AM_MAINTAINER_MODE
 
+dnl **************************************************************************
+dnl Library version information
+dnl **************************************************************************
+
+m4_define([lt_current], [1])
+m4_define([lt_revision], [0])
+m4_define([lt_age], [0])
+m4_define([lt_version_info], [lt_current:lt_revision:lt_age])
+
+AC_SUBST([LT_VERSION_INFO], [lt_version_info])
+
 # Honor aclocal flags
 AC_SUBST(ACLOCAL_AMFLAGS, "\${ACLOCAL_FLAGS}")
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -116,7 +116,7 @@ libmarco_private_la_SOURCES=			\
 	ui/ui.c \
 	include/all-keybindings.h
 
-libmarco_private_la_LDFLAGS = -no-undefined -version-info 1:0:0
+libmarco_private_la_LDFLAGS = -no-undefined -version-info $(LT_VERSION_INFO)
 libmarco_private_la_LIBADD = @MARCO_LIBS@
 
 libmarcoincludedir = $(includedir)/marco-1/marco-private


### PR DESCRIPTION
See docs https://www.sourceware.org/autobook/autobook/autobook_61.html#Library-Versioning

This is needed because current libmarco-private is incompatible to previous version.