### PR TITLE
 display.c: add missing "break"

### DIFF
--- a/src/core/display.c
+++ b/src/core/display.c
@@ -3809,7 +3809,7 @@ meta_display_begin_grab_op (MetaDisplay *display,
       meta_screen_ensure_tab_popup (screen,
                                     META_TAB_LIST_GROUP,
                                     META_TAB_SHOW_INSTANTLY);
-
+      break;
     case META_GRAB_OP_KEYBOARD_WORKSPACE_SWITCHING:
     case META_GRAB_OP_KEYBOARD_WORKSPACE_MOVING:
       meta_screen_ensure_workspace_popup (screen);


### PR DESCRIPTION
I'm not 100% sure, but I feel like `break` is missing here