### PR TITLE
WIP Fix some warnings about float conversion (-Wfloat-conversion)

### DIFF
--- a/src/compositor/compositor-xrender.c
+++ b/src/compositor/compositor-xrender.c
@@ -833,10 +833,10 @@ solid_picture (MetaDisplay *display,
       return None;
     }
 
-  c.alpha = a * 0xffff;
-  c.red = r * 0xffff;
-  c.green = g * 0xffff;
-  c.blue = b * 0xffff;
+  c.alpha = (guint16)(a * 65535 + 0.5);
+  c.red   = (guint16)(r * 65535 + 0.5);
+  c.green = (guint16)(g * 65535 + 0.5);
+  c.blue  = (guint16)(b * 65535 + 0.5);
 
   XRenderFillRectangle (xdisplay, PictOpSrc, picture, &c, 0, 0, 1, 1);
   XFreePixmap (xdisplay, pixmap);

--- a/src/core/constraints.c
+++ b/src/core/constraints.c
@@ -541,15 +541,15 @@ place_window_if_needed(MetaWindow     *window,
            */
           if (info->current.width >= info->work_area_xinerama.width)
             {
-              info->current.width = .75 * info->work_area_xinerama.width;
+              info->current.width = (int) (.75 * info->work_area_xinerama.width + 0.5);
               info->current.x = info->work_area_xinerama.x +
-                       .125 * info->work_area_xinerama.width;
+                       (int)(.125 * info->work_area_xinerama.width + 0.5);
             }
           if (info->current.height >= info->work_area_xinerama.height)
             {
-              info->current.height = .75 * info->work_area_xinerama.height;
+              info->current.height = (int)(.75 * info->work_area_xinerama.height + 0.5);
               info->current.y = info->work_area_xinerama.y +
-                       .083 * info->work_area_xinerama.height;
+                       (int)(.083 * info->work_area_xinerama.height + 0.5);
             }
 
           if (window->maximize_horizontally_after_placement ||
@@ -1293,14 +1293,12 @@ constrain_aspect_ratio (MetaWindow         *window,
     {
     case WestGravity:
     case EastGravity:
-      /* Yeah, I suck for doing implicit rounding -- sue me */
-      new_height = CLAMP (new_height, new_width / maxr,  new_width / minr);
+      new_height = CLAMP (new_height, (int)((new_width / maxr) + 0.5),  (int)((new_width / minr) + 0.5));
       break;
 
     case NorthGravity:
     case SouthGravity:
-      /* Yeah, I suck for doing implicit rounding -- sue me */
-      new_width  = CLAMP (new_width,  new_height * minr, new_height * maxr);
+      new_width  = CLAMP (new_width,  (int)((new_height * minr) + 0.5), (int)((new_height * maxr) + 0.5));
       break;
 
     case NorthWestGravity:
@@ -1312,8 +1310,8 @@ constrain_aspect_ratio (MetaWindow         *window,
     default:
       /* Find what width would correspond to new_height, and what height would
        * correspond to new_width */
-      alt_width  = CLAMP (new_width,  new_height * minr, new_height * maxr);
-      alt_height = CLAMP (new_height, new_width / maxr,  new_width / minr);
+      alt_width  = CLAMP (new_width,  (int)((new_height * minr) + 0.5), (int)((new_height * maxr) + 0.5));
+      alt_height = CLAMP (new_height, (int)((new_width / maxr) + 0.5),  (int)((new_width / minr) + 0.5));
 
       /* The line connecting the points (alt_width, new_height) and
        * (new_width, alt_height) provide a range of
@@ -1327,8 +1325,8 @@ constrain_aspect_ratio (MetaWindow         *window,
                                                       new_width, new_height,
                                                       &best_width, &best_height);
 
-      new_width  = round (best_width);
-      new_height = round (best_height);
+      new_width  = (int) (best_width + 0.5);
+      new_height = (int) (best_height + 0.5);
 
       break;
     }

--- a/src/core/effects.c
+++ b/src/core/effects.c
@@ -371,10 +371,10 @@ effects_draw_box_animation_timeout (BoxAnimationContext *context)
   draw_rect = context->start_rect;
 
   /* Now add a delta proportional to elapsed time. */
-  draw_rect.x += (context->end_rect.x - context->start_rect.x) * fraction;
-  draw_rect.y += (context->end_rect.y - context->start_rect.y) * fraction;
-  draw_rect.width += (context->end_rect.width - context->start_rect.width) * fraction;
-  draw_rect.height += (context->end_rect.height - context->start_rect.height) * fraction;
+  draw_rect.x += (int)((context->end_rect.x - context->start_rect.x) * fraction + 0.5);
+  draw_rect.y += (int)((context->end_rect.y - context->start_rect.y) * fraction + 0.5);
+  draw_rect.width += (int)((context->end_rect.width - context->start_rect.width) * fraction + 0.5);
+  draw_rect.height += (int)((context->end_rect.height - context->start_rect.height) * fraction + 0.5);
 
   /* don't confuse X or gdk-pixbuf with bogus rectangles */
   if (draw_rect.width < 1)

--- a/src/core/place.c
+++ b/src/core/place.c
@@ -31,6 +31,7 @@
 #include "prefs.h"
 #include <gdk/gdk.h>
 #include <math.h>
+#include <float.h>
 #include <stdlib.h>
 
 typedef enum
@@ -46,8 +47,8 @@ northwestcmp (gconstpointer a, gconstpointer b)
 {
   MetaWindow *aw = (gpointer) a;
   MetaWindow *bw = (gpointer) b;
-  int from_origin_a;
-  int from_origin_b;
+  float from_origin_a;
+  float from_origin_b;
   int ax, ay, bx, by;
 
   /* we're interested in the frame position for cascading,
@@ -76,8 +77,8 @@ northwestcmp (gconstpointer a, gconstpointer b)
     }
 
   /* probably there's a fast good-enough-guess we could use here. */
-  from_origin_a = sqrt (ax * ax + ay * ay);
-  from_origin_b = sqrt (bx * bx + by * by);
+  from_origin_a = sqrtf ((float)(ax * ax + ay * ay));
+  from_origin_b = sqrtf ((float)(bx * bx + by * by));
 
   if (from_origin_a < from_origin_b)
     return -1;

--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -1211,7 +1211,7 @@ meta_screen_update_cursor (MetaScreen *screen)
 }
 
 #define MAX_PREVIEW_SCREEN_FRACTION 0.33
-#define MAX_PREVIEW_SIZE 300
+#define MAX_PREVIEW_SIZE 300.0
 
 static cairo_surface_t *
 get_window_surface (MetaWindow *window)
@@ -1219,7 +1219,8 @@ get_window_surface (MetaWindow *window)
   cairo_surface_t *surface, *scaled;
   cairo_t *cr;
   const MetaXineramaScreenInfo *current;
-  int width, height, max_columns, max_size;
+  int width, height, max_columns;
+  double max_size;
   double ratio;
 
   surface = meta_compositor_get_window_surface (window->display->compositor, window);
@@ -1237,16 +1238,16 @@ get_window_surface (MetaWindow *window)
   if (width > height)
     {
       max_size = MIN (MAX_PREVIEW_SIZE, current->rect.width / max_columns * MAX_PREVIEW_SCREEN_FRACTION);
-      ratio = ((double) width) / max_size;
+      ratio = max_size / width;
       width = (int) max_size;
-      height = (int) (((double) height) / ratio);
+      height = (int) (height * ratio + 0.5);
     }
   else
     {
       max_size = MIN (MAX_PREVIEW_SIZE, current->rect.height / max_columns * MAX_PREVIEW_SCREEN_FRACTION);
-      ratio = ((double) height) / max_size;
+      ratio = max_size / height;
       height = (int) max_size;
-      width = (int) (((double) width) / ratio);
+      width = (int) (width * ratio + 0.5);
     }
 
   meta_error_trap_push (window->display);
@@ -1257,7 +1258,7 @@ get_window_surface (MetaWindow *window)
     return NULL;
 
   cr = cairo_create (scaled);
-  cairo_scale (cr, 1/ratio, 1/ratio);
+  cairo_scale (cr, ratio, ratio);
   cairo_set_source_surface (cr, surface, 0, 0);
   cairo_paint (cr);
 

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -2914,27 +2914,27 @@ meta_window_move_to_monitor(MetaWindow *window,
                           target_rect.height);
 }
 
-static void meta_window_transform_to_monitor(MetaRectangle *target_rect,
-                                           const MetaRectangle *from_monitor,
-                                           const MetaRectangle *to_monitor)
+static void
+meta_window_transform_to_monitor (MetaRectangle       *target_rect,
+                                  const MetaRectangle *from_monitor,
+                                  const MetaRectangle *to_monitor)
 {
-  double horizontal_ratio;
-  double vertical_ratio;
+  float horizontal_ratio;
+  float vertical_ratio;
 
-  horizontal_ratio = (double)to_monitor->width / from_monitor->width;
-  vertical_ratio = (double)to_monitor->height / from_monitor->height;
+  horizontal_ratio = (float)to_monitor->width / from_monitor->width;
+  vertical_ratio = (float)to_monitor->height / from_monitor->height;
 
   target_rect->x -= from_monitor->x;
   target_rect->y -= from_monitor->y;
 
-  target_rect->width *= horizontal_ratio;
-  target_rect->height *= vertical_ratio;
-  target_rect->x *= horizontal_ratio;
-  target_rect->y *= vertical_ratio;
+  target_rect->width  = (int)(target_rect->width  * horizontal_ratio + 0.5f);
+  target_rect->height = (int)(target_rect->height * vertical_ratio   + 0.5f);
+  target_rect->x = (int)(target_rect->x * horizontal_ratio + 0.5f);
+  target_rect->y = (int)(target_rect->y * vertical_ratio   + 0.5f);
 
   target_rect->x += to_monitor->x;
   target_rect->y += to_monitor->y;
-
 }
 
 void
@@ -7101,7 +7101,7 @@ meta_window_titlebar_is_onscreen (MetaWindow *window)
   gboolean       is_onscreen;
 
   const int min_height_needed  = 8;
-  const int min_width_percent  = 0.5;
+  const float min_width_percent  = 0.5f;
   const int min_width_absolute = 50;
 
   /* Titlebar can't be offscreen if there is no titlebar... */
@@ -7124,7 +7124,7 @@ meta_window_titlebar_is_onscreen (MetaWindow *window)
 
       meta_rectangle_intersect (&titlebar_rect, spanning_rect, &overlap);
       if (overlap.height > MIN (titlebar_rect.height, min_height_needed) &&
-          overlap.width  > MIN (titlebar_rect.width * min_width_percent,
+          overlap.width  > MIN ((int)(titlebar_rect.width * min_width_percent + 0.5f),
                                 min_width_absolute))
         {
           is_onscreen = TRUE;

--- a/src/ui/draw-workspace.c
+++ b/src/ui/draw-workspace.c
@@ -46,10 +46,10 @@ get_window_rect (const WnckWindowDisplayInfo *win,
   width = win->width;
   height = win->height;
 
-  x *= width_ratio;
-  y *= height_ratio;
-  width *= width_ratio;
-  height *= height_ratio;
+  x = (int)(x * width_ratio  + 0.5);
+  y = (int)(y * height_ratio + 0.5);
+  width  = (int)(width  * width_ratio  + 0.5);
+  height = (int)(height * height_ratio + 0.5);
 
   x += workspace_rect->x;
   y += workspace_rect->y;

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -838,13 +838,13 @@ meta_ui_frame_get_corner_radiuses (MetaFrames  *frames,
    */
 
   if (top_left)
-    *top_left = fgeom.top_left_corner_rounded_radius + sqrt(fgeom.top_left_corner_rounded_radius);
+    *top_left = fgeom.top_left_corner_rounded_radius + sqrtf (fgeom.top_left_corner_rounded_radius);
   if (top_right)
-    *top_right = fgeom.top_right_corner_rounded_radius + sqrt(fgeom.top_right_corner_rounded_radius);
+    *top_right = fgeom.top_right_corner_rounded_radius + sqrtf (fgeom.top_right_corner_rounded_radius);
   if (bottom_left)
-    *bottom_left = fgeom.bottom_left_corner_rounded_radius + sqrt(fgeom.bottom_left_corner_rounded_radius);
+    *bottom_left = fgeom.bottom_left_corner_rounded_radius + sqrtf (fgeom.bottom_left_corner_rounded_radius);
   if (bottom_right)
-    *bottom_right = fgeom.bottom_right_corner_rounded_radius + sqrt(fgeom.bottom_right_corner_rounded_radius);
+    *bottom_right = fgeom.bottom_right_corner_rounded_radius + sqrtf (fgeom.bottom_right_corner_rounded_radius);
 }
 
 void
@@ -953,12 +953,12 @@ get_visible_region (MetaFrames        *frames,
   if (fgeom->top_left_corner_rounded_radius != 0)
     {
       const int corner = fgeom->top_left_corner_rounded_radius * scale;
-      const float radius = sqrt(corner) + corner;
+      const float radius = sqrtf (corner) + corner;
       int i;
 
       for (i=0; i<corner; i++)
         {
-          const int width = floor(0.5 + radius - sqrt(radius*radius - (radius-(i+0.5))*(radius-(i+0.5))));
+          const int width = (int)(0.5f + radius - sqrtf (radius*radius - (radius-(i+0.5f))*(radius-(i+0.5f))));
           rect.x = frame_rect.x;
           rect.y = frame_rect.y + i;
           rect.width = width;
@@ -971,12 +971,12 @@ get_visible_region (MetaFrames        *frames,
   if (fgeom->top_right_corner_rounded_radius != 0)
     {
       const int corner = fgeom->top_right_corner_rounded_radius * scale;
-      const float radius = sqrt(corner) + corner;
+      const float radius = sqrtf (corner) + corner;
       int i;
 
       for (i=0; i<corner; i++)
         {
-          const int width = floor(0.5 + radius - sqrt(radius*radius - (radius-(i+0.5))*(radius-(i+0.5))));
+          const int width = (int)(0.5f + radius - sqrtf (radius*radius - (radius-(i+0.5f))*(radius-(i+0.5f))));
           rect.x = frame_rect.x + frame_rect.width - width;
           rect.y = frame_rect.y + i;
           rect.width = width;
@@ -989,12 +989,12 @@ get_visible_region (MetaFrames        *frames,
   if (fgeom->bottom_left_corner_rounded_radius != 0)
     {
       const int corner = fgeom->bottom_left_corner_rounded_radius * scale;
-      const float radius = sqrt(corner) + corner;
+      const float radius = sqrtf (corner) + corner;
       int i;
 
       for (i=0; i<corner; i++)
         {
-          const int width = floor(0.5 + radius - sqrt(radius*radius - (radius-(i+0.5))*(radius-(i+0.5))));
+          const int width = (int)(0.5f + radius - sqrtf (radius*radius - (radius-(i+0.5f))*(radius-(i+0.5f))));
           rect.x = frame_rect.x;
           rect.y = frame_rect.y + frame_rect.height - i - 1;
           rect.width = width;
@@ -1007,12 +1007,12 @@ get_visible_region (MetaFrames        *frames,
   if (fgeom->bottom_right_corner_rounded_radius != 0)
     {
       const int corner = fgeom->bottom_right_corner_rounded_radius * scale;
-      const float radius = sqrt(corner) + corner;
+      const float radius = sqrtf (corner) + corner;
       int i;
 
       for (i=0; i<corner; i++)
         {
-          const int width = floor(0.5 + radius - sqrt(radius*radius - (radius-(i+0.5))*(radius-(i+0.5))));
+          const int width = (int)(0.5f + radius - sqrtf (radius*radius - (radius-(i+0.5f))*(radius-(i+0.5f))));
           rect.x = frame_rect.x + frame_rect.width - width;
           rect.y = frame_rect.y + frame_rect.height - i - 1;
           rect.width = width;

--- a/src/ui/gradient.c
+++ b/src/ui/gradient.c
@@ -779,25 +779,25 @@ meta_gradient_create_interwoven (int            width,
   pixels = gdk_pixbuf_get_pixels (pixbuf);
   rowstride = gdk_pixbuf_get_rowstride (pixbuf);
 
-  r1 = (long)(colors1[0].red*0xffffff);
-  g1 = (long)(colors1[0].green*0xffffff);
-  b1 = (long)(colors1[0].blue*0xffffff);
-  a1 = (long)(colors1[0].alpha*0xffffff);
+  r1 = (long)(colors1[0].red   * 0xffffff + 0.5);
+  g1 = (long)(colors1[0].green * 0xffffff + 0.5);
+  b1 = (long)(colors1[0].blue  * 0xffffff + 0.5);
+  a1 = (long)(colors1[0].alpha * 0xffffff + 0.5);
 
-  r2 = (long)(colors2[0].red*0xffffff);
-  g2 = (long)(colors2[0].green*0xffffff);
-  b2 = (long)(colors2[0].blue*0xffffff);
-  a2 = (long)(colors2[0].alpha*0xffffff);
+  r2 = (long)(colors2[0].red   * 0xffffff + 0.5);
+  g2 = (long)(colors2[0].green * 0xffffff + 0.5);
+  b2 = (long)(colors2[0].blue  * 0xffffff + 0.5);
+  a2 = (long)(colors2[0].alpha * 0xffffff + 0.5);
 
-  dr1 = ((colors1[1].red-colors1[0].red)*0xffffff)/(int)height;
-  dg1 = ((colors1[1].green-colors1[0].green)*0xffffff)/(int)height;
-  db1 = ((colors1[1].blue-colors1[0].blue)*0xffffff)/(int)height;
-  da1 = ((colors1[1].alpha-colors1[0].alpha)*0xffffff)/(int)height;
+  dr1 = (long)((colors1[1].red   - colors1[0].red)   * 0xffffff + 0.5) / (long)height;
+  dg1 = (long)((colors1[1].green - colors1[0].green) * 0xffffff + 0.5) / (long)height;
+  db1 = (long)((colors1[1].blue  - colors1[0].blue)  * 0xffffff + 0.5) / (long)height;
+  da1 = (long)((colors1[1].alpha - colors1[0].alpha) * 0xffffff + 0.5) / (long)height;
 
-  dr2 = ((colors2[1].red-colors2[0].red)*0xffffff)/(int)height;
-  dg2 = ((colors2[1].green-colors2[0].green)*0xffffff)/(int)height;
-  db2 = ((colors2[1].blue-colors2[0].blue)*0xffffff)/(int)height;
-  da2 = ((colors2[1].alpha-colors2[0].alpha)*0xffffff)/(int)height;
+  dr2 = (long)((colors2[1].red   - colors2[0].red)   * 0xffffff + 0.5) / (long)height;
+  dg2 = (long)((colors2[1].green - colors2[0].green) * 0xffffff + 0.5) / (long)height;
+  db2 = (long)((colors2[1].blue  - colors2[0].blue)  * 0xffffff + 0.5) / (long)height;
+  da2 = (long)((colors2[1].alpha - colors2[0].alpha) * 0xffffff + 0.5) / (long)height;
 
   for (i=0,k=0,l=0,ll=thickness1; i<height; i++)
     {

--- a/src/ui/preview-widget.c
+++ b/src/ui/preview-widget.c
@@ -523,13 +523,13 @@ meta_preview_get_clip_region (MetaPreview *preview, gint new_window_width, gint 
   if (fgeom->top_left_corner_rounded_radius != 0)
     {
       const int corner = fgeom->top_left_corner_rounded_radius;
-      const float radius = sqrt(corner) + corner;
+      const float radius = sqrtf (corner) + corner;
       int i;
 
       for (i=0; i<corner; i++)
         {
 
-          const int width = floor(0.5 + radius - sqrt(radius*radius - (radius-(i+0.5))*(radius-(i+0.5))));
+          const int width = (int)(0.5f + radius - sqrtf (radius*radius - (radius-(i+0.5f))*(radius-(i+0.5f))));
           xrect.x = 0;
           xrect.y = i;
           xrect.width = width;
@@ -542,12 +542,12 @@ meta_preview_get_clip_region (MetaPreview *preview, gint new_window_width, gint 
   if (fgeom->top_right_corner_rounded_radius != 0)
     {
       const int corner = fgeom->top_right_corner_rounded_radius;
-      const float radius = sqrt(corner) + corner;
+      const float radius = sqrtf (corner) + corner;
       int i;
 
       for (i=0; i<corner; i++)
         {
-          const int width = floor(0.5 + radius - sqrt(radius*radius - (radius-(i+0.5))*(radius-(i+0.5))));
+          const int width = (int)(0.5f + radius - sqrtf (radius*radius - (radius-(i+0.5f))*(radius-(i+0.5f))));
           xrect.x = new_window_width - width;
           xrect.y = i;
           xrect.width = width;
@@ -560,12 +560,12 @@ meta_preview_get_clip_region (MetaPreview *preview, gint new_window_width, gint 
   if (fgeom->bottom_left_corner_rounded_radius != 0)
     {
       const int corner = fgeom->bottom_left_corner_rounded_radius;
-      const float radius = sqrt(corner) + corner;
+      const float radius = sqrtf (corner) + corner;
       int i;
 
       for (i=0; i<corner; i++)
         {
-          const int width = floor(0.5 + radius - sqrt(radius*radius - (radius-(i+0.5))*(radius-(i+0.5))));
+          const int width = (int)(0.5f + radius - sqrtf (radius*radius - (radius-(i+0.5f))*(radius-(i+0.5f))));
           xrect.x = 0;
           xrect.y = new_window_height - i - 1;
           xrect.width = width;
@@ -578,12 +578,12 @@ meta_preview_get_clip_region (MetaPreview *preview, gint new_window_width, gint 
   if (fgeom->bottom_right_corner_rounded_radius != 0)
     {
       const int corner = fgeom->bottom_right_corner_rounded_radius;
-      const float radius = sqrt(corner) + corner;
+      const float radius = sqrtf (corner) + corner;
       int i;
 
       for (i=0; i<corner; i++)
         {
-          const int width = floor(0.5 + radius - sqrt(radius*radius - (radius-(i+0.5))*(radius-(i+0.5))));
+          const int width = (int)(0.5f + radius - sqrtf (radius*radius - (radius-(i+0.5f))*(radius-(i+0.5f))));
           xrect.x = new_window_width - width;
           xrect.y = new_window_height - i - 1;
           xrect.width = width;

--- a/src/ui/theme-viewer.c
+++ b/src/ui/theme-viewer.c
@@ -628,10 +628,13 @@ preview_collection (int font_size,
 
       if (scale != 1.0)
         {
+          gint font_size_local;
+
           font_desc = pango_font_description_new ();
 
+          font_size_local = pango_font_description_get_size (base_desc);
           pango_font_description_set_size (font_desc,
-                                           MAX (pango_font_description_get_size (base_desc) * scale, 1));
+                                           MAX ((gint)(font_size_local * scale + 0.5), 1));
 
           font_string = pango_font_description_to_string (font_desc);
           override_font (preview, font_string);

--- a/src/ui/theme.c
+++ b/src/ui/theme.c
@@ -128,8 +128,8 @@ scale_surface (cairo_surface_t *surface,
     }
 
   content = CAIRO_CONTENT_COLOR_ALPHA;
-  width = ceil (new_width);
-  height = ceil (new_height);
+  width  = (int)new_width;
+  height = (int)new_height;
 
   scaled = cairo_surface_create_similar (surface, content, width, height);
   cr = cairo_create (scaled);
@@ -182,10 +182,8 @@ get_surface_from_pixbuf (GdkPixbuf         *pixbuf,
     }
 
   content = CAIRO_CONTENT_COLOR_ALPHA;
-  width = ceil (width);
-  height = ceil (height);
 
-  copy = cairo_surface_create_similar (surface, content, width, height);
+  copy = cairo_surface_create_similar (surface, content, (int)width, (int)height);
   cr = cairo_create (copy);
 
   cairo_set_source_surface (cr, surface, 0, 0);
@@ -779,7 +777,7 @@ meta_frame_layout_calc_geometry (const MetaFrameLayout  *layout,
     {
     case META_BUTTON_SIZING_ASPECT:
       button_height = borders.visible.top - layout->button_border.top - layout->button_border.bottom;
-      button_width = button_height / layout->button_aspect;
+      button_width = (int)(button_height / layout->button_aspect + 0.5);
       break;
     case META_BUTTON_SIZING_FIXED:
       button_width = layout->button_width;
@@ -879,15 +877,13 @@ meta_frame_layout_calc_geometry (const MetaFrameLayout  *layout,
 
       space_available = fgeom->width - layout->left_titlebar_edge - layout->right_titlebar_edge;
 
-      space_used_by_buttons = 0;
-
-      space_used_by_buttons += button_width * n_left;
-      space_used_by_buttons += (button_width * 0.75) * n_left_spacers;
+      space_used_by_buttons =  button_width * n_left;
+      space_used_by_buttons += (int)(button_width * 0.75 + 0.5) * n_left_spacers;
       space_used_by_buttons += layout->button_border.left * n_left;
       space_used_by_buttons += layout->button_border.right * n_left;
 
       space_used_by_buttons += button_width * n_right;
-      space_used_by_buttons += (button_width * 0.75) * n_right_spacers;
+      space_used_by_buttons += (int)(button_width * 0.75 + 0.5) * n_right_spacers;
       space_used_by_buttons += layout->button_border.left * n_right;
       space_used_by_buttons += layout->button_border.right * n_right;
 
@@ -988,7 +984,7 @@ meta_frame_layout_calc_geometry (const MetaFrameLayout  *layout,
       rect = right_func_rects[i];
       rect->visible.x = x - layout->button_border.right - button_width;
       if (right_buttons_has_spacer[i])
-        rect->visible.x -= (button_width * 0.75);
+        rect->visible.x -= (int)(button_width * 0.75 + 0.5);
 
       rect->visible.y = button_y;
       rect->visible.width = button_width;
@@ -1047,7 +1043,7 @@ meta_frame_layout_calc_geometry (const MetaFrameLayout  *layout,
 
       x = rect->visible.x + rect->visible.width + layout->button_border.right;
       if (left_buttons_has_spacer[i])
-        x += (button_width * 0.75);
+        x += (int)(button_width * 0.75 + 0.5);
 
       *(left_bg_rects[i]) = rect->visible;
     }
@@ -2880,7 +2876,7 @@ pos_eval (MetaDrawSpec              *spec,
           *val_p = expr.d.int_val;
           break;
         case POS_EXPR_DOUBLE:
-          *val_p = expr.d.double_val;
+          *val_p = (int)expr.d.double_val;
           break;
         case POS_EXPR_OPERATOR:
           g_assert_not_reached ();
@@ -6237,6 +6233,7 @@ meta_gtk_widget_get_font_desc (GtkWidget *widget,
 			       const PangoFontDescription *override)
 {
   PangoFontDescription *font_desc;
+  gint font_size;
 
   GtkStyleContext *style = gtk_widget_get_style_context (widget);
   GtkStateFlags state = gtk_widget_get_state_flags (widget);
@@ -6246,8 +6243,9 @@ meta_gtk_widget_get_font_desc (GtkWidget *widget,
   if (override)
     pango_font_description_merge (font_desc, override, TRUE);
 
+  font_size = pango_font_description_get_size (font_desc);
   pango_font_description_set_size (font_desc,
-                                   MAX (pango_font_description_get_size (font_desc) * scale, 1));
+                                   MAX ((gint)(font_size * scale + 0.5), 1));
 
   return font_desc;
 }

--- a/src/wm-tester/test-gravity.c
+++ b/src/wm-tester/test-gravity.c
@@ -83,8 +83,8 @@ calculate_position (int i, int doubled, int *x, int *y)
           yoff *= 2;
         }
 
-      *x = screen_x_fraction[i % 3] * screen_width + xoff;
-      *y = screen_y_fraction[i / 3] * screen_height + yoff;
+      *x = (int)(screen_x_fraction[i % 3] * screen_width  + 0.5) + xoff;
+      *y = (int)(screen_y_fraction[i / 3] * screen_height + 0.5) + yoff;
     }
 }
 


### PR DESCRIPTION
Test: marco.make.log (master), marco/make.log (PR)
```
$ CFLAGS="-O3 -fomit-frame-pointer -malign-double -fstrict-aliasing -ffast-math -Wconversion -Wunused-macros -Wunused-parameter" ./autogen.sh --prefix=/usr --enable-compile-warnings=maximum && make &> make.log && sudo make install
```
Comparing make logs
```
$ diff <(./warnings-file.sh marco.make.log) <(./warnings-file.sh marco/make.log)
3c3
< -Wconversion 978
---
> -Wconversion 951
5c5
< -Wfloat-conversion 97
---
> -Wfloat-conversion 18
```
warnings-file.sh
```
FILE=$1
for warning in $(grep warning $FILE | grep -Po '\[\-W.*\]' | sed 's/[][]//g' | sort -u)
do
 type=${warning#"-W"}
 num=$(echo "grep $type $FILE | wc -l" | sh)
 echo "$warning $num"
done
```
Testing scaled surfaces: save scaled surfaces to png files "/home/robert/SC_TIME " + TIMESTAMP + ".png"
- Run mate-appearance-properties
- Select Theme tab
```C
static cairo_surface_t *
scale_surface (cairo_surface_t *surface,
               gdouble          old_width,
               gdouble          old_height,
               gdouble          new_width,
               gdouble          new_height,
               gboolean         vertical_stripes,
               gboolean         horizontal_stripes)
```
```diff
diff --git a/src/ui/theme.c b/src/ui/theme.c
index be3e87a..6c7a055 100644
--- a/src/ui/theme.c
+++ b/src/ui/theme.c
@@ -140,6 +140,10 @@ scale_surface (cairo_surface_t *surface,
   cairo_pattern_set_extend (cairo_get_source (cr), CAIRO_EXTEND_PAD);
 
   cairo_paint (cr);
+  char *file = g_strdup_printf ("/home/robert/SC_TIME%lu.png", g_get_monotonic_time ());
+  cairo_surface_write_to_png (surface, file);
+  g_free (file);
+
   cairo_destroy (cr);
 
   return scaled;
```
Testing Alt+Tab thumbnails: save window screenshots to png files "/home/robert/SC_TIME " + TIMESTAMP + ".png"
- Press Alt+Tab
```C
static cairo_surface_t *
get_window_surface (MetaWindow *window)
```
```diff
diff --git a/src/core/screen.c b/src/core/screen.c
index 1218232..a821be5 100644
diff --git a/src/core/screen.c b/src/core/screen.c
index 1218232..6a300ff 100644
--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -1265,6 +1265,10 @@ get_window_surface (MetaWindow *window)
   cairo_destroy (cr);
   cairo_surface_destroy (surface);
 
+  char *file = g_strdup_printf ("/home/robert/SC_TIME%lu.png", g_get_monotonic_time ());
+  cairo_surface_write_to_png (scaled, file);
+  g_free (file);
+
   return scaled;
 }
 
```
benchmark: master vs PR (there is no significant difference)
```
$ marco-theme-viewer BlueMenta
```
### master

![Screenshot at 2020-08-09 21-53-07](https://user-images.githubusercontent.com/10171411/89740719-8e3ea180-da8b-11ea-9e9d-45fbeec80c6c.png)

### PR

![Screenshot at 2020-08-09 21-54-37](https://user-images.githubusercontent.com/10171411/89740723-9696dc80-da8b-11ea-9ff9-0499c86a80ce.png)
