### PR TITLE
Always focus and bring into foreground newly opened windows

### DIFF
--- a/src/core/display.c
+++ b/src/core/display.c
@@ -2345,6 +2345,8 @@ static gboolean event_callback(XEvent* event, gpointer data)
         {
           window = meta_window_new (display, event->xmaprequest.window,
                                     FALSE);
+          meta_window_focus (window, meta_display_get_current_time_roundtrip (window->display));
+          meta_window_raise (window);
         }
       /* if frame was receiver it's some malicious send event or something */
       else if (!frame_was_receiver && window)


### PR DESCRIPTION
I've added another misguided PR recently for this: https://github.com/mate-desktop/marco/pull/743 but this one attempts fix #278 in a less stupid way. It brings to front newly opened windows, such as opening the containing folder after downloading a file in firefox, or running `subl .` from the terminal. Confusingly the latter ended up in front but not focused in some cases. This seems to help with both.

This issue is reproducible with metacity as well.

I've tested this with and without mate-netbook/maximus turned on, so it should work whether the new window opens maximised or not. Also with the initial window maximised and unmaximised as well. No issues when using multiple workspaces either. All this after logging out and in again, using the modified version of marco by default.

(I suspect this might not be the best way to fix this, I have no prior knowledge of X11, marco, or C, I've just been trying to sort out some more noticeable issues after upgrading from 18.04.)