### PR TITLE
Add class for AltTab

### DIFF
--- a/src/ui/tabpopup.c
+++ b/src/ui/tabpopup.c
@@ -403,6 +403,7 @@ meta_ui_tab_popup_new (const MetaTabEntry *entries,
   gtk_container_set_border_width (GTK_CONTAINER (grid), 16);
   gtk_container_add (GTK_CONTAINER (popup->window), frame);
   gtk_container_add (GTK_CONTAINER (frame), vbox);
+  gtk_style_context_add_class (gtk_widget_get_style_context (frame), "mate-tabwin");
 
   gtk_box_pack_start (GTK_BOX (vbox), grid, TRUE, TRUE, 0);
 


### PR DESCRIPTION
Help #788 and Reopen #789
Tested by rebuilding MATE 1.26 Debian source package.

This allow to theme AltTab / TabWin popup, I found these CSS nodes:
```css
frame.mate-tabwin { border:1px solid orange; }
frame.mate-tabwin > border { border:1px solid yellow; }
frame.mate-tabwin box { }
frame.mate-tabwin box grid { }
frame.mate-tabwin box label { }

/* with .osd when compositor is enabled */
```

![image](https://github.com/user-attachments/assets/30763f3a-6512-4777-9a4c-d4db6a27f908)

