### PR TITLE
Fix implicit conversion changes signedness: 'gboolean' to 'guint'

### DIFF
--- a/src/core/constraints.c
+++ b/src/core/constraints.c
@@ -628,8 +628,8 @@ update_onscreen_requirements (MetaWindow     *window,
    */
   old = window->require_fully_onscreen;
   window->require_fully_onscreen =
-    meta_rectangle_contained_in_region (info->usable_screen_region,
-                                        &info->current);
+    (meta_rectangle_contained_in_region (info->usable_screen_region,
+                                         &info->current) != FALSE);
   if (old ^ window->require_fully_onscreen)
     meta_topic (META_DEBUG_GEOMETRY,
                 "require_fully_onscreen for %s toggled to %s\n",
@@ -641,8 +641,8 @@ update_onscreen_requirements (MetaWindow     *window,
    */
   old = window->require_on_single_xinerama;
   window->require_on_single_xinerama =
-    meta_rectangle_contained_in_region (info->usable_xinerama_region,
-                                        &info->current);
+    (meta_rectangle_contained_in_region (info->usable_xinerama_region,
+                                         &info->current) != FALSE);
   if (old ^ window->require_on_single_xinerama)
     meta_topic (META_DEBUG_GEOMETRY,
                 "require_on_single_xinerama for %s toggled to %s\n",
@@ -660,8 +660,8 @@ update_onscreen_requirements (MetaWindow     *window,
       titlebar_rect.height = info->borders->visible.top;
       old = window->require_titlebar_visible;
       window->require_titlebar_visible =
-        meta_rectangle_overlaps_with_region (info->usable_screen_region,
-                                             &titlebar_rect);
+        (meta_rectangle_overlaps_with_region (info->usable_screen_region,
+                                              &titlebar_rect) != FALSE);
       if (old ^ window->require_titlebar_visible)
         meta_topic (META_DEBUG_GEOMETRY,
                     "require_titlebar_visible for %s toggled to %s\n",

--- a/src/core/display-private.h
+++ b/src/core/display-private.h
@@ -177,11 +177,13 @@ struct _MetaDisplay {
 	guint       grab_wireframe_active : 1;
 	guint       grab_was_cancelled : 1;    /* Only used in wireframe mode */
 	guint       grab_frame_action : 1;
+	guint       grab_last_user_action_was_snap : 1;
+	guint       grab_threshold_movement_reached : 1;
 	MetaRectangle grab_wireframe_rect;
 	MetaRectangle grab_wireframe_last_xor_rect;
 	MetaRectangle grab_initial_window_pos;
 	int         grab_initial_x, grab_initial_y;  /* These are only relevant for */
-	gboolean    grab_threshold_movement_reached; /* raise_on_click == FALSE.    */
+	                                             /* raise_on_click == FALSE.    */
 	MetaResizePopup* grab_resize_popup;
 	gint64      grab_last_moveresize_time;
 	guint32     grab_motion_notify_time;
@@ -189,7 +191,6 @@ struct _MetaDisplay {
 	int         grab_wireframe_last_display_height;
 	GList*      grab_old_window_stacking;
 	MetaEdgeResistanceData* grab_edge_resistance_data;
-	unsigned int grab_last_user_action_was_snap;
 
 	/* we use property updates as sentinels for certain window focus events
 	 * to avoid some race conditions on EnterNotify events

--- a/src/core/display.c
+++ b/src/core/display.c
@@ -3623,11 +3623,11 @@ meta_display_begin_grab_op (MetaDisplay *display,
     {
       if (window)
         display->grab_have_keyboard =
-                     meta_window_grab_all_keys (window, timestamp);
+          (meta_window_grab_all_keys (window, timestamp) != FALSE);
 
       else
         display->grab_have_keyboard =
-                     meta_screen_grab_all_keys (screen, timestamp);
+          (meta_screen_grab_all_keys (screen, timestamp) != FALSE);
 
       if (!display->grab_have_keyboard)
         {
@@ -3668,7 +3668,7 @@ meta_display_begin_grab_op (MetaDisplay *display,
   display->grab_last_user_action_was_snap = FALSE;
 #endif
   display->grab_was_cancelled = FALSE;
-  display->grab_frame_action = frame_action;
+  display->grab_frame_action = (frame_action != FALSE);
 
   if (display->grab_resize_timeout_id)
     {
@@ -3855,7 +3855,7 @@ meta_display_end_grab_op (MetaDisplay *display,
        * For raise on click mode, the window was raised at the
        * beginning of the grab_op.
        */
-      if (!display->grab_threshold_movement_reached)
+      if (display->grab_threshold_movement_reached == FALSE)
         meta_window_raise (display->grab_window);
     }
 
@@ -3979,7 +3979,7 @@ meta_display_check_threshold_reached (MetaDisplay *display,
 {
   /* Don't bother doing the check again if we've already reached the threshold */
   if (meta_prefs_get_raise_on_click () ||
-      display->grab_threshold_movement_reached)
+      display->grab_threshold_movement_reached != FALSE)
     return;
 
   if (ABS (display->grab_initial_x - x) >= 8 ||

--- a/src/core/edge-resistance.c
+++ b/src/core/edge-resistance.c
@@ -1161,7 +1161,7 @@ meta_window_edge_resistance_for_move (MetaWindow  *window,
   proposed_outer.y += (*new_y - old_y);
   new_outer = proposed_outer;
 
-  window->display->grab_last_user_action_was_snap = snap;
+  window->display->grab_last_user_action_was_snap = (snap != FALSE);
   is_resize = FALSE;
   if (apply_edge_resistance_to_each_side (window->display,
                                           window,
@@ -1259,7 +1259,7 @@ meta_window_edge_resistance_for_resize (MetaWindow  *window,
                                       proposed_outer_width,
                                       proposed_outer_height);
 
-  window->display->grab_last_user_action_was_snap = snap;
+  window->display->grab_last_user_action_was_snap = (snap != FALSE);
   is_resize = TRUE;
   if (apply_edge_resistance_to_each_side (window->display,
                                           window,

--- a/src/core/window-props.c
+++ b/src/core/window-props.c
@@ -551,7 +551,7 @@ set_window_title (MetaWindow *window,
                     title,
                     window->display->atom__NET_WM_VISIBLE_NAME,
                     &window->title);
-  window->using_net_wm_visible_name = modified;
+  window->using_net_wm_visible_name = (modified != FALSE);
 
   /* strndup is a hack since GNU libc has broken %.10s */
   str = g_strndup (window->title, 10);
@@ -622,7 +622,7 @@ set_icon_title (MetaWindow *window,
                     title,
                     window->display->atom__NET_WM_VISIBLE_ICON_NAME,
                     &window->icon_name);
-  window->using_net_wm_visible_icon_name = modified;
+  window->using_net_wm_visible_icon_name = (modified != FALSE);
 }
 
 static void
@@ -819,31 +819,31 @@ reload_mwm_hints (MetaWindow    *window,
         {
           meta_verbose ("Window %s toggles close via MWM hints\n",
                         window->desc);
-          window->mwm_has_close_func = toggle_value;
+          window->mwm_has_close_func = (toggle_value != FALSE);
         }
       if ((hints->functions & MWM_FUNC_MINIMIZE) != 0)
         {
           meta_verbose ("Window %s toggles minimize via MWM hints\n",
                         window->desc);
-          window->mwm_has_minimize_func = toggle_value;
+          window->mwm_has_minimize_func = (toggle_value != FALSE);
         }
       if ((hints->functions & MWM_FUNC_MAXIMIZE) != 0)
         {
           meta_verbose ("Window %s toggles maximize via MWM hints\n",
                         window->desc);
-          window->mwm_has_maximize_func = toggle_value;
+          window->mwm_has_maximize_func = (toggle_value != FALSE);
         }
       if ((hints->functions & MWM_FUNC_MOVE) != 0)
         {
           meta_verbose ("Window %s toggles move via MWM hints\n",
                         window->desc);
-          window->mwm_has_move_func = toggle_value;
+          window->mwm_has_move_func = (toggle_value != FALSE);
         }
       if ((hints->functions & MWM_FUNC_RESIZE) != 0)
         {
           meta_verbose ("Window %s toggles resize via MWM hints\n",
                         window->desc);
-          window->mwm_has_resize_func = toggle_value;
+          window->mwm_has_resize_func = (toggle_value != FALSE);
         }
     }
   else

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -432,7 +432,7 @@ meta_window_new_with_attrs (MetaDisplay       *display,
   /* avoid tons of stack updates */
   meta_stack_freeze (window->screen->stack);
 
-  window->has_shape = has_shape;
+  window->has_shape = (has_shape != FALSE);
 
   window->rect.x = attrs->x;
   window->rect.y = attrs->y;
@@ -7298,7 +7298,7 @@ update_move_timeout (gpointer data)
   MetaWindow *window = data;
 
   update_move (window,
-               window->display->grab_last_user_action_was_snap,
+               window->display->grab_last_user_action_was_snap != FALSE,
                window->display->grab_latest_motion_x,
                window->display->grab_latest_motion_y);
 
@@ -7604,7 +7604,7 @@ update_resize_timeout (gpointer data)
   MetaWindow *window = data;
 
   update_resize (window,
-                 window->display->grab_last_user_action_was_snap,
+                 window->display->grab_last_user_action_was_snap != FALSE,
                  window->display->grab_latest_motion_x,
                  window->display->grab_latest_motion_y,
                  TRUE);
@@ -7968,7 +7968,7 @@ meta_window_handle_mouse_grab_op_event (MetaWindow *window,
         case META_GRAB_OP_KEYBOARD_RESIZING_NW:
           /* no pointer round trip here, to keep in sync */
           update_resize (window,
-                         window->display->grab_last_user_action_was_snap,
+                         window->display->grab_last_user_action_was_snap != FALSE,
                          window->display->grab_latest_motion_x,
                          window->display->grab_latest_motion_y,
                          TRUE);
@@ -7991,7 +7991,7 @@ meta_window_handle_mouse_grab_op_event (MetaWindow *window,
        * mouse button and they almost certainly do not want a
        * non-snapped movement to occur from the button release.
        */
-      if (!window->display->grab_last_user_action_was_snap)
+      if (window->display->grab_last_user_action_was_snap == FALSE)
         {
           if (meta_grab_op_is_moving (window->display->grab_op))
             {

--- a/src/ui/theme-parser.c
+++ b/src/ui/theme-parser.c
@@ -1063,10 +1063,10 @@ parse_toplevel_element (GMarkupParseContext  *context,
         info->layout = meta_frame_layout_new ();
 
       if (has_title) /* only if explicit, otherwise inherit */
-        info->layout->has_title = has_title_val;
+        info->layout->has_title = (has_title_val != FALSE);
 
       if (META_THEME_ALLOWS (info->theme, META_THEME_HIDDEN_BUTTONS) && hide_buttons_val)
-          info->layout->hide_buttons = hide_buttons_val;
+          info->layout->hide_buttons = (hide_buttons_val != FALSE);
 
       if (title_scale)
 	info->layout->title_scale = title_scale_val;


### PR DESCRIPTION
```
CFLAGS="-Wconversion -Wunused-macros -Wunused-parameter" CC=clang ./autogen.sh --prefix=/usr --enable-debug --enable-compile-warnings=maximum && make &> make.log
```
```
core/constraints.c:631:5: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
    meta_rectangle_contained_in_region (info->usable_screen_region,
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
core/constraints.c:644:5: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
    meta_rectangle_contained_in_region (info->usable_xinerama_region,
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
core/constraints.c:663:9: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
        meta_rectangle_overlaps_with_region (info->usable_screen_region,
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
--
core/display.c:3626:22: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
                     meta_window_grab_all_keys (window, timestamp);
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
core/display.c:3630:22: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
                     meta_screen_grab_all_keys (screen, timestamp);
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
core/display.c:3671:32: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
  display->grab_frame_action = frame_action;
                             ~ ^~~~~~~~~~~~
--
core/edge-resistance.c:1164:53: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'unsigned int' [-Wsign-conversion]
  window->display->grab_last_user_action_was_snap = snap;
                                                  ~ ^~~~
core/edge-resistance.c:1262:53: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'unsigned int' [-Wsign-conversion]
  window->display->grab_last_user_action_was_snap = snap;
                                                  ~ ^~~~
--
core/window-props.c:554:39: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
  window->using_net_wm_visible_name = modified;
                                    ~ ^~~~~~~~
--
core/window-props.c:625:44: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
  window->using_net_wm_visible_icon_name = modified;
                                         ~ ^~~~~~~~
--
core/window-props.c:822:40: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
          window->mwm_has_close_func = toggle_value;
                                     ~ ^~~~~~~~~~~~
core/window-props.c:828:43: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
          window->mwm_has_minimize_func = toggle_value;
                                        ~ ^~~~~~~~~~~~
core/window-props.c:834:43: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
          window->mwm_has_maximize_func = toggle_value;
                                        ~ ^~~~~~~~~~~~
core/window-props.c:840:39: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
          window->mwm_has_move_func = toggle_value;
                                    ~ ^~~~~~~~~~~~
core/window-props.c:846:41: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
          window->mwm_has_resize_func = toggle_value;
                                      ~ ^~~~~~~~~~~~
--
core/window.c:435:23: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
  window->has_shape = has_shape;
                    ~ ^~~~~~~~~
--
ui/theme-parser.c:1066:35: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
        info->layout->has_title = has_title_val;
                                ~ ^~~~~~~~~~~~~
ui/theme-parser.c:1069:40: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
          info->layout->hide_buttons = hide_buttons_val;
                                     ~ ^~~~~~~~~~~~~~~~
```