### PR TITLE
Use WARN_CFLAGS which are only set with --enable-compiler-warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -192,8 +192,21 @@ variables:
     -enable-checker alpha.core.FixedAddr
     -enable-checker security.insecureAPI.strcpy"'
 
+before_scripts:
+  - cd ${START_DIR}
+  - '[ -f mate-common-1.23.3.tar.xz ] || curl -Ls -o mate-common-1.23.3.tar.xz http://pub.mate-desktop.org/releases/1.23/mate-common-1.23.3.tar.xz'
+  - tar xf mate-common-1.23.3.tar.xz
+  - cd mate-common-1.23.3
+  - if [ ${DISTRO_NAME} == "debian" -o ${DISTRO_NAME} == "ubuntu" ];then
+  -     ./configure --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu --libexecdir=/usr/lib/x86_64-linux-gnu
+  - else
+  -     ./configure --prefix=/usr
+  - fi
+  - make
+  - make install
+
 build_scripts:
-  - ./autogen.sh
+  - ./autogen.sh --enable-compile-warnings=maximum
   - scan-build $CHECKERS ./configure
   - if [ $CPU_COUNT -gt 1 ]; then
   -     scan-build $CHECKERS --keep-cc -o html-report make -j $CPU_COUNT

--- a/configure.ac
+++ b/configure.ac
@@ -16,6 +16,7 @@ AM_INIT_AUTOMAKE([subdir-objects no-dist-gzip dist-xz check-news])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AM_MAINTAINER_MODE
 AX_CHECK_ENABLE_DEBUG()
+MATE_COMPILE_WARNINGS
 
 dnl **************************************************************************
 dnl Library version information
@@ -53,17 +54,6 @@ AC_CHECK_SIZEOF(__int64)
 
 ## byte order
 AC_C_BIGENDIAN
-
-#### Warnings
-AX_APPEND_COMPILE_FLAGS([-Wall -Wcast-align -Wchar-subscripts -Werror=format-security -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wpointer-arith -Wsign-compare -Wshadow], [CFLAGS])
-AC_ARG_ENABLE(more-warnings,
-  AC_HELP_STRING([--enable-more-warnings], [Maximum compiler warnings]),
-    set_more_warnings="$enableval",
-    set_more_warnings=no
-)
-if test "$set_more_warnings" != "no"; then
-  AX_APPEND_COMPILE_FLAGS([-Wextra], [CFLAGS])
-fi
 
 GIO_MIN_VERSION=2.25.10
 GTK_MIN_VERSION=3.22.0

--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,7 @@ AM_INIT_AUTOMAKE([subdir-objects no-dist-gzip dist-xz check-news])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AM_MAINTAINER_MODE
 AX_CHECK_ENABLE_DEBUG()
-MATE_COMPILE_WARNINGS
+MATE_COMPILE_WARNINGS([yes])
 
 dnl **************************************************************************
 dnl Library version information

--- a/configure.ac
+++ b/configure.ac
@@ -455,6 +455,8 @@ marco-$VERSION:
 	prefix:                   ${prefix}
 	source code location:     ${srcdir}
 	compiler:                 ${CC}
+        compiler flags:           ${CFLAGS}
+        compiler warnings:        ${WARN_CFLAGS}
 
 	XFree86 Xinerama:         ${use_xfree_xinerama}
 	Solaris Xinerama:         ${use_solaris_xinerama}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -11,7 +11,8 @@ AM_CPPFLAGS = \
 	-DMARCO_DATADIR=\"$(datadir)\" \
 	-DG_LOG_DOMAIN=\"marco\" \
 	-DSN_API_NOT_YET_FROZEN=1 \
-	@MARCO_CFLAGS@
+	@MARCO_CFLAGS@ \
+	$(WARN_CFLAGS)
 
 marco_SOURCES= 				\
 	core/main.c				\

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -1,9 +1,12 @@
 icondir=$(pkgdatadir)/icons
 icon_DATA=marco-window-demo.png
 
-AM_CPPFLAGS=@MARCO_WINDOW_DEMO_CFLAGS@ @MARCO_MESSAGE_CFLAGS@ \
+AM_CPPFLAGS =					\
+	@MARCO_WINDOW_DEMO_CFLAGS@		\
+	@MARCO_MESSAGE_CFLAGS@			\
 	-DMARCO_ICON_DIR=\"$(pkgdatadir)/icons\" \
-	-DMARCO_LOCALEDIR=\"$(prefix)/@DATADIRNAME@/locale\"
+	-DMARCO_LOCALEDIR=\"$(prefix)/@DATADIRNAME@/locale\" \
+	$(WARN_CFLAGS)
 
 marco_message_SOURCES= 				\
 	marco-message.c

--- a/src/wm-tester/Makefile.am
+++ b/src/wm-tester/Makefile.am
@@ -1,5 +1,7 @@
 
-AM_CPPFLAGS=@MARCO_CFLAGS@
+AM_CPPFLAGS = \
+	@MARCO_CFLAGS@ \
+	$(WARN_CFLAGS)
 
 wm_tester_SOURCES= 				\
 	main.c


### PR DESCRIPTION
It removes --enable-more-warnings, since it is recommended to use
--enable-compile-warnings=maximum