### PR TITLE
workspace: ignore not_this_one if not in current workspace

### DIFF
--- a/src/core/workspace.c
+++ b/src/core/workspace.c
@@ -1049,8 +1049,9 @@ focus_ancestor_or_top_window (MetaWorkspace *workspace,
     meta_topic (META_DEBUG_FOCUS,
                 "Focusing MRU window\n");
 
-  /* First, check to see if we need to focus an ancestor of a window */
-  if (not_this_one)
+  /* First, check to see if we need to focus an ancestor of a window
+   * that exists in this workspace */
+  if (not_this_one && g_list_find (workspace->mru_list, not_this_one) != NULL)
     {
       MetaWindow *ancestor;
       ancestor = NULL;


### PR DESCRIPTION
When the active workspace is changed, marco figures out which window should get focus by calling `focus_ancestor_or_top_window`. In some cases that call might include a window that should not get focus as `not_this_one`.

When `not_this_one` refers to a window, the function will check to see if it has a parent, and if it does, it will ignore the new workspace's `mru_list` and will focus that parent window. However, it doesn't check to see if the parent window is actually on the new workspace. If the parent isn't on the new workspace, focusing it will drag it over, including the transient window that was supposed to be ignored. This isn't the result a user would likely expect, and is made more confusing by the parent window being minimized, stuck that way until the user switches to another workspace and back.

This change makes `focus_ancestor_or_top_window` ignore the `not_this_one` window if it isn't on the new workspace's `mru_list`. Instead it will just search the new workspace's `mru_list` for a window to focus.