### PR TITLE
window: sync up command line option and code behavior.

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -4954,7 +4954,7 @@ meta_window_move_resize_request (MetaWindow *window,
        * workarea smaller than the monitor.
        */
       if (meta_prefs_get_force_fullscreen() &&
-          (window->decorated || !meta_window_is_client_decorated (window)) &&
+          (!window->decorated && !meta_window_is_client_decorated (window)) &&
           meta_rectangle_equal (&rect, &xinerama_info->rect) &&
           window->has_fullscreen_func &&
           !window->fullscreen)


### PR DESCRIPTION
The description for `--no-force-fullscreen` explicitly states that it
disables forcing fullscreen mode on windows that have *no* decorations
and are screen-sized.

Up until now, the code directly contradicted that by running the part
only if either the decorations where *enabled* or no CSD being used.

That causes multiple problems.

First, modern video players, which can certainly not be regarded as
"legacy applications", that try to show the video window as big as
possible and hence set the extents to exactly the screen size, including
using static gravity (so that borders are NOT removed from the window
size automatically) but still request window decorations are wrongly forced into
fullscreen mode by this hack. Changing the gravity would work around
that problem because the window size is effectively lowered, but we
can't expect applications to work around bugs in marco.

Secondly, the check for window decorations (or not) gets completely
cancelled out by the OR'd check for no CSD. According to the original
commit message, this hasn't been the intention, but rather to NOT force
fullscreen mode on windows that have no decorations and are CSD. It was
meant well, but the logic behind the change failed to do what it was
supposed to do.

Hence, fix that by checking if an application explicitly disabled window
decorations *AND* is not CSD.

This syncs up the help description and code behavior and fixes the CSD
part, but note that, naturally, it also changes the general behavior.
Specifically, this might break cases in which applications were supposed
to be forced into fullscreen mode even though they didn't explicitly
disable window decorations. I'd argue that such behavior would rather be
a bug and not a feature, though.