### PR TITLE
themes/eOS/meson.build: Install missing PNGs

### DIFF
--- a/src/themes/eOS/meson.build
+++ b/src/themes/eOS/meson.build
@@ -18,6 +18,8 @@ install_data(
   'trough_middle_unfocused.png',
   'trough_right.png',
   'trough_right_unfocused.png',
+  'trough_single.png',
+  'trough_single_unfocused.png',
   'unmaximize.png',
   'unmaximize_unfocused_over.png',
   'unmaximize_unfocused.png',


### PR DESCRIPTION
Follow-up of 4a2a5dc092814bfe ("eOS theme: Add single button backgrounds")

Without this fix these PNGs are installed when using autotools but not using meson.