### PR TITLE
Ci: use autotools for release for 1.28

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         run: sudo .github/workflows/mate-desktop.sh ${{env.MATE_DESKTOP_VERSION}} ${{ env.CACHE_PATH }}
 
       - name: Build the source code
-        run: .github/workflows/builds.sh meson
+        run: .github/workflows/builds.sh autotools
 
       - name: Install GH CLI
         uses: dev-hanz-ops/install-gh-cli-action@v0.2.1
@@ -34,6 +34,6 @@ jobs:
 
       - name: Create github release
         run: |
-          gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --generate-notes _build/meson-dist/*
+          gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --generate-notes marco*.tar.xz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Not sure how to test this, but it is the same way like pluma Ci handle this.
Note, this needs to push to 1.28 branch.