### PR TITLE
window: Track window rectangle before tiling

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -2699,7 +2699,11 @@ meta_window_tile (MetaWindow *window)
     return;
 
   if(window->tile_mode == META_TILE_LEFT || window->tile_mode == META_TILE_RIGHT)
-    meta_window_maximize_internal (window, META_MAXIMIZE_VERTICAL, NULL);
+    {
+      MetaRectangle *saved_rect = NULL;
+      saved_rect = &window->saved_rect;
+      meta_window_maximize_internal (window, META_MAXIMIZE_VERTICAL, saved_rect);
+    }
   else
     meta_window_save_rect(window);
 


### PR DESCRIPTION
When tiling a maximized window, we should keep track of the saved
rectangle so that tiling does not reset our window size. Otherwise,
untiling the previously maximized window will end up with an unmaximized
full-size window, rather than the original window size.

To reproduce:
1. Open a window (pluma, mate-termina, etc)
2. Maximize
3. Tile right using keyboard shortcuts
4. Restore window
  a. Before this patch, the restored window size is a full size window
  b. After this patch, the restored window size is the original size before maximizing