### PR TITLE
theme: macro "ALPHA_TO_UCHAR" is not used

### DIFF
--- a/src/ui/theme.c
+++ b/src/ui/theme.c
@@ -75,8 +75,6 @@
                                      ((int)((color).green * 255) << 8)  |    \
                                      ((int)((color).blue * 255))))
 
-#define ALPHA_TO_UCHAR(d) ((unsigned char) ((d) * 255))
-
 #define DEBUG_FILL_STRUCT(s) memset ((s), 0xef, sizeof (*(s)))
 #define CLAMP_UCHAR(v) ((guchar) (CLAMP (((int)v), (int)0, (int)255)))
 #define INTENSITY(r, g, b) ((r) * 0.30 + (g) * 0.59 + (b) * 0.11)


### PR DESCRIPTION
```
ui/theme.c:78: warning: macro "ALPHA_TO_UCHAR" is not used [-Wunused-macros]
   78 | #define ALPHA_TO_UCHAR(d) ((unsigned char) ((d) * 255))
      | 
```