### PR TITLE
Set compiler debug flags using MATE_DEBUG_CHECK

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@ AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([subdir-objects no-dist-gzip dist-xz check-news])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AM_MAINTAINER_MODE
-AX_CHECK_ENABLE_DEBUG()
+MATE_DEBUG_CHECK([no])
 MATE_COMPILE_WARNINGS([yes])
 
 dnl **************************************************************************


### PR DESCRIPTION
--enable-debug=yes/info/profile/no

By default, compiler debug flags are disabled.

Test 1:
```
$ ./autogen.sh && grep "^CFLAGS" config.log
CFLAGS=' -Wall -Wcast-align -Wchar-subscripts -Werror=format-security -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wpointer-arith -Wsign-compare -Wshadow'
```
Test 2:
```
$ ./autogen.sh --enable-debug && grep "^CFLAGS" config.log
CFLAGS=' -g -O0 -Wall -Wcast-align -Wchar-subscripts -Werror=format-security -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wpointer-arith -Wsign-compare -Wshadow'
```
It requires https://github.com/mate-desktop/mate-common/pull/29