### PR TITLE
Remove enum conversion warnings

### DIFF
--- a/src/tools/marco-window-demo.c
+++ b/src/tools/marco-window-demo.c
@@ -1051,7 +1051,7 @@ do_appwindow (GSimpleAction *action,
 
   contents = gtk_text_view_new ();
   gtk_text_view_set_wrap_mode (GTK_TEXT_VIEW (contents),
-                               PANGO_WRAP_WORD);
+                               GTK_WRAP_WORD);
 
   gtk_container_add (GTK_CONTAINER (sw),
                      contents);

--- a/src/ui/draw-workspace.c
+++ b/src/ui/draw-workspace.c
@@ -89,7 +89,7 @@ draw_window (GtkWidget                   *widget,
              cairo_t                     *cr,
              const WnckWindowDisplayInfo *win,
              const GdkRectangle          *winrect,
-             GtkStateType                state)
+             GtkStateFlags                state)
 {
   cairo_surface_t *icon;
   int icon_x, icon_y, icon_w, icon_h, scale;

--- a/src/ui/theme-parser.c
+++ b/src/ui/theme-parser.c
@@ -2340,7 +2340,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
       const char *height;
       const char *filled;
       gboolean filled_val;
-      GtkStateType state_val;
+      GtkStateFlags state_val;
       GtkShadowType shadow_val;
       GtkArrowType arrow_val;
 
@@ -2430,7 +2430,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
       const char *y;
       const char *width;
       const char *height;
-      GtkStateType state_val;
+      GtkStateFlags state_val;
       GtkShadowType shadow_val;
 
       if (!locate_attributes (context, element_name, attribute_names, attribute_values,
@@ -2498,7 +2498,7 @@ parse_draw_op_element (GMarkupParseContext  *context,
       const char *x;
       const char *y1;
       const char *y2;
-      GtkStateType state_val;
+      GtkStateFlags state_val;
 
       if (!locate_attributes (context, element_name, attribute_names, attribute_values,
                               error,

--- a/src/ui/theme-viewer.c
+++ b/src/ui/theme-viewer.c
@@ -207,7 +207,7 @@ normal_contents (void)
 
   contents = gtk_text_view_new ();
   gtk_text_view_set_wrap_mode (GTK_TEXT_VIEW (contents),
-                               PANGO_WRAP_WORD);
+                               GTK_WRAP_WORD);
 
   gtk_container_add (GTK_CONTAINER (sw),
                      contents);


### PR DESCRIPTION
```
marco-window-demo.c:1054:32: warning: implicit conversion from ‘enum <anonymous>’ to ‘GtkWrapMode’ [-Wenum-conversion]
 1054 |                                PANGO_WRAP_WORD);
      |                                ^~~~~~~~~~~~~~~
--
ui/draw-workspace.c:109:44: warning: implicit conversion from ‘GtkStateType’ to ‘GtkStateFlags’ [-Wenum-conversion]
  109 |     meta_gtk_style_get_light_color (style, state, &color);
      |                                            ^~~~~
ui/draw-workspace.c:111:34: warning: implicit conversion from ‘GtkStateType’ to ‘GtkStateFlags’ [-Wenum-conversion]
  111 |     get_background_color (style, state, &color);
      |                                  ^~~~~
ui/draw-workspace.c:160:39: warning: implicit conversion from ‘GtkStateType’ to ‘GtkStateFlags’ [-Wenum-conversion]
  160 |   gtk_style_context_get_color (style, state, &color);
      |                                       ^~~~~
--
ui/draw-workspace.c:236:20: warning: implicit conversion from ‘GtkStateFlags’ to ‘GtkStateType’ [-Wenum-conversion]
  236 |                    state);
      |                    ^~~~~
--
ui/theme-parser.c:2375:17: warning: implicit conversion from ‘GtkStateFlags’ to ‘GtkStateType’ [-Wenum-conversion]
 2375 |       state_val = meta_gtk_state_from_string (state);
      |                 ^
ui/theme-parser.c:2414:32: warning: implicit conversion from ‘GtkStateType’ to ‘GtkStateFlags’ [-Wenum-conversion]
 2414 |       op->data.gtk_arrow.state = state_val;
      |                                ^
ui/theme-parser.c:2458:17: warning: implicit conversion from ‘GtkStateFlags’ to ‘GtkStateType’ [-Wenum-conversion]
 2458 |       state_val = meta_gtk_state_from_string (state);
      |                 ^
ui/theme-parser.c:2485:30: warning: implicit conversion from ‘GtkStateType’ to ‘GtkStateFlags’ [-Wenum-conversion]
 2485 |       op->data.gtk_box.state = state_val;
      |                              ^
ui/theme-parser.c:2521:17: warning: implicit conversion from ‘GtkStateFlags’ to ‘GtkStateType’ [-Wenum-conversion]
 2521 |       state_val = meta_gtk_state_from_string (state);
      |                 ^
ui/theme-parser.c:2537:32: warning: implicit conversion from ‘GtkStateType’ to ‘GtkStateFlags’ [-Wenum-conversion]
 2537 |       op->data.gtk_vline.state = state_val;
      |                                ^
--
ui/theme-viewer.c:210:32: warning: implicit conversion from ‘enum <anonymous>’ to ‘GtkWrapMode’ [-Wenum-conversion]
  210 |                                PANGO_WRAP_WORD);
      |                                ^~~~~~~~~~~~~~~
```