### PR TITLE
README: Update gtk requirement and patch submission

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -42,9 +42,8 @@ Minimal Building/Testing Environment
   build a development version of Marco -- odds are, you may be able
   to build marco from GIT without building any other modules.
 
-  As long as you have gtk+ >= 2.10 and GIO >= 2.25.10 with your distro
-  (gtk+ >= 2.6 if you manually revert the change from bug 348633), you
-  should be able to install your distro's development packages
+  As long as you have gtk+ >= 3.22 and GIO >= 2.25.10 with your distro
+  you should be able to install your distro's development packages
   (e.g. gtk2-devel, glib-devel, startup-notification-devel on
   Fedora; also, remember to install the mate-common package which is
   needed for building git versions of Mate modules like Marco) as

--- a/README
+++ b/README
@@ -6,7 +6,7 @@ MATE Marco is a fork of GNOME Metacity.
 COMPILING MARCO
 ===
 
-You need GTK+ 3.14.  For startup notification to work you need
+You need GTK+ 3.22.  For startup notification to work you need
 libstartup-notification at
 http://www.freedesktop.org/software/startup-notification/.
 
@@ -24,7 +24,8 @@ about missing features or misfeatures.
 
 Feel free to send patches too; Marco is relatively small and
 simple, so if you find a bug or want to add a feature it should be
-pretty easy.  Send me mail, or put the patch in bugzilla.
+pretty easy.  Send me mail, or file a pull request at
+https://github.com/mate-desktop/marco/pulls
 
 See the HACKING file for some notes on hacking Marco.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ MATE Marco is a fork of GNOME Metacity.
 COMPILING MARCO
 ===
 
-You need GTK+ 3.14.  For startup notification to work you need
+You need GTK+ 3.22.  For startup notification to work you need
 libstartup-notification at
 http://www.freedesktop.org/software/startup-notification/.
 
@@ -24,7 +24,8 @@ about missing features or misfeatures.
 
 Feel free to send patches too; Marco is relatively small and
 simple, so if you find a bug or want to add a feature it should be
-pretty easy.  Send me mail, or put the patch in bugzilla.
+pretty easy.  Send me mail, or file a pull request at
+https://github.com/mate-desktop/marco/pulls
 
 See the HACKING file for some notes on hacking Marco.
 


### PR DESCRIPTION
Update README README.md HACKING with gtk+ >= 3.22 and suggest github instead of bugzilla for patches.