### PR TITLE
window: do not disable fullscreen for dialogs

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -6729,7 +6729,8 @@ recalc_window_features (MetaWindow *window)
       window->has_resize_func = FALSE;
     }
 
-  if (window->type != META_WINDOW_NORMAL)
+  if (window->type != META_WINDOW_NORMAL &&
+      window->type != META_WINDOW_DIALOG)
     {
       window->has_minimize_func = FALSE;
       window->has_maximize_func = FALSE;


### PR DESCRIPTION
fixing dialog windows in wine.
see https://github.com/mate-desktop/marco/issues/735