### PR TITLE
Add css class for AltTab popup

### DIFF
--- a/src/ui/tabpopup.c
+++ b/src/ui/tabpopup.c
@@ -403,6 +403,7 @@ meta_ui_tab_popup_new (const MetaTabEntry *entries,
   gtk_container_set_border_width (GTK_CONTAINER (grid), 16);
   gtk_container_add (GTK_CONTAINER (popup->window), frame);
   gtk_container_add (GTK_CONTAINER (frame), vbox);
+  gtk_style_context_add_class (gtk_widget_get_style_context (frame), "mate-tabwin");
 
   gtk_box_pack_start (GTK_BOX (vbox), grid, TRUE, TRUE, 0);
 


### PR DESCRIPTION
This allow to theme AltTab / TabWin popup, see #788.

I found this CSS nodes:
```css
frame.mate-tabwin { }
frame.mate-tabwin > border { }
frame.mate-tabwin box { }
frame.mate-tabwin box grid { }
frame.mate-tabwin box label { }

.osd { } /* when compositor is enabled */
```

Not tested, maybe another class name could be better.