### PR TITLE
Remove obsolete gdk_window_process_all_updates()

### DIFF
--- a/src/core/boxes.c
+++ b/src/core/boxes.c
@@ -26,6 +26,7 @@
  * 02110-1301, USA.
  */
 
+#include <config.h>
 #include "boxes.h"
 #include "util.h"
 #include <X11/Xutil.h>  /* Just for the definition of the various gravities */

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -7120,7 +7120,7 @@ meta_window_show_menu (MetaWindow *window,
 
   meta_verbose ("Popping up window menu for %s\n", window->desc);
 
-  meta_ui_window_menu_popup (menu, root_x, root_y, button, timestamp);
+  meta_ui_window_menu_popup (menu);
 }
 
 void

--- a/src/include/errors.h
+++ b/src/include/errors.h
@@ -26,6 +26,7 @@
 
 #include <X11/Xlib.h>
 
+#include <config.h>
 #include "util.h"
 #include "display.h"
 

--- a/src/include/ui.h
+++ b/src/include/ui.h
@@ -130,11 +130,7 @@ MetaWindowMenu* meta_ui_window_menu_new   (MetaUI             *ui,
                                            int                 n_workspaces,
                                            MetaWindowMenuFunc  func,
                                            gpointer            data);
-void            meta_ui_window_menu_popup (MetaWindowMenu     *menu,
-                                           int                 root_x,
-                                           int                 root_y,
-                                           int                 button,
-                                           guint32             timestamp);
+void            meta_ui_window_menu_popup (MetaWindowMenu     *menu);
 void            meta_ui_window_menu_free  (MetaWindowMenu     *menu);
 
 GdkPixbuf* meta_gdk_pixbuf_get_from_pixmap (GdkPixbuf   *dest,

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -1302,11 +1302,6 @@ meta_frames_repaint_frame (MetaFrames *frames,
   frame = meta_frames_lookup_window (frames, xwindow);
 
   g_assert (frame);
-
-  /* repaint everything, so the other frame don't
-   * lag behind if they are exposed
-   */
-  gdk_window_process_all_updates ();
 }
 
 static void
@@ -2966,7 +2961,6 @@ meta_frames_push_delay_exposes (MetaFrames *frames)
   if (frames->expose_delay_count == 0)
     {
       /* Make sure we've repainted things */
-      gdk_window_process_all_updates ();
       XFlush (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()));
     }
 

--- a/src/ui/menu.c
+++ b/src/ui/menu.c
@@ -241,18 +241,9 @@ static GtkWidget* menu_item_new(MenuItem* menuitem, int workspace_id)
 	GtkWidget* mi;
 	GtkWidget* accel_label;
 
