### PR TITLE
tabpopup: Draw popups as OSD windows

### DIFF
--- a/src/core/prefs.c
+++ b/src/core/prefs.c
@@ -1137,7 +1137,10 @@ meta_prefs_get_cursor_size (void)
 int
 meta_prefs_get_icon_size (void)
 {
-  return icon_size;
+  GdkWindow *window = gdk_get_default_root_window ();
+  gint scale = gdk_window_get_scale_factor (window);
+
+  return icon_size * scale;
 }
 
 int

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -6115,7 +6115,7 @@ meta_window_update_icon_now (MetaWindow *window)
 
   icon = NULL;
   mini_icon = NULL;
-  
+
   int icon_size = meta_prefs_get_icon_size();
 
   if (meta_read_icons (window->screen,

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -320,8 +320,8 @@ void meta_frame_borders_clear (MetaFrameBorders *self);
 
 /* should investigate changing these to whatever most apps use */
 #define META_DEFAULT_ICON_SIZE 48
-#define META_MIN_ICON_SIZE 6
-#define META_MAX_ICON_SIZE 480
+#define META_MIN_ICON_SIZE 8
+#define META_MAX_ICON_SIZE 256
 
 #define META_MINI_ICON_WIDTH 16
 #define META_MINI_ICON_HEIGHT 16
@@ -349,7 +349,7 @@ typedef enum
 
 #define META_DEFAULT_ALT_TAB_MAX_COLUMNS 5
 #define META_MIN_ALT_TAB_MAX_COLUMNS 1
-#define META_MAX_ALT_TAB_MAX_COLUMNS 1024
+#define META_MAX_ALT_TAB_MAX_COLUMNS 16
 
 #define META_DEFAULT_ALT_TAB_EXPAND_TO_FIT_TITLE FALSE
 

--- a/src/include/tabpopup.h
+++ b/src/include/tabpopup.h
@@ -49,6 +49,7 @@ struct _MetaTabEntry
   MetaTabEntryKey  key;
   const char      *title;
   GdkPixbuf       *icon;
+  cairo_surface_t *win_surface;
   MetaRectangle    rect;
   MetaRectangle    inner_rect;
   guint            blank : 1;

--- a/src/org.mate.marco.gschema.xml
+++ b/src/org.mate.marco.gschema.xml
@@ -154,7 +154,7 @@
     <key name="compositing-fast-alt-tab" type="b">
       <default>false</default>
       <summary>Fast Alt-Tab with compositing manager (disable thumbnails)</summary>
-      <description>If set to true, no window thumbnails will be displayed in the alt-tab popup window when the compositing manager is enabled. Application icons will be displayed instead.</description>
+      <description>If set to true, no window thumbnails will be displayed in the alt-tab popup window when the compositing manager is enabled. Application icons will be displayed instead. Note that on high resolution screens with many visible windows there can be a perceptible lag in rendering.</description>
     </key>
     <key name="reduced-resources" type="b">
       <default>false</default>
@@ -197,13 +197,13 @@
         <description>Comma separated class list. Each running GUI application referenced to given windows manager class will be ignored by 'Show Desktop' functionality.</description>
     </key>
     <key name="icon-size" type="i">
-        <range min="6" max="480"/>
+        <range min="8" max="256"/>
         <default>48</default>
-        <summary>Icon size</summary>
+        <summary>Icon size in alt-tab popup window</summary>
         <description>Size of the application icons displayed in alt-tab popup window. The screen's scale factor is applied to this value.</description>
     </key>
     <key name="alt-tab-max-columns" type="i">
-        <range min="1" max="1024"/>
+        <range min="1" max="16"/>
         <default>5</default>
         <summary>Maximum number of columns in alt-tab popup window</summary>
         <description>The popup window will be expanded to fit up to these many entries per row.</description>

--- a/src/ui/tabpopup.c
+++ b/src/ui/tabpopup.c
@@ -912,7 +912,7 @@ struct _MetaSelectWorkspaceClass
 static GType meta_select_workspace_get_type (void) G_GNUC_CONST;
 
 #define SELECT_OUTLINE_WIDTH 2
-#define MINI_WORKSPACE_SCALE 2
+#define MINI_WORKSPACE_SCREEN_FRACTION 0.33
 
 static GtkWidget*
 selectable_workspace_new (MetaWorkspace *workspace, int entry_count)
@@ -929,20 +929,20 @@ selectable_workspace_new (MetaWorkspace *workspace, int entry_count)
   if (workspace->screen->rect.width < workspace->screen->rect.height)
   {
     mini_workspace_ratio = (double) workspace->screen->rect.width / (double) workspace->screen->rect.height;
-    mini_workspace_height = (int) ((double) current->rect.height / entry_count - SELECT_OUTLINE_WIDTH * 2);
+    mini_workspace_height = (int) ((double) current->rect.height * MINI_WORKSPACE_SCREEN_FRACTION / entry_count);
     mini_workspace_width = (int) ((double) mini_workspace_height * mini_workspace_ratio);
   }
   else
   {
     mini_workspace_ratio = (double) workspace->screen->rect.height / (double) workspace->screen->rect.width;
-    mini_workspace_width = (int) ((double) current->rect.width / entry_count - SELECT_OUTLINE_WIDTH * 2);
+    mini_workspace_width = (int) ((double) current->rect.width * MINI_WORKSPACE_SCREEN_FRACTION / entry_count);
     mini_workspace_height = (int) ((double) mini_workspace_width * mini_workspace_ratio);
   }
 
   /* account for select rect */
   gtk_widget_set_size_request (widget,
-                               mini_workspace_width / MINI_WORKSPACE_SCALE,
-                               mini_workspace_height / MINI_WORKSPACE_SCALE);
+                               mini_workspace_width + SELECT_OUTLINE_WIDTH * 2,
+                               mini_workspace_height + SELECT_OUTLINE_WIDTH * 2);
 
   META_SELECT_WORKSPACE (widget)->workspace = workspace;
 
@@ -1114,7 +1114,7 @@ meta_select_workspace_draw (GtkWidget *widget,
       gtk_style_context_set_state (context,
                                    gtk_widget_get_state_flags (widget));
 
-      gtk_style_context_lookup_color (context, "color", &color);
+      meta_gtk_style_get_light_color (context, GTK_STATE_FLAG_SELECTED, &color);
 
       cairo_set_line_width (cr, SELECT_OUTLINE_WIDTH);
       cairo_set_source_rgb (cr, color.red, color.green, color.blue);


### PR DESCRIPTION
This changes how the Alt+Tab and Workspace Switcher popups are drawn. The are now styled as OSD windows with a bunch of stylistic improvements. Also more things are drawn as cairo surfaces and some gschema values have been changed to make them compatible with the new design.