### PR TITLE
compositor-xrender: fix memory leak

### DIFF
--- a/src/compositor/compositor-xrender.c
+++ b/src/compositor/compositor-xrender.c
@@ -402,11 +402,6 @@ presum_gaussian (shadow *shad)
   msize = map->size;
   centre = map->size / 2;
 
-  if (shad->shadow_corner)
-    g_free (shad->shadow_corner);
-  if (shad->shadow_top)
-    g_free (shad->shadow_top);
-
   shad->shadow_corner = (guchar *)(g_malloc ((msize + 1) * (msize + 1) * 26));
   shad->shadow_top = (guchar *) (g_malloc ((msize + 1) * 26));
 


### PR DESCRIPTION
```
Direct leak of 72 byte(s) in 3 object(s) allocated from:
    #0 0x7fea8cc8caf7 in calloc (/lib64/libasan.so.6+0xaeaf7)
    #1 0x7fea8b9e0c04 in g_malloc0 ../glib/gmem.c:136
    #2 0x7fea8b9e0f52 in g_malloc0_n ../glib/gmem.c:368
    #3 0x7fea8ca3eb79 in generate_shadows compositor/compositor-xrender.c:459
    #4 0x7fea8ca4e50b in xrender_manage_screen compositor/compositor-xrender.c:3010
    #5 0x7fea8ca3d465 in meta_compositor_manage_screen compositor/compositor.c:74
    #6 0x7fea8ca5db9e in enable_compositor core/display.c:288
    #7 0x7fea8ca636ed in meta_display_open core/display.c:742
    #8 0x404673 in main core/main.c:553
    #9 0x7fea8b4deb74 in __libc_start_main (/lib64/libc.so.6+0x27b74)

Indirect leak of 48126 byte(s) in 3 object(s) allocated from:
    #0 0x7fea8cc8c93f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7fea8b9e0b7f in g_malloc ../glib/gmem.c:106
    #2 0x7fea8ca3e435 in presum_gaussian compositor/compositor-xrender.c:410
    #3 0x7fea8ca3ec04 in generate_shadows compositor/compositor-xrender.c:462
    #4 0x7fea8ca4e50b in xrender_manage_screen compositor/compositor-xrender.c:3010
    #5 0x7fea8ca3d465 in meta_compositor_manage_screen compositor/compositor.c:74
    #6 0x7fea8ca5db9e in enable_compositor core/display.c:288
    #7 0x7fea8ca636ed in meta_display_open core/display.c:742
    #8 0x404673 in main core/main.c:553
    #9 0x7fea8b4deb74 in __libc_start_main (/lib64/libc.so.6+0x27b74)

Indirect leak of 1742 byte(s) in 3 object(s) allocated from:
    #0 0x7fea8cc8c93f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7fea8b9e0b7f in g_malloc ../glib/gmem.c:106
    #2 0x7fea8ca3e478 in presum_gaussian compositor/compositor-xrender.c:411
    #3 0x7fea8ca3ec04 in generate_shadows compositor/compositor-xrender.c:462
    #4 0x7fea8ca4e50b in xrender_manage_screen compositor/compositor-xrender.c:3010
    #5 0x7fea8ca3d465 in meta_compositor_manage_screen compositor/compositor.c:74
    #6 0x7fea8ca5db9e in enable_compositor core/display.c:288
    #7 0x7fea8ca636ed in meta_display_open core/display.c:742
    #8 0x404673 in main core/main.c:553
    #9 0x7fea8b4deb74 in __libc_start_main (/lib64/libc.so.6+0x27b74)
```