### PR TITLE
fix dark window decorations on apps which prefer dark theme

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -264,7 +264,7 @@ meta_window_new_with_attrs (MetaDisplay       *display,
   gulong existing_wm_state;
   gulong event_mask;
   MetaMoveResizeFlags flags;
-#define N_INITIAL_PROPS 19
+#define N_INITIAL_PROPS 20
   Atom initial_props[N_INITIAL_PROPS];
   int i;
   gboolean has_shape;
@@ -623,6 +623,7 @@ meta_window_new_with_attrs (MetaDisplay       *display,
   initial_props[i++] = XA_WM_TRANSIENT_FOR;
   initial_props[i++] = display->atom__NET_WM_USER_TIME_WINDOW;
   initial_props[i++] = display->atom__NET_WM_FULLSCREEN_MONITORS;
+  initial_props[i++] = display->atom__GTK_THEME_VARIANT;
   g_assert (N_INITIAL_PROPS == i);
 
   meta_window_reload_properties (window, initial_props, N_INITIAL_PROPS, TRUE);

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -200,7 +200,7 @@ create_style_context (MetaFrames  *frames,
       provider = gtk_css_provider_get_named (theme_name, variant);
       gtk_style_context_add_provider (style,
                                       GTK_STYLE_PROVIDER (provider),
-                                      GTK_STYLE_PROVIDER_PRIORITY_THEME);
+                                      GTK_STYLE_PROVIDER_PRIORITY_SETTINGS);
     }
 
   if (theme_name)

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -233,20 +233,20 @@ static void
 update_style_contexts (MetaFrames *frames)
 {
   GtkStyleContext *style;
-  GList *variants, *variant;
+  GList *variant_list, *variant;
 
   if (frames->normal_style)
     g_object_unref (frames->normal_style);
   frames->normal_style = create_style_context (frames, NULL);
 
-  variants = g_hash_table_get_keys (frames->style_variants);
-  for (variant = variants; variant; variant = variants->next)
+  variant_list = g_hash_table_get_keys (frames->style_variants);
+  for (variant = variant_list; variant; variant = variant->next)
     {
       style = create_style_context (frames, (char *)variant->data);
       g_hash_table_insert (frames->style_variants,
                            g_strdup (variant->data), style);
     }
-  g_list_free (variants);
+  g_list_free (variant_list);
 }
 static void
 meta_frames_init (MetaFrames *frames)

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -50,8 +50,7 @@ static void meta_frames_class_init (MetaFramesClass *klass);
 static void meta_frames_init       (MetaFrames      *frames);
 static void meta_frames_destroy    (GtkWidget       *object);
 static void meta_frames_finalize   (GObject         *object);
-static void meta_frames_style_set  (GtkWidget       *widget,
-                                    GtkStyle        *prev_style);
+static void meta_frames_style_updated  (GtkWidget   *widget);
 static void meta_frames_realize    (GtkWidget       *widget);
 static void meta_frames_unrealize  (GtkWidget       *widget);
 
@@ -131,7 +130,7 @@ meta_frames_class_init (MetaFramesClass *class)
   gobject_class->constructor = meta_frames_constructor;
   gobject_class->finalize = meta_frames_finalize;
   widget_class->destroy = meta_frames_destroy;
-  widget_class->style_set = meta_frames_style_set;
+  widget_class->style_updated = meta_frames_style_updated;
   widget_class->realize = meta_frames_realize;
   widget_class->unrealize = meta_frames_unrealize;
 
@@ -483,8 +482,7 @@ reattach_style_func (gpointer key, gpointer value, gpointer data)
 }
 
 static void
-meta_frames_style_set  (GtkWidget *widget,
-                        GtkStyle  *prev_style)
+meta_frames_style_updated (GtkWidget *widget)
 {
   MetaFrames *frames;
 
@@ -496,7 +494,7 @@ meta_frames_style_set  (GtkWidget *widget,
   g_hash_table_foreach (frames->frames,
                         reattach_style_func, frames);
 
-  GTK_WIDGET_CLASS (meta_frames_parent_class)->style_set (widget, prev_style);
+  GTK_WIDGET_CLASS (meta_frames_parent_class)->style_updated (widget);
 }
 
 static void

--- a/src/ui/frames.h
+++ b/src/ui/frames.h
@@ -90,7 +90,7 @@ struct _MetaUIFrame
 
 struct _MetaFrames
 {
-  GtkInvisible parent_instance;
+  GtkWindow parent_instance;
 
   GHashTable *text_heights;
 
@@ -110,7 +110,7 @@ struct _MetaFrames
 
 struct _MetaFramesClass
 {
-  GtkInvisibleClass parent_class;
+  GtkWindowClass parent_class;
 };
 
 GType        meta_frames_get_type               (void) G_GNUC_CONST;

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -271,9 +271,12 @@ meta_ui_new (Display *xdisplay,
 
   g_assert (xdisplay == GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()));
   ui->frames = meta_frames_new ();
-  /* This does not actually show any widget. MetaFrames has been hacked so
-   * that showing it doesn't actually do anything. But we need the flags
-   * set for GTK to deliver events properly. */
+  /* GTK+ needs the frame-sync protocol to work in order to properly
+   * handle style changes. This means that the dummy widget we create
+   * to get the style for title bars actually needs to be mapped
+   * and fully tracked as a MetaWindow. Horrible, but mostly harmless -
+   * the window is a 1x1 overide redirect window positioned offscreen.
+   */
   gtk_widget_show (GTK_WIDGET (ui->frames));
 
   g_object_set_data (G_OBJECT (gdisplay), "meta-ui", ui);


### PR DESCRIPTION
This should completely fix #105, so that apps which prefer dark theme will also have dark window decoration if the theme supports that. If the theme doesn't support that, everything should work as before.

How to test:

1. Use some theme which has light and dark variants. Light variant should support dark theming for apps that prefer the dark theme (they set `gtk-application-prefer-dark-theme` in `GtkSettings`). I've used Arc theme.

2. Run some app which has the setting to prefer the dark theme. I've used gnome-terminal. Set the dark theme preference in `Edit > Preferences > General > Theme variant: Dark`.

Without this PR:

![dark1](https://user-images.githubusercontent.com/5138986/61369838-a7c9e580-a899-11e9-80d9-6d12adc2b9f6.png)

With this PR:

![dark2](https://user-images.githubusercontent.com/5138986/61369853-b1ebe400-a899-11e9-871a-81fa4b7e5961.png)