-	if (menuitem->type == MENU_ITEM_NORMAL)
+	if (menuitem->type == MENU_ITEM_NORMAL || menuitem->type == MENU_ITEM_IMAGE)
 	{
 		mi = gtk_menu_item_new ();
-	}
-	else if (menuitem->type == MENU_ITEM_IMAGE)
-	{
-		GtkWidget* image = gtk_image_new_from_icon_name(menuitem->stock_id, GTK_ICON_SIZE_MENU);
-
-		mi = gtk_image_menu_item_new();
-
-		gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(mi), image);
-		gtk_widget_show(image);
 	}
 	else if (menuitem->type == MENU_ITEM_CHECKBOX)
 	{
@@ -282,8 +273,22 @@ static GtkWidget* menu_item_new(MenuItem* menuitem, int workspace_id)
 	accel_label = meta_accel_label_new_with_mnemonic (i18n_label);
 	gtk_widget_set_halign (accel_label, GTK_ALIGN_START);
 
-	gtk_container_add (GTK_CONTAINER (mi), accel_label);
-	gtk_widget_show (accel_label);
+	if (menuitem->type == MENU_ITEM_IMAGE)
+	{
+		GtkWidget* image = gtk_image_new_from_icon_name(menuitem->stock_id, GTK_ICON_SIZE_MENU);
+		GtkWidget* box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
+
+		gtk_container_add (GTK_CONTAINER (box), image);
+		gtk_label_set_xalign (GTK_LABEL (accel_label), 0.0);
+		gtk_box_pack_end (GTK_BOX (box), accel_label, TRUE, TRUE, 0);
+		gtk_container_add (GTK_CONTAINER (mi), box);
+		gtk_widget_show_all (mi);
+	}
+	else
+	{
+		gtk_container_add (GTK_CONTAINER (mi), accel_label);
+		gtk_widget_show (accel_label);
+	}
 
 	meta_accel_label_set_accelerator (META_ACCEL_LABEL (accel_label), key, mods);
 

--- a/src/ui/menu.c
+++ b/src/ui/menu.c
@@ -101,28 +101,6 @@ static MenuItem menuitems[] = {
 	{META_MENU_OP_DELETE, MENU_ITEM_IMAGE, MARCO_STOCK_DELETE, FALSE, N_("_Close")}
 };
 
-static void popup_position_func(GtkMenu* menu, gint* x, gint* y, gboolean* push_in, gpointer user_data)
-{
-	GtkRequisition req;
-	GdkPoint* pos;
-
-	pos = user_data;
-
-	gtk_widget_get_preferred_size (GTK_WIDGET (menu), &req, NULL);
-
-	*x = pos->x;
-	*y = pos->y;
-
-	if (meta_ui_get_direction() == META_UI_DIRECTION_RTL)
-	{
-		*x = MAX (0, *x - req.width);
-	}
-
-	/* Ensure onscreen */
-	*x = CLAMP (*x, 0, MAX(0, WidthOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())) - req.width));
-	*y = CLAMP (*y, 0, MAX(0, HeightOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())) - req.height));
-}
-
 static void menu_closed(GtkMenu* widget, gpointer data)
 {
 	MetaWindowMenu *menu;
@@ -487,23 +465,6 @@ meta_window_menu_new   (MetaFrames         *frames,
                     G_CALLBACK (menu_closed), menu);
 
   return menu;
-}
-
-void meta_window_menu_popup(MetaWindowMenu* menu, int root_x, int root_y, int button, guint32 timestamp)
-{
-	GdkPoint* pt = g_new(GdkPoint, 1);
-	gint scale;
-
-	g_object_set_data_full(G_OBJECT(menu->menu), "destroy-point", pt, g_free);
-
-	scale = gtk_widget_get_scale_factor (menu->menu);
-	pt->x = root_x / scale;
-	pt->y = root_y / scale;
-
-	gtk_menu_popup(GTK_MENU (menu->menu), NULL, NULL, popup_position_func, pt, button, timestamp);
-
-    if (!gtk_widget_get_visible (menu->menu))
-      meta_warning("GtkMenu failed to grab the pointer\n");
 }
 
 void meta_window_menu_free(MetaWindowMenu* menu)

--- a/src/ui/menu.h
+++ b/src/ui/menu.h
@@ -42,7 +42,6 @@ struct _MetaWindowMenu {
 };
 
 MetaWindowMenu* meta_window_menu_new(MetaFrames* frames, MetaMenuOp ops, MetaMenuOp insensitive, Window client_xwindow, unsigned long active_workspace, int n_workspaces, MetaWindowMenuFunc func, gpointer data);
-void meta_window_menu_popup(MetaWindowMenu* menu, int root_x, int root_y, int button, guint32 timestamp);
 void meta_window_menu_free(MetaWindowMenu* menu);
 
 #endif

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -516,13 +516,9 @@ meta_ui_window_menu_new  (MetaUI             *ui,
 }
 
 void
-meta_ui_window_menu_popup (MetaWindowMenu     *menu,
-                           int                 root_x,
-                           int                 root_y,
-                           int                 button,
-                           guint32             timestamp)
+meta_ui_window_menu_popup (MetaWindowMenu     *menu)
 {
-  meta_window_menu_popup (menu, root_x, root_y, button, timestamp);
+  gtk_menu_popup_at_pointer (GTK_MENU (menu->menu), NULL);
 }
 
 void

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -20,6 +20,7 @@
  * 02110-1301, USA.
  */
 
+#include <config.h>
 #include "prefs.h"
 #include "ui.h"
 #include "frames.h"


### PR DESCRIPTION
The first commit "Always include config.h before util.h" is independent but included here for simplicity.

I am not sure if meta_frames_repaint_frame() is useful at all at this point, or it might be excised as well. Just let me know.