### PR TITLE
theme.c: Fix window control hidpi rendering for all themes.

### DIFF
--- a/src/ui/theme.c
+++ b/src/ui/theme.c
@@ -4134,8 +4134,8 @@ meta_draw_op_draw_with_env (const MetaDrawOp    *op,
 
         if (op->data.image.pixbuf)
           {
-            env->object_width = gdk_pixbuf_get_width (op->data.image.pixbuf);
-            env->object_height = gdk_pixbuf_get_height (op->data.image.pixbuf);
+            env->object_width = gdk_pixbuf_get_width (op->data.image.pixbuf) / scale;
+            env->object_height = gdk_pixbuf_get_height (op->data.image.pixbuf) / scale;
           }
 
         rwidth = parse_size_unchecked (op->data.image.width, env) * scale;
@@ -5672,7 +5672,19 @@ meta_theme_load_image (MetaTheme  *theme,
           char *full_path;
           full_path = g_build_filename (theme->dirname, filename, NULL);
 
-          pixbuf = gdk_pixbuf_new_from_file (full_path, error);
+          gint width, height;
+
+          if (gdk_pixbuf_get_file_info (full_path, &width, &height) == NULL)
+            {
+              g_free (full_path);
+              return NULL;
+            }
+
+          width *= scale;
+          height *= scale;
+
+          pixbuf = gdk_pixbuf_new_from_file_at_size (full_path, width, height, error);
+
           if (pixbuf == NULL)
             {
               g_free (full_path);


### PR DESCRIPTION
By scaling the pixbuf when loading, existing assets can be used.

meta_theme_load_image() is only run once for each image when the theme loads, so the cost of loading them twice is relatively minor.

Examples (in hidpi):
![Screenshot from 2019-12-05 12-13-18](https://user-images.githubusercontent.com/262776/70258159-b5eda500-1759-11ea-8881-59a94ad996c9.png)

![Screenshot from 2019-12-05 12-09-52](https://user-images.githubusercontent.com/262776/70258163-b71ed200-1759-11ea-90e3-b1dab31f00d8.png)
(this is with or without https://github.com/mate-desktop/mate-themes/commit/8f56d6be5a2e3116699703da9f103a964ee7222d)
