### PR TITLE
common: window icon (META_DEFAULT_ICON_NAME) is no longer available

### DIFF
--- a/src/include/common.h
+++ b/src/include/common.h
@@ -326,7 +326,7 @@ void meta_frame_borders_clear (MetaFrameBorders *self);
 #define META_MINI_ICON_WIDTH 16
 #define META_MINI_ICON_HEIGHT 16
 
-#define META_DEFAULT_ICON_NAME "window"
+#define META_DEFAULT_ICON_NAME "preferences-desktop-theme"
 
 #define META_PRIORITY_PREFS_NOTIFY   (G_PRIORITY_DEFAULT_IDLE + 10)
 #define META_PRIORITY_WORK_AREA_HINT (G_PRIORITY_DEFAULT_IDLE + 15)


### PR DESCRIPTION
test: Remove cache
```
$ rm -fr .cache
```

![Screenshot at 2020-06-28 15-02-23](https://user-images.githubusercontent.com/10171411/85948325-9b2a8a00-b950-11ea-87dc-3cd72f271f6e.png)


closes #631