### PR TITLE
Fix losing title of windows with a 3 or 4 bytes first character

### DIFF
--- a/src/core/window-props.c
+++ b/src/core/window-props.c
@@ -489,7 +489,7 @@ set_title_text (MetaWindow  *window,
 
   g_free (*target);
 
-  if (!title || g_utf8_strlen (title, 2) < 1)
+  if (!title || !*title)
     *target = g_strdup ("");
   else if (g_utf8_strlen (title, MAX_TITLE_LENGTH + 1) > MAX_TITLE_LENGTH)
     {


### PR DESCRIPTION
Fixes #757.