### PR TITLE
Focus on newly opened window that was brought into foreground

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -4725,7 +4725,10 @@ meta_window_raise (MetaWindow  *window)
    * the child windows appropriately.
    */
   if (window->screen->stack == ancestor->screen->stack)
-    meta_stack_raise (window->screen->stack, ancestor);
+    {
+      meta_stack_raise (window->screen->stack, ancestor);
+      meta_window_focus (window, meta_display_get_current_time_roundtrip (window->display));
+    }
   else
     {
       meta_warning (


### PR DESCRIPTION
I don't know if this is the proper way to do this but it does fix #278 and also for example when opening sublime text from the terminal: `subl .` It sets the focus on the newly opened window in both cases.

I can reproduce this issue in `metacity` as well.