### PR TITLE
Show correct window title when owned by superuser. Issue #749

### DIFF
--- a/src/core/window-props.c
+++ b/src/core/window-props.c
@@ -489,7 +489,7 @@ set_title_text (MetaWindow  *window,
 
   g_free (*target);
 
-  if (!title)
+  if (!title || g_utf8_strlen (title, 2) < 1)
     *target = g_strdup ("");
   else if (g_utf8_strlen (title, MAX_TITLE_LENGTH + 1) > MAX_TITLE_LENGTH)
     {


### PR DESCRIPTION
Basically, it adds a check to see if the title is empty, not just null.