### PR TITLE
window: Add optional tile size cycling

### DIFF
--- a/src/core/prefs.c
+++ b/src/core/prefs.c
@@ -130,6 +130,7 @@ static gboolean center_new_windows = FALSE;
 static gboolean force_fullscreen = TRUE;
 static gboolean allow_tiling = FALSE;
 static gboolean allow_top_tiling = TRUE;
+static gboolean allow_tile_cycling = TRUE;
 static GList *show_desktop_skip_list = NULL;
 
 static MetaVisualBellType visual_bell_type = META_VISUAL_BELL_FULLSCREEN_FLASH;
@@ -441,6 +442,12 @@ static MetaBoolPreference preferences_bool[] =
       KEY_GENERAL_SCHEMA,
       META_PREF_ALLOW_TOP_TILING,
       &allow_top_tiling,
+      FALSE,
+    },
+    { "allow-tile-cycling",
+      KEY_GENERAL_SCHEMA,
+      META_PREF_ALLOW_TILE_CYCLING,
+      &allow_tile_cycling,
       FALSE,
     },
     { "alt-tab-expand-to-fit-title",
@@ -1700,6 +1707,9 @@ meta_preference_to_string (MetaPreference pref)
     case META_PREF_ALLOW_TOP_TILING:
       return "ALLOW_TOP_TILING";
 
+    case META_PREF_ALLOW_TILE_CYCLING:
+      return "ALLOW_TILE_CYCLING";
+
     case META_PREF_PLACEMENT_MODE:
       return "PLACEMENT_MODE";
 
@@ -2388,6 +2398,12 @@ gboolean
 meta_prefs_get_allow_top_tiling ()
 {
   return allow_top_tiling;
+}
+
+gboolean
+meta_prefs_get_allow_tile_cycling ()
+{
+  return allow_tile_cycling;
 }
 
 guint

--- a/src/core/window-private.h
+++ b/src/core/window-private.h
@@ -83,6 +83,15 @@ typedef enum {
   META_QUEUE_UPDATE_ICON  = 1 << 2,
 } MetaQueueType;
 
+typedef enum {
+  META_TILE_CYCLE_NONE,
+  META_TILE_CYCLE_50,
+  META_TILE_CYCLE_33,
+  META_TILE_CYCLE_25,
+  META_TILE_CYCLE_75,
+  META_TILE_CYCLE_66
+} MetaTileCycle;
+
 #define NUMBER_OF_QUEUES 3
 
 struct _MetaWindow
@@ -150,6 +159,7 @@ struct _MetaWindow
   guint tile_mode : 3;
   guint tile_resized : 1;
   guint tiled : 1;
+  guint tile_cycle : 3;
 
   /* The last "full" maximized/unmaximized state. We need to keep track of
    * that to toggle between normal/tiled or maximized/tiled states. */

--- a/src/include/prefs.h
+++ b/src/include/prefs.h
@@ -70,6 +70,7 @@ typedef enum
   META_PREF_CENTER_NEW_WINDOWS,
   META_PREF_ALLOW_TILING,
   META_PREF_ALLOW_TOP_TILING,
+  META_PREF_ALLOW_TILE_CYCLING,
   META_PREF_FORCE_FULLSCREEN,
   META_PREF_PLACEMENT_MODE,
   META_PREF_SHOW_DESKTOP_SKIP_LIST
@@ -107,6 +108,7 @@ gboolean                    meta_prefs_get_mate_accessibility (void);
 gboolean                    meta_prefs_get_mate_animations    (void);
 gboolean                    meta_prefs_get_allow_tiling       (void);
 gboolean                    meta_prefs_get_allow_top_tiling   (void);
+gboolean                    meta_prefs_get_allow_tile_cycling (void);
 
 const char*                 meta_prefs_get_command            (int i);
 

--- a/src/org.mate.marco.gschema.xml
+++ b/src/org.mate.marco.gschema.xml
@@ -186,6 +186,11 @@
       <summary>Whether to maximize the window when dragged to the top of the screen</summary>
       <description>If enabled, drag-dropping a window to the top of the screen will maximize it. Only works when allow-tiling is enabled.</description>
     </key>
+    <key name="allow-tile-cycling" type="b">
+      <default>true</default>
+      <summary>Whether to enable cycling through different tile sizes</summary>
+      <description>If enabled, tiling a window will cycle through multiple different sizes by using the same keyboard shortcut multiple times in a row.</description>
+    </key>
     <key name="placement-mode" enum="org.mate.Marco.placement_type">
       <default>'automatic'</default>
       <summary>Window placement mode</summary>


### PR DESCRIPTION
Adding a new option to allow tile size cycling. When enabled, using the
keyboard shortcut for tiling multiple times in a row cycles the window
through different sizes (1/2 -> 1/3 -> 1/4 -> 3/4 -> 2/3 -> Untiled).