### PR TITLE
util: meta_bug raises SIGABRT so it shouldn't return

### DIFF
--- a/src/core/util.c
+++ b/src/core/util.c
@@ -363,7 +363,7 @@ meta_bug (const char *format, ...)
   gchar *str;
   FILE *out;
 
-  g_return_if_fail (format != NULL);
+  g_assert (format != NULL);
 
   va_start (args, format);
   str = g_strdup_vprintf (format, args);

--- a/src/include/util.h
+++ b/src/include/util.h
@@ -43,7 +43,7 @@ void meta_verbose_real    (const char *format,
                            ...) G_GNUC_PRINTF (1, 2);
 
 void meta_bug        (const char *format,
-                      ...) G_GNUC_PRINTF (1, 2);
+                      ...) G_GNUC_PRINTF (1, 2) G_GNUC_NORETURN G_ANALYZER_NORETURN;
 void meta_warning    (const char *format,
                       ...) G_GNUC_PRINTF (1, 2);
 void meta_fatal      (const char *format,


### PR DESCRIPTION
It removes the warnings below:
```
core/core.c:505:3: warning: dereference of NULL ‘window’ [CWE-690] [-Wanalyzer-null-dereference]
  505 |   meta_window_change_workspace (window,
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  506 |                                 meta_screen_get_workspace_by_index (window->screen,
      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  507 |                                                                     new_workspace));
      |                                                                     ~~~~~~~~~~~~~~~
  ‘meta_core_change_workspace’: events 1-2
    |
    |  499 | meta_core_change_workspace (Display *xdisplay,
    |      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
    |      | |
    |      | (1) entry to ‘meta_core_change_workspace’
    |......
    |  503 |   MetaWindow *window = get_window (xdisplay, frame_xwindow);
    |      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    |      |                        |
    |      |                        (2) calling ‘get_window’ from ‘meta_core_change_workspace’
    |
    +--> ‘get_window’: events 3-5
           |
           |   45 | get_window (Display *xdisplay,
           |      | ^~~~~~~~~~
           |      | |
           |      | (3) entry to ‘get_window’
           |......
           |   54 |   if (window == NULL || window->frame == NULL)
           |      |      ~
           |      |      |
           |      |      (4) following ‘true’ branch (when ‘window’ is NULL)...
           |   55 |     {
           |   56 |       meta_bug ("No such frame window 0x%lx!\n", frame_xwindow);
           |      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           |      |       |
           |      |       (5) ...to here
           |
         ‘get_window’: event 6
           |
           |cc1:
           | (6): assuming ‘<return-value>’ is NULL
           |
    <------+
    |
  ‘meta_core_change_workspace’: events 7-8
    |
    |  503 |   MetaWindow *window = get_window (xdisplay, frame_xwindow);
    |      |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    |      |                        |
    |      |                        (7) return of NULL to ‘meta_core_change_workspace’ from ‘get_window’
    |  504 | 
    |  505 |   meta_window_change_workspace (window,
    |      |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    |      |   |
    |      |   (8) dereference of NULL ‘window’
    |  506 |                                 meta_screen_get_workspace_by_index (window->screen,
    |      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    |  507 |                                                                     new_workspace));
    |      |                                                                     ~~~~~~~~~~~~~~~
    |
core/core.c:505:3: note: 1 duplicate
  505 |   meta_window_change_workspace (window,
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  506 |                                 meta_screen_get_workspace_by_index (window->screen,
      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  507 |                                                                     new_workspace));
      |                                                                     ~~~~~~~~~~~~~~~
```

```
In function ‘meta_core_set_screen_cursor’:
core/core.c:779:3: warning: dereference of NULL ‘window’ [CWE-690] [-Wanalyzer-null-dereference]
  779 |   meta_frame_set_screen_cursor (window->frame, cursor);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  ‘meta_core_set_screen_cursor’: events 1-2
    |
    |  773 | meta_core_set_screen_cursor (Display *xdisplay,
    |      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
    |      | |
    |      | (1) entry to ‘meta_core_set_screen_cursor’
    |......
    |  777 |   MetaWindow *window = get_window (xdisplay, frame_on_screen);
    |      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    |      |                        |
    |      |                        (2) calling ‘get_window’ from ‘meta_core_set_screen_cursor’
    |
    +--> ‘get_window’: events 3-5
           |
           |   45 | get_window (Display *xdisplay,
           |      | ^~~~~~~~~~
           |      | |
           |      | (3) entry to ‘get_window’
           |......
           |   54 |   if (window == NULL || window->frame == NULL)
           |      |      ~
           |      |      |
           |      |      (4) following ‘true’ branch (when ‘window’ is NULL)...
           |   55 |     {
           |   56 |       meta_bug ("No such frame window 0x%lx!\n", frame_xwindow);
           |      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           |      |       |
           |      |       (5) ...to here
           |
         ‘get_window’: event 6
           |
           |cc1:
           | (6): assuming ‘<return-value>’ is NULL
           |
    <------+
    |
  ‘meta_core_set_screen_cursor’: events 7-8
    |
    |  777 |   MetaWindow *window = get_window (xdisplay, frame_on_screen);
    |      |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    |      |                        |
    |      |                        (7) return of NULL to ‘meta_core_set_screen_cursor’ from ‘get_window’
    |  778 | 
    |  779 |   meta_frame_set_screen_cursor (window->frame, cursor);
    |      |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    |      |   |
    |      |   (8) dereference of NULL ‘window’
    |
core/core.c:779:3: note: 1 duplicate
  779 |   meta_frame_set_screen_cursor (window->frame, cursor);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```