### PR TITLE
warning: declaration of a variable shadows a previous local

### DIFF
--- a/src/core/display.c
+++ b/src/core/display.c
@@ -403,8 +403,8 @@ meta_display_open (void)
   XInternAtoms (the_display->xdisplay, atom_names, G_N_ELEMENTS (atom_names),
                 False, atoms);
   {
-    int i = 0;
-#define item(x) the_display->atom_##x = atoms[i++];
+    int idx = 0;
+#define item(x) the_display->atom_##x = atoms[idx++];
 #include "atomnames.h"
 #undef item
   }
@@ -5240,7 +5240,6 @@ prefs_changed_callback (MetaPreference pref,
   if (pref == META_PREF_MOUSE_BUTTON_MODS ||
       pref == META_PREF_FOCUS_MODE)
     {
-      MetaDisplay *display = data;
       GSList *windows;
       GSList *tmp;
 
@@ -5290,7 +5289,6 @@ prefs_changed_callback (MetaPreference pref,
     }
   else if (pref == META_PREF_ATTACH_MODAL_DIALOGS)
     {
-      MetaDisplay *display = data;
       GSList *windows;
       GSList *tmp;
 

--- a/src/ui/menu.c
+++ b/src/ui/menu.c
@@ -351,9 +351,6 @@ meta_window_menu_new   (MetaFrames         *frames,
       if (ops & menuitem.op || menuitem.op == 0)
         {
           GtkWidget *mi;
-          MenuData *md;
-          unsigned int key;
-          MetaVirtualModifier mods;
 
           mi = menu_item_new (&menuitem, -1);
 
@@ -455,6 +452,10 @@ meta_window_menu_new   (MetaFrames         *frames,
             }
           else if (menuitem.type != MENU_ITEM_SEPARATOR)
             {
+              MenuData *md;
+              unsigned int key;
+              MetaVirtualModifier mods;
+
               meta_core_get_menu_accelerator (menuitems[i].op, -1,
                                               &key, &mods);
 

--- a/src/wm-tester/test-gravity.c
+++ b/src/wm-tester/test-gravity.c
@@ -66,7 +66,7 @@ window_gravity_to_string (int gravity)
 }
 
 static void
-calculate_position (int i, int doubled, int *x, int *y)
+calculate_position (int i, int is_doubled, int *x, int *y)
 {
   if (i == 9)
     {
@@ -77,7 +77,7 @@ calculate_position (int i, int doubled, int *x, int *y)
     {
       int xoff = x_offset[i % 3];
       int yoff = y_offset[i / 3];
-      if (doubled)
+      if (is_doubled)
         {
           xoff *= 2;
           yoff *= 2;


### PR DESCRIPTION
```
test-gravity.c:69:32: warning: declaration of ‘doubled’ shadows a global declaration [-Wshadow]
ui/menu.c:411:33: warning: declaration of ‘md’ shadows a previous local [-Wshadow]
ui/menu.c:412:36: warning: declaration of ‘key’ shadows a previous local [-Wshadow]
ui/menu.c:413:43: warning: declaration of ‘mods’ shadows a previous local [-Wshadow]
core/display.c:406:9: warning: declaration of ‘i’ shadows a previous local [-Wshadow]
core/display.c:5243:20: warning: declaration of ‘display’ shadows a previous local [-Wshadow]
core/display.c:5293:20: warning: declaration of ‘display’ shadows a previous local [-Wshadow]
```