### PR TITLE
prefs: fix memory leak

### DIFF
--- a/src/core/prefs.c
+++ b/src/core/prefs.c
@@ -1746,21 +1746,23 @@ static void
 init_bindings (GSettings *settings)
 {
   GSettingsSchema *schema;
-  gchar **list = NULL;
-  gchar *str_val = NULL;
+  gchar **list;
+  gsize i;
 
   g_object_get (settings, "settings-schema", &schema, NULL);
   list = g_settings_schema_list_keys (schema);
   g_settings_schema_unref (schema);
 
-  while (*list != NULL)
+  for (i = 0; list[i] != NULL; i++)
     {
-      str_val = g_settings_get_string (settings, *list);
-      update_key_binding (*list, str_val);
-      list++;
+      gchar *str_val;
+
+      str_val = g_settings_get_string (settings, list[i]);
+      update_key_binding (list[i], str_val);
+      g_free (str_val);
     }
 
-  g_free (str_val);
+  g_strfreev (list);
 }
 
 static void
@@ -1779,42 +1781,46 @@ static void
 init_commands (void)
 {
   GSettingsSchema *schema;
-  gchar **list = NULL;
-  gchar *str_val = NULL;
+  gchar **list;
+  gsize i;
 
   g_object_get (settings_command, "settings-schema", &schema, NULL);
   list = g_settings_schema_list_keys (schema);
   g_settings_schema_unref (schema);
 
-  while (*list != NULL)
+  for (i = 0; list[i] != NULL; i++)
     {
-      str_val = g_settings_get_string (settings_command, *list);
-      update_command (*list, str_val);
-      list++;
+      gchar *str_val;
+
+      str_val = g_settings_get_string (settings_command, list[i]);
+      update_command (list[i], str_val);
+      g_free (str_val);
     }
 
-  g_free (str_val);
+  g_strfreev (list);
 }
 
 static void
 init_workspace_names (void)
 {
   GSettingsSchema *schema;
-  gchar **list = NULL;
-  gchar *str_val = NULL;
+  gchar **list;
+  gsize i;
 
   g_object_get (settings_workspace_names, "settings-schema", &schema, NULL);
   list = g_settings_schema_list_keys (schema);
   g_settings_schema_unref (schema);
 
-  while (*list != NULL)
+  for (i = 0; list[i] != NULL; i++)
     {
-      str_val = g_settings_get_string (settings_workspace_names, *list);
-      update_workspace_name (*list, str_val);
-      list++;
+      gchar *str_val;
+
+      str_val = g_settings_get_string (settings_workspace_names, list[i]);
+      update_workspace_name (list[i], str_val);
+      g_free (str_val);
     }
 
-  g_free (str_val);
+  g_strfreev (list);
 }
 
 static gboolean


### PR DESCRIPTION
```
Direct leak of 424 byte(s) in 1 object(s) allocated from:
    #0 0x7fd3bc5ee93f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7fd3bb342b7f in g_malloc ../glib/gmem.c:106
    #2 0x7fd3bb342ec2 in g_malloc_n ../glib/gmem.c:344
    #3 0x7fd3bb642c1b in g_settings_schema_list_keys ../gio/gsettingsschema.c:1112
    #4 0x7fd3bc40e5e7 in init_bindings core/prefs.c:1753
    #5 0x7fd3bc40e73b in init_window_bindings core/prefs.c:1774
    #6 0x7fd3bc40ba95 in meta_prefs_init core/prefs.c:978
    #7 0x4040fb in main core/main.c:467
    #8 0x7fd3bae40b74 in __libc_start_main (/lib64/libc.so.6+0x27b74)

Direct leak of 523 byte(s) in 51 object(s) allocated from:
    #0 0x7f208ab9893f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7f20898ecb7f in g_malloc ../glib/gmem.c:106
    #2 0x7f20898ecec2 in g_malloc_n ../glib/gmem.c:344
    #3 0x7f208990f1a5 in g_strdup ../glib/gstrfuncs.c:364
    #4 0x7f208993c9b4 in g_variant_dup_string ../glib/gvariant.c:1537
    #5 0x7f2089bf3d0d in g_settings_get_string ../gio/gsettings.c:1809
    #6 0x7f208a9b8651 in init_bindings core/prefs.c:1758
    #7 0x7f208a9b8738 in init_window_bindings core/prefs.c:1775
    #8 0x7f208a9b5a95 in meta_prefs_init core/prefs.c:978
    #9 0x4040fb in main core/main.c:467
    #10 0x7f20893eab74 in __libc_start_main (/lib64/libc.so.6+0x27b74)
```