### PR TITLE
Revert "compositor: fix possible crash closing/destroying window"

### DIFF
--- a/src/compositor/compositor-private.h
+++ b/src/compositor/compositor-private.h
@@ -50,9 +50,6 @@ struct _MetaCompositor
                              MetaScreen     *screen,
                              MetaWindow     *window);
 
-  void (*free_window) (MetaCompositor *compositor,
-                       MetaWindow     *window);
-
   void (*maximize_window)   (MetaCompositor *compositor,
                              MetaWindow     *window);
   void (*unmaximize_window) (MetaCompositor *compositor,

--- a/src/compositor/compositor-xrender.c
+++ b/src/compositor/compositor-xrender.c
@@ -3040,38 +3040,23 @@ xrender_end_move (MetaCompositor *compositor,
 #ifdef HAVE_COMPOSITE_EXTENSIONS
 #endif
 }
-#endif /* 0 */
 
 static void
 xrender_free_window (MetaCompositor *compositor,
                      MetaWindow     *window)
 {
 #ifdef HAVE_COMPOSITE_EXTENSIONS
-  MetaCompositorXRender *xrc;
-  MetaFrame *frame;
-  Window xwindow;
+  /* FIXME: When an undecorated window is hidden this is called,
+     but the window does not get readded if it is subsequentally shown again
+     See http://bugzilla.gnome.org/show_bug.cgi?id=504876
 
-  xrc = (MetaCompositorXRender *) compositor;
-  frame = meta_window_get_frame (window);
-  xwindow = None;
-
-  if (frame)
-    {
-      xwindow = meta_frame_get_xwindow (frame);
-    }
-  else
-    {
-      /* FIXME: When an undecorated window is hidden this is called, but the
-       * window does not get readded if it is subsequentally shown again. See:
-       * http://bugzilla.gnome.org/show_bug.cgi?id=504876
-       */
-      /* xwindow = meta_window_get_xwindow (window); */
-    }
-
-  if (xwindow != None)
-    destroy_win (xrc->display, xwindow, FALSE);
+     I don't *think* theres any need for this call anyway, leaving it out
+     does not seem to cause any side effects so far, but I should check with
+     someone who understands more. */
+  /* destroy_win (compositor->display, window->xwindow, FALSE); */
 #endif
 }
+#endif /* 0 */
 
 static void
 xrender_process_event (MetaCompositor *compositor,
@@ -3375,7 +3360,6 @@ static MetaCompositor comp_info = {
   xrender_process_event,
   xrender_get_window_surface,
   xrender_set_active_window,
-  xrender_free_window,
   xrender_maximize_window,
   xrender_unmaximize_window,
 };

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -156,10 +156,6 @@ void meta_compositor_end_move (MetaCompositor *compositor,
 void meta_compositor_free_window (MetaCompositor *compositor,
                                   MetaWindow     *window)
 {
-#ifdef HAVE_COMPOSITE_EXTENSIONS
-  if (compositor && compositor->free_window)
-    compositor->free_window (compositor, window);
-#endif
 }
 
 void


### PR DESCRIPTION
This reverts commit df56628979abc17474b001c58c28c6f3637ada9d.

It causes an issue where windows remain in the background even when
being drawn in the foreground.