### PR TITLE
Build with verbose mode support by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -65,9 +65,9 @@ MARCO_PC_MODULES="gtk+-3.0 >= $GTK_MIN_VERSION gio-2.0 >= $GIO_MIN_VERSION pango
 GLIB_GSETTINGS
 
 AC_ARG_ENABLE(verbose-mode,
-  AS_HELP_STRING([--enable-verbose-mode],
-                 [enable marco's ability to do verbose logging, for embedded/size-sensitive custom builds]),,
-  enable_verbose_mode=no)
+  AS_HELP_STRING([--disable-verbose-mode],
+                 [disable marco's ability to do verbose logging, for embedded/size-sensitive custom builds]),,
+  enable_verbose_mode=yes)
 
 if test x$enable_verbose_mode = xyes; then
     AC_DEFINE(WITH_VERBOSE_MODE,1,[Build with verbose mode support])

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,6 +1,6 @@
 option('verbose-mode',
-  type: 'boolean', value: false,
-  description: 'verbose logging, for embedded/size-sensitive custom builds')
+  type: 'boolean', value: true,
+  description: 'verbose logging, disable for embedded/size-sensitive custom builds')
 
 option('sm',
   type: 'boolean', value: true,


### PR DESCRIPTION
Verbose mode is not enabled when running Macro by default, but can be toggled dynamically as needed, e.g. for debugging a user issue, possibly even while it happens.

For some reason Meson was introduced with this option off by default (d86c29b0e518f765e7570573c76bc033fbd17f6d), and we later forwarded to Autoconf with no other rationale than getting in line with Meson (397e31879bf79861a1a21ec4e2a75017e243d34b).

I was surprised to see this disabled by default, and so was @muktupavels, see short discussion on https://github.com/mate-desktop/marco/pull/748#issuecomment-1404918784.

If this is deliberate, you can close this, and possibly explain why it is better to have this disabled by default?