### PR TITLE
Do not call cairo paint on generate_pixmaps.

### DIFF
--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -2280,8 +2280,6 @@ generate_pixmap (MetaFrames            *frames,
   cr = cairo_create (result);
   cairo_translate (cr, -rect->x, -rect->y);
 
-  cairo_paint (cr);
-
   meta_frames_paint_to_drawable (frames, frame, cr);
 
   cairo_destroy (cr);


### PR DESCRIPTION
Based on Metacity commit https://gitlab.gnome.org/GNOME/metacity/-/commit/0b2f5ad0a2f30726ac0dc59aa59f7f513e91c832

Fixes transparent windows on issue #486 

![transparent](https://user-images.githubusercontent.com/11843298/91641006-85e9de80-ea19-11ea-976a-9d1fbf3f3583.jpg)
