### PR TITLE
theme: Fix left-side Fitt's Law

### DIFF
--- a/src/ui/theme.c
+++ b/src/ui/theme.c
@@ -1003,17 +1003,12 @@ meta_frame_layout_calc_geometry (const MetaFrameLayout  *layout,
           rect->clickable.width = button_width;
           rect->clickable.height = button_height;
 
-          if (i == n_right - 1)
+          /* For the last right button on maximized/right-tiled windows, extend clickable area to the top-right edge (Fitts's law)*/
+          if (i == n_right - 1 && (flags & META_FRAME_MAXIMIZED || flags & META_FRAME_TILED_RIGHT))
             {
-              /* Extend clickable area to the right edge */
+              rect->clickable.y = 0;
               rect->clickable.width += layout->right_titlebar_edge + layout->right_width + layout->button_border.right;
-
-              /* For maximized and right-tiled windows, extend clickable area to the top edge (Fitts's law)*/
-              if (flags & META_FRAME_MAXIMIZED || flags & META_FRAME_TILED_RIGHT)
-                {
-                  rect->clickable.y = 0;
-                  rect->clickable.height = button_y + button_height;
-                }
+              rect->clickable.height = button_y + button_height;
             }
 
         }
@@ -1054,12 +1049,12 @@ meta_frame_layout_calc_geometry (const MetaFrameLayout  *layout,
           rect->clickable.width = button_width;
           rect->clickable.height = button_height;
 
-          /* For the first left button on maximized/left-tiled windows, extend to top-left corner (Fitts's law) */
+          /* For the first left button on maximized/left-tiled windows, extend clickable area to top-left corner (Fitts's law) */
           if (i == 0 && (flags & META_FRAME_MAXIMIZED || flags & META_FRAME_TILED_LEFT))
             {
               rect->clickable.x = 0;
               rect->clickable.y = 0;
-              rect->clickable.width = rect->visible.x + button_width;
+              rect->clickable.width += layout->left_titlebar_edge + layout->left_width + layout->button_border.left;
               rect->clickable.height = button_y + button_height;
             }
         }


### PR DESCRIPTION
When calculating the clickable area on the left-most button of a maximized window, we need to take into account the layout components, not just the button size.

Fixes mate-desktop/mate-themes#318