### PR TITLE
window: Exclude invisible borders from wireframe rectangle

### DIFF
--- a/src/core/screen.c
+++ b/src/core/screen.c
@@ -529,7 +529,7 @@ meta_screen_new (MetaDisplay *display,
     gc_values.line_width = META_WIREFRAME_XOR_LINE_WIDTH;
     value_mask |= GCLineWidth;
 
-    font_info = XLoadQueryFont (screen->display->xdisplay, "fixed");
+    font_info = XLoadQueryFont (screen->display->xdisplay, "10x20");
 
     if (font_info != NULL)
       {
@@ -538,7 +538,7 @@ meta_screen_new (MetaDisplay *display,
         XFreeFontInfo (NULL, font_info, 1);
       }
     else
-      meta_warning ("xserver doesn't have 'fixed' font.\n");
+      meta_warning ("xserver doesn't have '10x20' font.\n");
 
     screen->root_xor_gc = XCreateGC (screen->display->xdisplay,
                                      screen->xroot,

--- a/src/core/window.c
+++ b/src/core/window.c
@@ -4238,14 +4238,17 @@ meta_window_get_xor_rect (MetaWindow          *window,
 {
   if (window->frame)
     {
-      xor_rect->x = grab_wireframe_rect->x - window->frame->child_x;
-      xor_rect->y = grab_wireframe_rect->y - window->frame->child_y;
-      xor_rect->width = grab_wireframe_rect->width + window->frame->child_x + window->frame->right_width;
+      MetaFrameBorders borders;
+      meta_frame_calc_borders (window->frame, &borders);
+
+      xor_rect->x = grab_wireframe_rect->x - window->frame->child_x + borders.invisible.left;
+      xor_rect->y = grab_wireframe_rect->y - window->frame->child_y + borders.invisible.top;
+      xor_rect->width = grab_wireframe_rect->width + window->frame->child_x + window->frame->right_width - borders.invisible.left - borders.invisible.right;
 
       if (window->shaded)
-        xor_rect->height = window->frame->child_y;
+        xor_rect->height = window->frame->child_y - borders.invisible.top;
       else
-        xor_rect->height = grab_wireframe_rect->height + window->frame->child_y + window->frame->bottom_height;
+        xor_rect->height = grab_wireframe_rect->height + window->frame->child_y + window->frame->bottom_height - borders.invisible.top - borders.invisible.bottom;
     }
   else
     *xor_rect = *grab_wireframe_rect;


### PR DESCRIPTION
The wireframe drawn in reduced-resources mode included invisible resize borders, making it larger than the visible window. This removes the invisible borders from the xor rect calculation.

Fixes #532