### PR TITLE
fix make dist to remove .gmo files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -189,6 +189,7 @@ variables:
 
 build_scripts:
   - ./autogen.sh
+  - sed -i 's/$(POFILES) $(GMOFILES) \\/$(POFILES) \\/' po/Makefile.in.in
   - scan-build $CHECKERS ./configure
   - if [ $CPU_COUNT -gt 1 ]; then
   -     scan-build $CHECKERS --keep-cc -o html-report make -j $CPU_COUNT
@@ -206,6 +207,7 @@ after_scripts:
   -   ./gen-index -l 20 -i https://github.com/${OWNER_NAME}/mate-icon-theme/raw/master/mate/16x16/apps/preferences-system-windows.png
   - fi
   - make distcheck
+  - tar tf marco-*.tar.xz|grep po #just for view
 
 releases:
   draft: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -207,7 +207,6 @@ after_scripts:
   -   ./gen-index -l 20 -i https://github.com/${OWNER_NAME}/mate-icon-theme/raw/master/mate/16x16/apps/preferences-system-windows.png
   - fi
   - make distcheck
-  - tar tf marco-*.tar.xz|grep po #just for view
 
 releases:
   draft: false


### PR DESCRIPTION
Fix `make dist` include .gmo files.
The result of `$ tar tf marco-*.tar.xz|grep po`:
https://travis-ci.org/mate-desktop/marco/jobs/549023754#L2256
