### PR TITLE
mate-keybinding-properties: Add entry for area screenshot

### DIFF
--- a/src/50-marco-desktop-key.xml.in
+++ b/src/50-marco-desktop-key.xml.in
@@ -9,6 +9,8 @@
 
 	<KeyListEntry name="run-command-window-screenshot" description="Take a screenshot of a window" />
 
+	<KeyListEntry name="run-command-area-screenshot" description="Take a screenshot of an area" />
+
 	<KeyListEntry name="run-command-terminal" description="Run a terminal" />
 
 	<KeyListEntry name="rename-workspace" description="Rename current workspace" />

--- a/src/core/prefs.c
+++ b/src/core/prefs.c
@@ -35,9 +35,10 @@
 #define MAX_REASONABLE_WORKSPACES 36
 
 #define MAX_COMMANDS (32 + NUM_EXTRA_COMMANDS)
-#define NUM_EXTRA_COMMANDS 2
-#define SCREENSHOT_COMMAND_IDX (MAX_COMMANDS - 2)
-#define WIN_SCREENSHOT_COMMAND_IDX (MAX_COMMANDS - 1)
+#define NUM_EXTRA_COMMANDS 3
+#define SCREENSHOT_COMMAND_IDX (MAX_COMMANDS - 3)
+#define WIN_SCREENSHOT_COMMAND_IDX (MAX_COMMANDS - 2)
+#define AREA_SCREENSHOT_COMMAND_IDX (MAX_COMMANDS - 1)
 
 /* If you add a key, it needs updating in init() and in the GSettings
  * notify listener and of course in the .gschema file.
@@ -2013,6 +2014,10 @@ update_command (const char  *name,
         {
           i = WIN_SCREENSHOT_COMMAND_IDX;
         }
+      else if (strcmp (name, "command-area-screenshot") == 0)
+        {
+          i = AREA_SCREENSHOT_COMMAND_IDX;
+        }
       else
         {
           meta_topic (META_DEBUG_KEYBINDINGS,
@@ -2066,6 +2071,9 @@ meta_prefs_get_settings_key_for_command (int i)
       break;
     case WIN_SCREENSHOT_COMMAND_IDX:
       key = g_strdup (KEY_COMMAND_PREFIX "window-screenshot");
+      break;
+    case AREA_SCREENSHOT_COMMAND_IDX:
+      key = g_strdup (KEY_COMMAND_PREFIX "area-screenshot");
       break;
     default:
       key = g_strdup_printf (KEY_COMMAND_PREFIX"%d", i + 1);

--- a/src/include/all-keybindings.h
+++ b/src/include/all-keybindings.h
@@ -194,6 +194,7 @@ keybind (run-command-32, handle_run_command, 31, 0)
 
 keybind (run-command-screenshot, handle_run_command, 32, 0)
 keybind (run-command-window-screenshot, handle_run_command, 33, 0)
+keybind (run-command-area-screenshot, handle_run_command, 34, 0)
 
 keybind (run-command-terminal, handle_run_terminal, 0, 0)
 keybind (rename-workspace, handle_rename_workspace, 0, 0)

--- a/src/org.mate.marco.gschema.xml
+++ b/src/org.mate.marco.gschema.xml
@@ -644,6 +644,11 @@
       <summary>Take a screenshot of a window</summary>
       <description>The format looks like "&lt;Control&gt;a" or "&lt;Shift&gt;&lt;Alt&gt;F1". The parser is fairly liberal and allows lower or upper case, and also abbreviations such as "&lt;Ctl&gt;" and "&lt;Ctrl&gt;". If you set the option to the special string "disabled", then there will be no keybinding for this action.</description>
     </key>
+    <key name="run-command-area-screenshot" type="s">
+      <default>'&lt;Shift&gt;Print'</default>
+      <summary>Take a screenshot of an area</summary>
+      <description>The format looks like "&lt;Control&gt;a" or "&lt;Shift&gt;&lt;Alt&gt;F1". The parser is fairly liberal and allows lower or upper case, and also abbreviations such as "&lt;Ctl&gt;" and "&lt;Ctrl&gt;". If you set the option to the special string "disabled", then there will be no keybinding for this action.</description>
+    </key>
     <key name="run-command-terminal" type="s">
       <default>'disabled'</default>
       <summary>Run a terminal</summary>
@@ -726,6 +731,11 @@
       <default>'mate-screenshot --window'</default>
       <summary>The window screenshot command</summary>
       <description>The /apps/marco/global_keybindings/run_command_window_screenshot key defines a keybinding which causes the command specified by this setting to be invoked.</description>
+    </key>
+    <key name="command-area-screenshot" type="s">
+      <default>'mate-screenshot --area'</default>
+      <summary>The area screenshot command</summary>
+      <description>The /apps/marco/global_keybindings/run_command_area_screenshot key defines a keybinding which causes the command specified by this setting to be invoked.</description>
     </key>
   </schema>
 


### PR DESCRIPTION
Adds a default keyboard shortcut for taking a screenshot of an area. 

To test, run `src/marco --replace` and press `Shift+Print`.

Closes #157.