### PR TITLE
menu: avoid deprecated gtk_menu_popup

### DIFF
--- a/src/core/core.c
+++ b/src/core/core.c
@@ -530,20 +530,18 @@ meta_core_get_active_workspace (Screen *xscreen)
 }
 
 void
-meta_core_show_window_menu (Display *xdisplay,
-                            Window   frame_xwindow,
-                            int      root_x,
-                            int      root_y,
-                            int      button,
-                            guint32  timestamp)
+meta_core_show_window_menu (Display              *xdisplay,
+                            Window                frame_xwindow,
+                            const GdkRectangle   *rect,
+                            const GdkEventButton *event)
 {
   MetaWindow *window = get_window (xdisplay, frame_xwindow);
 
   if (meta_prefs_get_raise_on_click ())
     meta_window_raise (window);
-  meta_window_focus (window, timestamp);
+  meta_window_focus (window, event->time);
 
-  meta_window_show_menu (window, root_x, root_y, button, timestamp);
+  meta_window_show_menu (window, rect, (GdkEvent *) event);
 }
 
 void

--- a/src/core/core.c
+++ b/src/core/core.c
@@ -530,18 +530,18 @@ meta_core_get_active_workspace (Screen *xscreen)
 }
 
 void
-meta_core_show_window_menu (Display              *xdisplay,
-                            Window                frame_xwindow,
-                            const GdkRectangle   *rect,
-                            const GdkEventButton *event)
+meta_core_show_window_menu (Display            *xdisplay,
+                            Window              frame_xwindow,
+                            const GdkRectangle *rect,
+                            guint32             timestamp)
 {
   MetaWindow *window = get_window (xdisplay, frame_xwindow);
 
   if (meta_prefs_get_raise_on_click ())
     meta_window_raise (window);
-  meta_window_focus (window, event->time);
+  meta_window_focus (window, timestamp);
 
-  meta_window_show_menu (window, rect, (GdkEvent *) event);
+  meta_window_show_menu (window, rect, timestamp);
 }
 
 void

--- a/src/core/display.c
+++ b/src/core/display.c
@@ -1641,35 +1641,18 @@ mouse_event_is_in_tab_popup (MetaDisplay *display,
   return FALSE;
 }
 
-static gint
-get_window_scaling_factor (void)
-{
-  GdkScreen *screen;
-  GValue value = G_VALUE_INIT;
-
-  screen = gdk_screen_get_default ();
-
-  g_value_init (&value, G_TYPE_INT);
-
-  if (gdk_screen_get_setting (screen, "gdk-window-scaling-factor", &value))
-    return g_value_get_int (&value);
-  else
-    return 1;
-}
-
 static GdkEvent *
