### PR TITLE
Remove unnecessary warnings about visible region

### DIFF
--- a/src/compositor/compositor-xrender.c
+++ b/src/compositor/compositor-xrender.c
@@ -1153,13 +1153,9 @@ border_size (MetaCompWindow *cw)
     {
       visible_region = meta_window_get_frame_bounds (cw->window);
 
-      if (visible_region != NULL) {
+      if (visible_region != NULL)
         visible = cairo_region_to_xserver_region (xdisplay, visible_region);
-      }
-      else {
-        g_warning ("Visible region is null");
     }
-  }
 
   meta_error_trap_push (display);
   border = XFixesCreateRegionFromWindow (xdisplay, cw->id,

--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -407,12 +407,13 @@ meta_frame_sync_to_window (MetaFrame *frame,
 cairo_region_t *
 meta_frame_get_frame_bounds (MetaFrame *frame)
 {
-  if(frame->xwindow && frame->window !=NULL && frame->window->screen  !=NULL && frame->window->screen->ui !=NULL)  {
-	return meta_ui_get_frame_bounds (frame->window->screen->ui,
-                                     frame->xwindow,
-                                     frame->rect.width,
-                                     frame->rect.height);
-  }
+  if (frame->xwindow && frame->window != NULL && frame->window->screen != NULL && frame->window->screen->ui != NULL)
+    {
+      return meta_ui_get_frame_bounds (frame->window->screen->ui,
+                                       frame->xwindow,
+                                       frame->rect.width,
+                                       frame->rect.height);
+    }
   return NULL;
 }
 


### PR DESCRIPTION
This latest change works fine, but floods my logs with
```
Window manager warning: Log level 16: Visible region is null
```

Also reformatted recent code change to fix styling issues.