### PR TITLE
fix switch-windows-all hotkey

### DIFF
--- a/src/core/keybindings.c
+++ b/src/core/keybindings.c
@@ -2106,8 +2106,6 @@ process_tab_grab (MetaDisplay *display,
                       target_window->desc);
           display->mouse_mode = FALSE;
           meta_window_activate (target_window, event->xkey.time);
-          if (!target_window->on_all_workspaces)
-            meta_workspace_activate (target_window->workspace, event->xkey.time);
 
           meta_topic (META_DEBUG_KEYBINDINGS,
                       "Ending grab early so we can focus the target window\n");
@@ -3068,8 +3066,6 @@ do_choose_window (MetaDisplay    *display,
                       initial_selection->desc);
           display->mouse_mode = FALSE;
           meta_window_activate (initial_selection, event->xkey.time);
-          if (!initial_selection->on_all_workspaces)
-            meta_workspace_activate (initial_selection->workspace, event->xkey.time);
         }
       else if (meta_display_begin_grab_op (display,
                                            screen,
@@ -3099,8 +3095,6 @@ do_choose_window (MetaDisplay    *display,
               meta_display_end_grab_op (display, event->xkey.time);
               display->mouse_mode = FALSE;
               meta_window_activate (initial_selection, event->xkey.time);
-              if (!initial_selection->on_all_workspaces)
-                meta_workspace_activate (initial_selection->workspace, event->xkey.time);
             }
           else
             {

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -3186,6 +3186,10 @@ window_activate (MetaWindow     *window,
          the source window.  */
       meta_window_change_workspace (window, workspace);
     }
+  else
+    {
+      meta_workspace_activate_with_focus(workspace, window, timestamp);
+    }
 
   if (window->shaded)
     meta_window_unshade (window, timestamp);
@@ -3210,11 +3214,14 @@ void
 meta_window_activate (MetaWindow     *window,
                       guint32         timestamp)
 {
+  MetaWorkspace *workspace;
+
+  workspace = window->on_all_workspaces ? NULL : window->workspace;
   /* We're not really a pager, but the behavior we want is the same as if
    * we were such.  If we change the pager behavior later, we could revisit
    * this and just add extra flags to window_activate.
    */
-  window_activate (window, timestamp, META_CLIENT_TYPE_PAGER, NULL);
+  window_activate (window, timestamp, META_CLIENT_TYPE_PAGER, workspace);
 }
 
 void


### PR DESCRIPTION
pass focus to window if it is on another workspace.

current behavior:
1. there are 2 windows on workspace A and window 2 is above window 1
2. switch to workspace B
3. use "switch-windows-all" keys to switch to window 1

actual result:
window 1 get "demands attention" mark.
focus passed to window 2.

with this changes:
focus passed to window 1. window 1 is raised above all normal windows.


there is still problem with stealing focus by "always on top" windows. it can fixed separately.