### PR TITLE
Xprops fix memory leak.

### DIFF
--- a/src/core/xprops.c
+++ b/src/core/xprops.c
@@ -652,21 +652,27 @@ text_property_to_utf8 (Display             *xdisplay,
 {
   char *ret = NULL;
   char **local_list = NULL;
+  const char *charset = NULL;
   int count = 0;
   int res;
 
   res = XmbTextPropertyToTextList (xdisplay, prop, &local_list, &count);
   if (res == XNoMemory || res == XLocaleNotSupported || res == XConverterNotFound)
-    goto out;
+    return NULL;
 
   if (count == 0)
-    goto out;
+  {
+	XFreeStringList (local_list);
+	return NULL;
+  }
+	
+  if (g_get_charset (&charset))
+    ret = g_strdup (local_list[0]);
+  else
+    ret = g_convert (local_list[0], -1, "UTF-8", charset, NULL, NULL, NULL);
 
-  ret = g_strdup (local_list[0]);
-
-  out:
-    meta_XFree (local_list);
-    return ret;
+  XFreeStringList (local_list);
+  return ret;
 }
 
 static gboolean


### PR DESCRIPTION
Backports a fix for a memory leak fixed on Metacity but not on Marco.
This brings down normal usage on my machine from 256 Mb to 180 something

Origin commit :
https://gitlab.gnome.org/GNOME/metacity/commit/c87f73f3b4413720a2f3e6a672826d3fec7f77a9
"
XmbTextPropertyToTextList documentation says that XFreeStringList
should be used to free the storage for the list and its contents.
"