### PR TITLE
Only enable compositing in UI code if it's actually available.

### DIFF
--- a/src/core/frame.c
+++ b/src/core/frame.c
@@ -152,6 +152,7 @@ meta_window_ensure_frame (MetaWindow *window)
 
   /* Shape mask */
   meta_ui_apply_frame_shape (frame->window->screen->ui,
+                             frame->window->display,
                              frame->xwindow,
                              frame->rect.width,
                              frame->rect.height,
@@ -325,6 +326,7 @@ update_shape (MetaFrame *frame)
   if (frame->need_reapply_frame_shape)
     {
       meta_ui_apply_frame_shape (frame->window->screen->ui,
+                                 frame->window->display,
                                  frame->xwindow,
                                  frame->rect.width,
                                  frame->rect.height,

--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -1407,6 +1407,7 @@ meta_screen_ensure_tab_popup (MetaScreen      *screen,
     }
 
   screen->tab_popup = meta_ui_tab_popup_new (entries,
+                                             screen,
                                              len,
                                              meta_prefs_get_alt_tab_max_columns(),
                                              meta_prefs_get_alt_tab_expand_to_fit_title(),
@@ -1486,6 +1487,7 @@ meta_screen_ensure_workspace_popup (MetaScreen *screen)
     }
 
   screen->tab_popup = meta_ui_tab_popup_new (entries,
+                                             screen,
                                              len,
                                              layout.cols,
                                              FALSE, /* expand_for_titles */

--- a/src/include/tabpopup.h
+++ b/src/include/tabpopup.h
@@ -28,6 +28,7 @@
 /* Don't include gtk.h or gdk.h here */
 #include "common.h"
 #include "boxes.h"
+#include "types.h"
 #include <X11/Xlib.h>
 #include <glib.h>
 #include <gdk-pixbuf/gdk-pixbuf.h>
@@ -58,6 +59,7 @@ struct _MetaTabEntry
 };
 
 MetaTabPopup*   meta_ui_tab_popup_new          (const MetaTabEntry *entries,
+                                                MetaScreen         *meta_screen,
                                                 int                 entry_count,
                                                 int                 width,
                                                 gboolean            expand_for_titles,

--- a/src/include/ui.h
+++ b/src/include/ui.h
@@ -26,6 +26,7 @@
 
 /* Don't include gtk.h or gdk.h here */
 #include "common.h"
+#include "types.h"
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <glib.h>
@@ -91,11 +92,12 @@ void meta_ui_map_frame   (MetaUI *ui,
 void meta_ui_unmap_frame (MetaUI *ui,
                           Window  xwindow);
 
-void meta_ui_apply_frame_shape  (MetaUI  *ui,
-                                 Window   xwindow,
-                                 int      new_window_width,
-                                 int      new_window_height,
-                                 gboolean window_has_shape);
+void meta_ui_apply_frame_shape  (MetaUI      *ui,
+                                 MetaDisplay *display,
+                                 Window       xwindow,
+                                 int          new_window_width,
+                                 int          new_window_height,
+                                 gboolean     window_has_shape);
 
 cairo_region_t *meta_ui_get_frame_bounds (MetaUI *ui,
                                           Window  xwindow,

--- a/src/ui/frames.c
+++ b/src/ui/frames.c
@@ -37,6 +37,7 @@
 #include "theme.h"
 #include "prefs.h"
 #include "ui.h"
+#include "display.h"
 
 #ifdef HAVE_SHAPE
 #include <X11/extensions/shape.h>
@@ -1063,11 +1064,12 @@ get_frame_region (int window_width,
 #endif /* HAVE_SHAPE */
 
 void
-meta_frames_apply_shapes (MetaFrames *frames,
-                          Window      xwindow,
-                          int         new_window_width,
-                          int         new_window_height,
-                          gboolean    window_has_shape)
+meta_frames_apply_shapes (MetaFrames  *frames,
+                          MetaDisplay *meta_display,
+                          Window       xwindow,
+                          int          new_window_width,
+                          int          new_window_height,
+                          gboolean     window_has_shape)
 {
 #ifdef HAVE_SHAPE
   /* Apply shapes as if window had new_window_width, new_window_height */
@@ -1095,7 +1097,9 @@ meta_frames_apply_shapes (MetaFrames *frames,
 
   meta_frames_calc_geometry (frames, frame, &fgeom);
 
-  compositing_manager = meta_prefs_get_compositing_manager ();
+  compositing_manager = meta_prefs_get_compositing_manager () &&
+                        meta_display &&
+                        !!(meta_display_get_compositor (meta_display));
 
   if (!window_has_shape && compositing_manager)
     return;

--- a/src/ui/frames.h
+++ b/src/ui/frames.h
@@ -28,6 +28,7 @@
 #include <gdk/gdkx.h>
 #include "common.h"
 #include "theme.h"
+#include "types.h"
 
 typedef enum
 {
@@ -135,11 +136,12 @@ void meta_frames_get_borders (MetaFrames       *frames,
                               Window            xwindow,
                               MetaFrameBorders *borders);
 
-void meta_frames_apply_shapes (MetaFrames *frames,
-                               Window      xwindow,
-                               int         new_window_width,
-                               int         new_window_height,
-                               gboolean    window_has_shape);
+void meta_frames_apply_shapes (MetaFrames  *frames,
+                               MetaDisplay *meta_display,
+                               Window       xwindow,
+                               int          new_window_width,
+                               int          new_window_height,
+                               gboolean     window_has_shape);
 cairo_region_t *meta_frames_get_frame_bounds (MetaFrames *frames,
                                               Window      xwindow,
                                               int         window_width,

--- a/src/ui/tabpopup.c
+++ b/src/ui/tabpopup.c
@@ -30,6 +30,7 @@
 #include "tabpopup.h"
 #include "theme.h"
 #include "prefs.h"
+#include "screen.h"
 /* FIXME these two includes are 100% broken... */
 #include "../core/workspace.h"
 #include "../core/frame-private.h"
@@ -235,6 +236,7 @@ tab_entry_new (const MetaTabEntry *entry,
 
 MetaTabPopup*
 meta_ui_tab_popup_new (const MetaTabEntry *entries,
+                       MetaScreen         *meta_screen,
                        int                 entry_count,
                        int                 width,
                        gboolean            expand_for_titles,
@@ -285,7 +287,8 @@ meta_ui_tab_popup_new (const MetaTabEntry *entries,
   gtk_window_set_resizable (GTK_WINDOW (popup->window), TRUE);
 
   /* This style should only be set for composited mode. */
-  if (meta_prefs_get_compositing_manager ())
+  if (meta_prefs_get_compositing_manager () && meta_screen &&
+      !!(meta_display_get_compositor (meta_screen_get_display (meta_screen))))
     {
       frame_shadow = GTK_SHADOW_NONE;
       gtk_style_context_add_class (gtk_widget_get_style_context (GTK_WIDGET (popup->window)),
@@ -1117,13 +1120,15 @@ meta_select_workspace_draw (GtkWidget *widget,
     {
       GtkStyleContext *context;
       GdkRGBA color;
+      MetaScreen *screen = META_SELECT_WORKSPACE (widget)->workspace->screen;
 
       context = gtk_widget_get_style_context (widget);
 
       gtk_style_context_set_state (context,
                                    gtk_widget_get_state_flags (widget));
 
-      if (meta_prefs_get_compositing_manager ())
+      if (meta_prefs_get_compositing_manager () && screen &&
+          !!(meta_display_get_compositor (meta_screen_get_display (screen))))
         {
           /* compositing manager creates a dark background: show the selection in a light color */
           meta_gtk_style_get_light_color (context, GTK_STATE_FLAG_SELECTED, &color);

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -458,13 +458,14 @@ meta_ui_repaint_frame (MetaUI *ui,
 }
 
 void
-meta_ui_apply_frame_shape  (MetaUI  *ui,
-                            Window   xwindow,
-                            int      new_window_width,
-                            int      new_window_height,
-                            gboolean window_has_shape)
+meta_ui_apply_frame_shape  (MetaUI      *ui,
+                            MetaDisplay *display,
+                            Window       xwindow,
+                            int          new_window_width,
+                            int          new_window_height,
+                            gboolean     window_has_shape)
 {
-  meta_frames_apply_shapes (ui->frames, xwindow,
+  meta_frames_apply_shapes (ui->frames, display, xwindow,
                             new_window_width, new_window_height,
                             window_has_shape);
 }


### PR DESCRIPTION
Thus far, the UI code enabled internal compositing code if compositing has been requested (i.e., the `compositing-manager` preference is turned on).

Unfortunately, requesting compositing doesn't mean that it needs to be available. Meta core code handles this gracefully by checking if X server extensions related to compositing are available and only enabling the internal compositor if everything looks alright, but this is not exposed to UI code directly.

If UI code enables compositing parts merely based upon the preference and doesn't check if compositing is actually available, we end up with black borders around windows and other weird effects.

This can be reproduced via X2Go/NX or testing with nested X servers such as Xephyr and disabling the XComposite extension.

This PR introduces checks for the availability of compositing and fixes this bug.

However, I'm not sure if the way I implemented this is "correct". I've noticed that UI code generally does not have access to core code and mostly only uses GTK/GDK and Xlib interfaces. To implement this, I had to pass down `MetaScreen` or `MetaDisplay` objects into the UI code, which might be frowned upon.

An alternative would have been to create a global property (hidden preference?) indicating whether compositing is available or not, manage this in core code and check it in UI code, but this would have been more complicated/intrusive.  