### PR TITLE
build: fix meson build

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -211,7 +211,7 @@ xml_files = [
   ]
 
 foreach xml : xml_files
-  i18n.merge_file(xml,
+  i18n.merge_file(
     input: xml+ '.in',
     output: xml,
     po_dir: '../po',


### PR DESCRIPTION
```
src/meson.build:214:7: ERROR: Function does not take positional arguments.
```