### PR TITLE
Fix window focus stack

### DIFF
--- a/src/core/display.c
+++ b/src/core/display.c
@@ -2223,7 +2223,7 @@ static gboolean event_callback(XEvent* event, gpointer data)
                       meta_event_detail_to_string (event->xfocus.detail));
 
           if (event->type == FocusIn &&
-              event->xfocus.detail == NotifyDetailNone)
+              (event->xfocus.detail == NotifyDetailNone || event->xfocus.detail == NotifyPointerRoot))
             {
               meta_topic (META_DEBUG_FOCUS,
                           "Focus got set to None, probably due to "


### PR DESCRIPTION
This reverts https://github.com/mate-desktop/marco/commit/f96255beb (except for some unnecessary whitespace changes) to fix https://github.com/mate-desktop/marco/issues/647

I've been using this for a few days and had no issues at all. It works fine with multiple workspaces too.