-button_press_event_new (XEvent *xevent)
+button_press_event_new (XEvent *xevent,
+                        gint    scale)
 {
   GdkDisplay *display;
   GdkSeat *seat;
-  gint scale;
   GdkWindow *window;
   GdkDevice *device;
   GdkEvent *event;
 
   display = gdk_display_get_default ();
   seat = gdk_display_get_default_seat (display);
-  scale = get_window_scaling_factor ();
 
   window = gdk_x11_window_lookup_for_display (display, xevent->xbutton.window);
   device = gdk_seat_get_pointer (seat);
@@ -2050,6 +2033,7 @@ static gboolean event_callback(XEvent* event, gpointer data)
           else if (event->xbutton.button == meta_prefs_get_mouse_button_menu())
             {
               GdkRectangle rect;
+              gint scale;
               GdkEvent *gdk_event;
 
               if (meta_prefs_get_raise_on_click ())
@@ -2060,7 +2044,8 @@ static gboolean event_callback(XEvent* event, gpointer data)
               rect.width = 0;
               rect.height = 0;
 
-              gdk_event = button_press_event_new (event);
+              scale = meta_ui_get_scale (window->screen->ui);
+              gdk_event = button_press_event_new (event, scale);
               meta_window_show_menu (window, &rect, gdk_event);
               gdk_event_free (gdk_event);
             }

--- a/src/core/keybindings.c
+++ b/src/core/keybindings.c
@@ -42,6 +42,7 @@
 
 #include <gio/gio.h>
 
+#include <gdk/gdkx.h>
 #include <X11/keysym.h>
 #include <string.h>
 #include <stdio.h>
@@ -2946,6 +2947,34 @@ handle_panel (MetaDisplay    *display,
   meta_error_trap_pop (display, FALSE);
 }
 
+static GdkEvent *
+key_press_event_new (XEvent *xevent)
+{
+  GdkDisplay *display;
+  GdkSeat *seat;
+  GdkWindow *window;
+  GdkDevice *device;
+  GdkEvent *event;
+
+  display = gdk_display_get_default ();
+  seat = gdk_display_get_default_seat (display);
+
+  window = gdk_x11_window_lookup_for_display (display, xevent->xkey.window);
+  device = gdk_seat_get_keyboard (seat);
+
+  event = gdk_event_new (GDK_KEY_PRESS);
+
+  event->key.window = window ? g_object_ref (window) : NULL;
+  event->key.send_event = xevent->xkey.send_event ? TRUE : FALSE;
+  event->key.time = xevent->xkey.time;
+  event->key.state = (GdkModifierType) xevent->xkey.state;
+  event->key.hardware_keycode = xevent->xkey.keycode;
+
+  gdk_event_set_device (event, device);
+
+  return event;
+}
+
 static void
 handle_activate_window_menu (MetaDisplay    *display,
                       MetaScreen     *screen,
@@ -2955,18 +2984,17 @@ handle_activate_window_menu (MetaDisplay    *display,
 {
   if (display->focus_window)
     {
-      int x, y;
+      GdkRectangle rect;
+      GdkEvent *gdk_event;
 
-      meta_window_get_position (display->focus_window,
-                                &x, &y);
+      rect.x = display->focus_window->rect.x;
+      rect.y = display->focus_window->rect.y;
+      rect.width = display->focus_window->rect.width;
+      rect.height = 0;
 
-      if (meta_ui_get_direction() == META_UI_DIRECTION_RTL)
-	  x += display->focus_window->rect.width;
-
-      meta_window_show_menu (display->focus_window,
-                             x, y,
-                             0,
-                             event->xkey.time);
+      gdk_event = key_press_event_new (event);
+      meta_window_show_menu (display->focus_window, &rect, gdk_event);
+      gdk_event_free (gdk_event);
     }
 }
 

--- a/src/core/keybindings.c
+++ b/src/core/keybindings.c
@@ -42,7 +42,6 @@
 
 #include <gio/gio.h>
 
-#include <gdk/gdkx.h>
 #include <X11/keysym.h>
 #include <string.h>
 #include <stdio.h>
@@ -2947,34 +2946,6 @@ handle_panel (MetaDisplay    *display,
   meta_error_trap_pop (display, FALSE);
 }
 
-static GdkEvent *
-key_press_event_new (XEvent *xevent)
-{
-  GdkDisplay *display;
-  GdkSeat *seat;
-  GdkWindow *window;
-  GdkDevice *device;
-  GdkEvent *event;
-
-  display = gdk_display_get_default ();
-  seat = gdk_display_get_default_seat (display);
-
-  window = gdk_x11_window_lookup_for_display (display, xevent->xkey.window);
-  device = gdk_seat_get_keyboard (seat);
-
-  event = gdk_event_new (GDK_KEY_PRESS);
-
-  event->key.window = window ? g_object_ref (window) : NULL;
-  event->key.send_event = xevent->xkey.send_event ? TRUE : FALSE;
-  event->key.time = xevent->xkey.time;
-  event->key.state = (GdkModifierType) xevent->xkey.state;
-  event->key.hardware_keycode = xevent->xkey.keycode;
-
-  gdk_event_set_device (event, device);
-
-  return event;
-}
-
 static void
 handle_activate_window_menu (MetaDisplay    *display,
                       MetaScreen     *screen,
@@ -2985,16 +2956,13 @@ handle_activate_window_menu (MetaDisplay    *display,
   if (display->focus_window)
     {
       GdkRectangle rect;
-      GdkEvent *gdk_event;
 
-      rect.x = display->focus_window->rect.x;
-      rect.y = display->focus_window->rect.y;
+      meta_window_get_position (display->focus_window,
+                                &rect.x, &rect.y);
       rect.width = display->focus_window->rect.width;
       rect.height = 0;
 
-      gdk_event = key_press_event_new (event);
-      meta_window_show_menu (display->focus_window, &rect, gdk_event);
-      gdk_event_free (gdk_event);
+      meta_window_show_menu (display->focus_window, &rect, event->xkey.time);
     }
 }
 

--- a/src/core/window-private.h
+++ b/src/core/window-private.h
@@ -606,11 +606,9 @@ void     meta_window_set_current_workspace_hint (MetaWindow *window);
 
 unsigned long meta_window_get_net_wm_desktop (MetaWindow *window);
 
-void meta_window_show_menu (MetaWindow *window,
-                            int         root_x,
-                            int         root_y,
-                            int         button,
-                            guint32     timestamp);
+void meta_window_show_menu (MetaWindow         *window,
+                            const GdkRectangle *rect,
+                            const GdkEvent     *event);
 
 gboolean meta_window_titlebar_is_onscreen    (MetaWindow *window);
 void     meta_window_shove_titlebar_onscreen (MetaWindow *window);

--- a/src/core/window-private.h
+++ b/src/core/window-private.h
@@ -608,7 +608,7 @@ unsigned long meta_window_get_net_wm_desktop (MetaWindow *window);
 
 void meta_window_show_menu (MetaWindow         *window,
                             const GdkRectangle *rect,
-                            const GdkEvent     *event);
+                            guint32             timestamp);
 
 gboolean meta_window_titlebar_is_onscreen    (MetaWindow *window);
 void     meta_window_shove_titlebar_onscreen (MetaWindow *window);

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -5562,7 +5562,7 @@ meta_window_client_message (MetaWindow *window,
            display->atom__GTK_SHOW_WINDOW_MENU)
     {
       GdkRectangle rect;
-      GdkEvent *gdk_event;
+      guint32 timestamp;
 
       if (meta_prefs_get_raise_on_click ())
         meta_window_raise (window);
@@ -5572,10 +5572,8 @@ meta_window_client_message (MetaWindow *window,
       rect.width = 0;
       rect.height = 0;
 
-      gdk_event = gdk_event_new(GDK_BUTTON_PRESS);
-      gdk_event->button.button = 3;
-      meta_window_show_menu (window, &rect, gdk_event);
-      gdk_event_free(gdk_event);
+      timestamp = meta_display_get_current_time_roundtrip (display);
+      meta_window_show_menu (window, &rect, timestamp);
     }
 
   return FALSE;
@@ -6995,7 +6993,7 @@ menu_callback (MetaWindowMenu *menu,
 void
 meta_window_show_menu (MetaWindow         *window,
                        const GdkRectangle *rect,
-                       const GdkEvent     *event)
+                       guint32             timestamp)
 {
   MetaMenuOp ops;
   MetaMenuOp insensitive;
@@ -7116,7 +7114,7 @@ meta_window_show_menu (MetaWindow         *window,
 
   meta_verbose ("Popping up window menu for %s\n", window->desc);
 
-  meta_ui_window_menu_popup (menu, rect, event);
+  meta_ui_window_menu_popup (menu, rect, timestamp);
 }
 
 void

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -5561,23 +5561,21 @@ meta_window_client_message (MetaWindow *window,
   else if (event->xclient.message_type ==
            display->atom__GTK_SHOW_WINDOW_MENU)
     {
-      gulong x_root, y_root;
-      guint32 timestamp;
-      int button;
+      GdkRectangle rect;
+      GdkEvent *gdk_event;
 
       if (meta_prefs_get_raise_on_click ())
         meta_window_raise (window);
 
-      timestamp = meta_display_get_current_time_roundtrip (display);
-      x_root = event->xclient.data.l[1];
-      y_root = event->xclient.data.l[2];
-      button = 3;
+      rect.x = event->xclient.data.l[1];
+      rect.y = event->xclient.data.l[2];
+      rect.width = 0;
+      rect.height = 0;
 
-      meta_window_show_menu (window,
-                             x_root,
-                             y_root,
-                             button,
-                             timestamp);
+      gdk_event = gdk_event_new(GDK_BUTTON_PRESS);
+      gdk_event->button.button = 3;
+      meta_window_show_menu (window, &rect, gdk_event);
+      gdk_event_free(gdk_event);
     }
 
   return FALSE;
@@ -6995,11 +6993,9 @@ menu_callback (MetaWindowMenu *menu,
 }
 
 void
-meta_window_show_menu (MetaWindow *window,
-                       int         root_x,
-                       int         root_y,
-                       int         button,
-                       guint32     timestamp)
+meta_window_show_menu (MetaWindow         *window,
+                       const GdkRectangle *rect,
+                       const GdkEvent     *event)
 {
   MetaMenuOp ops;
   MetaMenuOp insensitive;
@@ -7120,7 +7116,7 @@ meta_window_show_menu (MetaWindow *window,
 
   meta_verbose ("Popping up window menu for %s\n", window->desc);
 
-  meta_ui_window_menu_popup (menu, root_x, root_y, button, timestamp);
+  meta_ui_window_menu_popup (menu, rect, event);
 }
 
 void

--- a/src/include/core.h
+++ b/src/include/core.h
@@ -162,10 +162,10 @@ const char* meta_core_get_workspace_name_with_index (Display *xdisplay,
                                                      Window xroot,
                                                      int    index);
 
-void meta_core_show_window_menu (Display              *xdisplay,
-                                 Window                frame_xwindow,
-                                 const GdkRectangle   *rect,
-                                 const GdkEventButton *event);
+void meta_core_show_window_menu (Display            *xdisplay,
+                                 Window              frame_xwindow,
+                                 const GdkRectangle *rect,
+                                 guint32             timestamp);
 
 void meta_core_get_menu_accelerator (MetaMenuOp           menu_op,
                                      int                  workspace,

--- a/src/include/core.h
+++ b/src/include/core.h
@@ -162,12 +162,10 @@ const char* meta_core_get_workspace_name_with_index (Display *xdisplay,
                                                      Window xroot,
                                                      int    index);
 
-void meta_core_show_window_menu (Display *xdisplay,
-                                 Window   frame_xwindow,
-                                 int      root_x,
-                                 int      root_y,
-                                 int      button,
-                                 guint32  timestamp);
+void meta_core_show_window_menu (Display              *xdisplay,
+                                 Window                frame_xwindow,
+                                 const GdkRectangle   *rect,
+                                 const GdkEventButton *event);
 
 void meta_core_get_menu_accelerator (MetaMenuOp           menu_op,
                                      int                  workspace,

--- a/src/include/ui.h
+++ b/src/include/ui.h
@@ -131,10 +131,8 @@ MetaWindowMenu* meta_ui_window_menu_new   (MetaUI             *ui,
                                            MetaWindowMenuFunc  func,
                                            gpointer            data);
 void            meta_ui_window_menu_popup (MetaWindowMenu     *menu,
-                                           int                 root_x,
-                                           int                 root_y,
-                                           int                 button,
-                                           guint32             timestamp);
+                                           const GdkRectangle *rect,
+                                           const GdkEvent     *event);
 void            meta_ui_window_menu_free  (MetaWindowMenu     *menu);
 
 GdkPixbuf* meta_gdk_pixbuf_get_from_pixmap (GdkPixbuf   *dest,

--- a/src/include/ui.h
+++ b/src/include/ui.h
@@ -134,7 +134,7 @@ MetaWindowMenu* meta_ui_window_menu_new   (MetaUI             *ui,
                                            gpointer            data);
 void            meta_ui_window_menu_popup (MetaWindowMenu     *menu,
                                            const GdkRectangle *rect,
-                                           const GdkEvent     *event);
+                                           guint32             timestamp);
 void            meta_ui_window_menu_free  (MetaWindowMenu     *menu);
 
 GdkPixbuf* meta_gdk_pixbuf_get_from_pixmap (GdkPixbuf   *dest,

--- a/src/include/ui.h
+++ b/src/include/ui.h
@@ -62,6 +62,8 @@ MetaUI* meta_ui_new (Display *xdisplay,
                      Screen  *screen);
 void    meta_ui_free (MetaUI *ui);
 
+gint meta_ui_get_scale (MetaUI *ui);
+
 void meta_ui_theme_get_frame_borders (MetaUI           *ui,
                                       MetaFrameType     type,
                                       MetaFrameFlags    flags,

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -1567,14 +1567,14 @@ meta_frame_titlebar_event (MetaUIFrame    *frame,
       {
         GdkRectangle rect;
 
-        rect.x = event->x;
-        rect.y = event->y;
+        rect.x = event->x_root;
+        rect.y = event->y_root;
         rect.width = 0;
         rect.height = 0;
         meta_core_show_window_menu (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()),
                                   frame->xwindow,
                                   &rect,
-                                  event);
+                                  event->time);
       }
       break;
 
@@ -1752,7 +1752,7 @@ meta_frames_button_press_event (GtkWidget      *widget,
           meta_core_show_window_menu (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()),
                                       frame->xwindow,
                                       rect,
-                                      event);
+                                      event->time);
         }
     }
   else if (event->button == 1 &&

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -1564,12 +1564,18 @@ meta_frame_titlebar_event (MetaUIFrame    *frame,
       break;
 
     case META_ACTION_TITLEBAR_MENU:
-      meta_core_show_window_menu (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()),
+      {
+        GdkRectangle rect;
+
+        rect.x = event->x;
+        rect.y = event->y;
+        rect.width = 0;
+        rect.height = 0;
+        meta_core_show_window_menu (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()),
                                   frame->xwindow,
-                                  event->x_root,
-                                  event->y_root,
-                                  event->button,
-                                  event->time);
+                                  &rect,
+                                  event);
+      }
       break;
 
     case META_ACTION_TITLEBAR_LAST:
@@ -1738,26 +1744,15 @@ meta_frames_button_press_event (GtkWidget      *widget,
         {
           MetaFrameGeometry fgeom;
           GdkRectangle *rect;
-          int dx, dy;
 
           meta_frames_calc_geometry (frames, frame, &fgeom);
 
           rect = control_rect (META_FRAME_CONTROL_MENU, &fgeom);
 
-          /* get delta to convert to root coords */
-          dx = event->x_root - event->x;
-          dy = event->y_root - event->y;
-
-          /* Align to the right end of the menu rectangle if RTL */
-          if (meta_ui_get_direction() == META_UI_DIRECTION_RTL)
-            dx += rect->width;
-
           meta_core_show_window_menu (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()),
                                       frame->xwindow,
-                                      rect->x + dx,
-                                      rect->y + rect->height + dy,
-                                      event->button,
-                                      event->time);
+                                      rect,
+                                      event);
         }
     }
   else if (event->button == 1 &&

--- a/src/ui/menu.c
+++ b/src/ui/menu.c
@@ -467,12 +467,25 @@ meta_window_menu_new   (MetaFrames         *frames,
   return menu;
 }
 
-void meta_window_menu_popup(MetaWindowMenu* menu, const GdkRectangle *rect, const GdkEvent *event)
+void meta_window_menu_popup(MetaWindowMenu* menu, const GdkRectangle *rect, guint32 timestamp)
 {
-	GdkEventAny *any;
+	GdkDisplay *display;
+	GdkEvent *event;
+	GdkWindow *window;
+	GdkDevice *device;
 
-	any = (GdkEventAny *) event;
-	gtk_menu_popup_at_rect(GTK_MENU (menu->menu), any->window, rect, GDK_GRAVITY_SOUTH_WEST, GDK_GRAVITY_NORTH_WEST, event);
+	display = gdk_display_get_default ();
+
+	event = gdk_event_new (GDK_BUTTON_PRESS);
+	event->button.time = timestamp;
+
+	window = gdk_screen_get_root_window (gdk_display_get_default_screen (display));
+	event->button.window = g_object_ref (window);
+
+	device = gdk_seat_get_pointer (gdk_display_get_default_seat (display));
+	gdk_event_set_device (event, device);
+
+	gtk_menu_popup_at_rect(GTK_MENU (menu->menu), event->any.window, rect, GDK_GRAVITY_SOUTH_WEST, GDK_GRAVITY_NORTH_WEST, event);
 
     if (!gtk_widget_get_visible (menu->menu))
       meta_warning("GtkMenu failed to grab the pointer\n");

--- a/src/ui/menu.c
+++ b/src/ui/menu.c
@@ -101,28 +101,6 @@ static MenuItem menuitems[] = {
 	{META_MENU_OP_DELETE, MENU_ITEM_IMAGE, MARCO_STOCK_DELETE, FALSE, N_("_Close")}
 };
 
-static void popup_position_func(GtkMenu* menu, gint* x, gint* y, gboolean* push_in, gpointer user_data)
-{
-	GtkRequisition req;
-	GdkPoint* pos;
-
-	pos = user_data;
-
-	gtk_widget_get_preferred_size (GTK_WIDGET (menu), &req, NULL);
-
-	*x = pos->x;
-	*y = pos->y;
-
-	if (meta_ui_get_direction() == META_UI_DIRECTION_RTL)
-	{
-		*x = MAX (0, *x - req.width);
-	}
-
-	/* Ensure onscreen */
-	*x = CLAMP (*x, 0, MAX(0, WidthOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())) - req.width));
-	*y = CLAMP (*y, 0, MAX(0, HeightOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ())) - req.height));
-}
-
 static void menu_closed(GtkMenu* widget, gpointer data)
 {
 	MetaWindowMenu *menu;
@@ -489,18 +467,12 @@ meta_window_menu_new   (MetaFrames         *frames,
   return menu;
 }
 
-void meta_window_menu_popup(MetaWindowMenu* menu, int root_x, int root_y, int button, guint32 timestamp)
+void meta_window_menu_popup(MetaWindowMenu* menu, const GdkRectangle *rect, const GdkEvent *event)
 {
-	GdkPoint* pt = g_new(GdkPoint, 1);
-	gint scale;
+	GdkEventAny *any;
 
-	g_object_set_data_full(G_OBJECT(menu->menu), "destroy-point", pt, g_free);
-
-	scale = gtk_widget_get_scale_factor (menu->menu);
-	pt->x = root_x / scale;
-	pt->y = root_y / scale;
-
-	gtk_menu_popup(GTK_MENU (menu->menu), NULL, NULL, popup_position_func, pt, button, timestamp);
+	any = (GdkEventAny *) event;
+	gtk_menu_popup_at_rect(GTK_MENU (menu->menu), any->window, rect, GDK_GRAVITY_SOUTH_WEST, GDK_GRAVITY_NORTH_WEST, event);
 
     if (!gtk_widget_get_visible (menu->menu))
       meta_warning("GtkMenu failed to grab the pointer\n");

--- a/src/ui/menu.h
+++ b/src/ui/menu.h
@@ -42,7 +42,7 @@ struct _MetaWindowMenu {
 };
 
 MetaWindowMenu* meta_window_menu_new(MetaFrames* frames, MetaMenuOp ops, MetaMenuOp insensitive, Window client_xwindow, unsigned long active_workspace, int n_workspaces, MetaWindowMenuFunc func, gpointer data);
-void meta_window_menu_popup(MetaWindowMenu* menu, int root_x, int root_y, int button, guint32 timestamp);
+void meta_window_menu_popup(MetaWindowMenu* menu, const GdkRectangle *rect, const GdkEvent *event);
 void meta_window_menu_free(MetaWindowMenu* menu);
 
 #endif

--- a/src/ui/menu.h
+++ b/src/ui/menu.h
@@ -42,7 +42,7 @@ struct _MetaWindowMenu {
 };
 
 MetaWindowMenu* meta_window_menu_new(MetaFrames* frames, MetaMenuOp ops, MetaMenuOp insensitive, Window client_xwindow, unsigned long active_workspace, int n_workspaces, MetaWindowMenuFunc func, gpointer data);
-void meta_window_menu_popup(MetaWindowMenu* menu, const GdkRectangle *rect, const GdkEvent *event);
+void meta_window_menu_popup(MetaWindowMenu* menu, const GdkRectangle *rect, guint32 timestamp);
 void meta_window_menu_free(MetaWindowMenu* menu);
 
 #endif

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -473,6 +473,12 @@ meta_ui_destroy_frame_window (MetaUI *ui,
   meta_frames_unmanage_window (ui->frames, xwindow);
 }
 
+gint
+meta_ui_get_scale (MetaUI *ui)
+{
+  return ui->scale;
+}
+
 void
 meta_ui_move_resize_frame (MetaUI *ui,
 			   Window frame,

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -594,9 +594,9 @@ meta_ui_window_menu_new  (MetaUI             *ui,
 void
 meta_ui_window_menu_popup (MetaWindowMenu     *menu,
                            const GdkRectangle *rect,
-                           const GdkEvent     *event)
+                           guint32             timestamp)
 {
-  meta_window_menu_popup (menu, rect, event);
+  meta_window_menu_popup (menu, rect, timestamp);
 }
 
 void

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -516,12 +516,10 @@ meta_ui_window_menu_new  (MetaUI             *ui,
 
 void
 meta_ui_window_menu_popup (MetaWindowMenu     *menu,
-                           int                 root_x,
-                           int                 root_y,
-                           int                 button,
-                           guint32             timestamp)
+                           const GdkRectangle *rect,
+                           const GdkEvent     *event)
 {
-  meta_window_menu_popup (menu, root_x, root_y, button, timestamp);
+  meta_window_menu_popup (menu, rect, event);
 }
 
 void


### PR DESCRIPTION
Adapted from metacity commit 37fa0d19 by Alberts Muktupāvels

Unsure about the handling of atom__GTK_SHOW_WINDOW_MENU xclient message in meta_window_client_message() in src/core/window.c - whether more gdk_event fields must be filled in, or if we could use button_press_event_new() from display.c instead. Also unsure on how to test this path.
