### PR TITLE
iconcache: Use GDesktopAppInfo to find correct application icons

### DIFF
--- a/src/core/iconcache.c
+++ b/src/core/iconcache.c
@@ -25,6 +25,7 @@
 #include "iconcache.h"
 #include "ui.h"
 #include "errors.h"
+#include "window-private.h"
 
 #include <X11/Xatom.h>
 
@@ -690,6 +691,7 @@ scaled_from_pixdata (guchar *pixdata,
 gboolean
 meta_read_icons (MetaScreen     *screen,
                  Window          xwindow,
+                 char           *res_name,
                  MetaIconCache  *icon_cache,
                  Pixmap          wm_hints_pixmap,
                  Pixmap          wm_hints_mask,
@@ -847,13 +849,20 @@ meta_read_icons (MetaScreen     *screen,
     {
       icon_cache->fallback_icon_dirty_forced = FALSE;
 
-      get_fallback_icons (screen,
-                          iconp,
-                          ideal_width,
-                          ideal_height,
-                          mini_iconp,
-                          ideal_mini_width,
-                          ideal_mini_height);
+      if (res_name != NULL)
+        {
+          *iconp = meta_ui_get_window_icon_from_name (screen->ui, res_name);
+          *mini_iconp = meta_ui_get_mini_icon_from_name (screen->ui, res_name);
+        }
+
+      if (*iconp == NULL || *mini_iconp == NULL)
+        get_fallback_icons (screen,
+                            iconp,
+                            ideal_width,
+                            ideal_height,
+                            mini_iconp,
+                            ideal_mini_width,
+                            ideal_mini_height);
 
       replace_cache (icon_cache, USING_FALLBACK_ICON,
                      *iconp, *mini_iconp);

--- a/src/core/iconcache.h
+++ b/src/core/iconcache.h
@@ -67,6 +67,7 @@ gboolean       meta_icon_cache_get_icon_invalidated (MetaIconCache *icon_cache);
 
 gboolean meta_read_icons         (MetaScreen     *screen,
                                   Window          xwindow,
+                                  char           *res_name,
                                   MetaIconCache  *icon_cache,
                                   Pixmap          wm_hints_pixmap,
                                   Pixmap          wm_hints_mask,

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -6124,6 +6124,7 @@ meta_window_update_icon_now (MetaWindow *window)
 
   if (meta_read_icons (window->screen,
                        window->xwindow,
+                       window->res_name,
                        &window->icon_cache,
                        window->wm_hints_pixmap,
                        window->wm_hints_mask,

--- a/src/include/ui.h
+++ b/src/include/ui.h
@@ -155,6 +155,8 @@ void      meta_ui_pop_delay_exposes  (MetaUI *ui);
 
 GdkPixbuf* meta_ui_get_default_window_icon (MetaUI *ui);
 GdkPixbuf* meta_ui_get_default_mini_icon (MetaUI *ui);
+GdkPixbuf* meta_ui_get_window_icon_from_name (MetaUI *ui, char *name);
+GdkPixbuf* meta_ui_get_mini_icon_from_name (MetaUI *ui, char *name);
 
 gboolean  meta_ui_window_should_not_cause_focus (Display *xdisplay,
                                                  Window   xwindow);


### PR DESCRIPTION
Some files do not report their application icons correctly in the window
properties. This patch allows the marco UI to search for the
corresponding .desktop file and render the icon in the desktop info on
both the alt-tab popup and the window mini-icon.

Before:
![Screenshot at 2021-05-26 14-17-59](https://user-images.githubusercontent.com/259780/119711376-7b843600-be2d-11eb-9831-19dd24544103.png)

After:
![Screenshot at 2021-05-26 14-12-26](https://user-images.githubusercontent.com/259780/119711400-82ab4400-be2d-11eb-8509-ff8d493187a3.png)
