### PR TITLE
window-props: g_memdup is dreprecated from glib 2.68

### DIFF
--- a/src/core/window-props.c
+++ b/src/core/window-props.c
@@ -1605,8 +1605,14 @@ meta_display_init_window_prop_hooks (MetaDisplay *display)
     { 0 },
   };
 
-  MetaWindowPropHooks *table = g_memdup (hooks, sizeof (hooks)),
-    *cursor = table;
+  MetaWindowPropHooks *table, *cursor;
+
+#if GLIB_CHECK_VERSION (2, 68, 0)
+  table = g_memdup2 (hooks, sizeof (hooks));
+#else
+  table = g_memdup (hooks, sizeof (hooks));
+#endif
+  cursor = table;
 
   g_assert (display->prop_hooks == NULL);
 


### PR DESCRIPTION
```
core/window-props.c:1608:3: warning: ‘g_memdup’ is deprecated: Use 'g_memdup2' instead [-Wdeprecated-declarations]
 1608 |   MetaWindowPropHooks *table = g_memdup (hooks, sizeof (hooks)),
      |   ^~~~~~~~~~~~~~~~~~~
```