### PR TITLE
window: focus modal dialogs whose ancestor is focused

### DIFF
--- a/src/core/window.c
+++ b/src/core/window.c
@@ -2158,6 +2158,14 @@ meta_window_show (MetaWindow *window)
           if (!window->placed)
             window->denied_focus_and_not_transient = TRUE;
         }
+      else if (window->type == META_WINDOW_MODAL_DIALOG)
+        {
+          /* Keep the non-modal transient behavior from 6ea23df for GTK
+           * popups and VLC controls, but focus modal dialogs that block
+           * the focused ancestor.
+           */
+          takes_focus_on_map = TRUE;
+        }
     }
 
   if (!window->placed)


### PR DESCRIPTION
Fixes #784.

Commit 6ea23df ("window: do not unfocus on new window") imported the Metacity bf17c79 / Mutter 998d921d behavior for GNOME Bugzilla #773210: when a new transient maps without taking focus, keep focus on the parent so GTK popup and completion windows and VLC fullscreen controls do not steal keyboard focus.

That blanket change also affected modal dialogs whose parent already has focus. Electron and GTK file chooser dialogs can reach meta_window_show() with takes_focus_on_map false because their _NET_WM_USER_TIME is missing or stale. Since 6ea23df, such dialogs are mapped above the parent but keyboard focus stays on the parent, so typing goes to the wrong window.

Keep the bf17c79-equivalent behavior for non-modal transients, but when the new window is a META_WINDOW_MODAL_DIALOG whose ancestor is the current focus window, force takes_focus_on_map so the blocking dialog receives keyboard focus immediately.