### PR TITLE
build: by default disable also the verbose mode for autoconf

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -65,9 +65,9 @@ MARCO_PC_MODULES="gtk+-3.0 >= $GTK_MIN_VERSION gio-2.0 >= $GIO_MIN_VERSION pango
 GLIB_GSETTINGS
 
 AC_ARG_ENABLE(verbose-mode,
-  AC_HELP_STRING([--disable-verbose-mode],
-                 [disable marco's ability to do verbose logging, for embedded/size-sensitive custom builds]),,
-  enable_verbose_mode=yes)
+  AC_HELP_STRING([--enable-verbose-mode],
+                 [enable marco's ability to do verbose logging, for embedded/size-sensitive custom builds]),,
+  enable_verbose_mode=no)
 
 if test x$enable_verbose_mode = xyes; then
     AC_DEFINE(WITH_VERBOSE_MODE,1,[Build with verbose mode support])

--- a/configure.ac
+++ b/configure.ac
@@ -471,4 +471,6 @@ marco-$VERSION:
 	Xpresent:                 ${found_xpresent}
 	Render:                   ${have_xrender}
 	Xcursor:                  ${have_xcursor}
+	Verbose logging:          ${enable_verbose_mode}
+	Debug:                    ${ax_enable_debug}
 "


### PR DESCRIPTION
The default value for meson build is false.
https://github.com/mate-desktop/marco/blob/05ffd59e8b5a0c125e21f487e91fb0d456b63fa3/meson_options.txt#L1-L2