### PR TITLE
Fix MARCO_LOCALEDIR displaying the translated messages

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -6,7 +6,7 @@ AM_CPPFLAGS = \
 	-I$(srcdir)/include \
 	-DMARCO_LIBEXECDIR=\"$(libexecdir)\" \
 	-DHOST_ALIAS=\"@HOST_ALIAS@\" \
-	-DMARCO_LOCALEDIR=\"$(prefix)/@DATADIRNAME@/locale\" \
+	-DMARCO_LOCALEDIR=\""$(datadir)/locale"\" \
 	-DMARCO_PKGDATADIR=\"$(pkgdatadir)\" \
 	-DMARCO_DATADIR=\"$(datadir)\" \
 	-DG_LOG_DOMAIN=\"marco\" \


### PR DESCRIPTION
DATADIRNAME was established by [glib-gettext.m4](https://github.com/GNOME/glib/blob/master/m4macros/glib-gettext.m4) before the migration to gettext in https://github.com/mate-desktop/marco/commit/3324c2850b96cb99efb0c90cbf37e563a17f6f7b.
Use $([datadir](https://www.gnu.org/software/automake/manual/html_node/Standard-Directory-Variables.html))/locale instead of $(prefix)/@DATADIRNAME@/locale from now on.
### Before

![Captura de pantalla a 2019-10-12 00-19-58](https://user-images.githubusercontent.com/10171411/66688322-6d989600-ec86-11e9-8a61-f7ad920a9272.png)

![Captura de pantalla a 2019-10-12 00-20-49](https://user-images.githubusercontent.com/10171411/66688323-6d989600-ec86-11e9-9fef-2b5babb089ba.png)

### After
Catalan screenshots:

![Captura de pantalla a 2019-10-12 00-16-06](https://user-images.githubusercontent.com/10171411/66688339-7c7f4880-ec86-11e9-8a64-a753cc713f25.png)

![Captura de pantalla a 2019-10-12 00-17-43](https://user-images.githubusercontent.com/10171411/66688341-7c7f4880-ec86-11e9-82df-2b26992836b9.png)
