### PR TITLE
Remove "(as superuser)" text

### DIFF
--- a/src/core/window-props.c
+++ b/src/core/window-props.c
@@ -486,7 +486,7 @@ set_title_text (MetaWindow  *window,
           if (window_owner==0)
             {
               /* Simple case-- don't bother to look it up.  It's root. */
-              *target = g_strdup_printf (_("%s (as superuser)"),
+              *target = g_strdup_printf (_("%s"),
                                          title);
             }
           else


### PR DESCRIPTION
Unfortunately using _NET_WM_PID isn't reliable on sandboxed applications, leading to a bug with Flatpak and Firejail as seen here:
https://github.com/mate-desktop/marco/issues/301.
This commit disables the functionality completely, fixing the sandbox issue.