### PR TITLE
ci: Trigger full release on new tag

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -98,3 +98,15 @@ jobs:
 
       - name: Build the source code
         run: .github/workflows/builds.sh ${{ matrix.build-system }}
+
+      - name: IRC notification on failure
+        if: failure() && (github.event_name == 'push' && github.ref == 'refs/heads/master' || github.event_name == 'pull_request')
+        uses: rectalogic/notify-irc@v2
+        with:
+          channel: "#mate-dev"
+          server: "irc.libera.chat"
+          nickname: "github-marco"
+          message: |
+            [marco] ${{ github.actor }}: Build failed for ${{ github.event_name }}
+            [${{ github.ref_name }}] ${{ github.sha }} - ${{ github.event.head_commit.message || github.event.pull_request.title }}
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,14 @@ jobs:
         run: sudo .github/workflows/mate-desktop.sh ${{env.MATE_DESKTOP_VERSION}} ${{ env.CACHE_PATH }}
 
       - name: Build the source code
-        run: .github/workflows/builds.sh meson
+        run: .github/workflows/builds.sh autotools
+
+      - name: Generate release tarball and checksums
+        run: |
+          make distcheck
+          TARBALL=$(ls marco-*.tar.xz | head -1)
+          sha256sum "$TARBALL" > "$TARBALL.sha256"
+          md5sum "$TARBALL" > "$TARBALL.md5"
 
       - name: Install GH CLI
         uses: dev-hanz-ops/install-gh-cli-action@v0.2.1
@@ -34,6 +41,12 @@ jobs:
 
       - name: Create github release
         run: |
-          gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --generate-notes _build/meson-dist/*
+          gh release create ${{ github.ref_name }} --title "Marco ${{ github.ref_name }}" --generate-notes marco-*.tar.xz marco-*.tar.xz.sha256 marco-*.tar.xz.md5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Notify MATE release server
+        run: |
+          curl -X POST -H "Content-Type: application/json" \
+            -d "{\"tag\": \"${{ github.ref_name }}\", \"repository\": \"${{ github.repository }}\", \"release_url\": \"https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}\"}" \
+            https://release.mate-desktop.org/release || echo "::warning::Release notification failed"


### PR DESCRIPTION
Whenever there's a new v* tag, GitHub will use distcheck to generate tarballs, create a proper release, and trigger the mate-desktop.org webhook.