### PR TITLE
Change default icon from preferences-desktop-theme to application-x-executable

### DIFF
--- a/src/include/common.h
+++ b/src/include/common.h
@@ -341,7 +341,7 @@ void meta_frame_borders_clear (MetaFrameBorders *self);
 #define META_MINI_ICON_WIDTH 16
 #define META_MINI_ICON_HEIGHT 16
 
-#define META_DEFAULT_ICON_NAME "preferences-desktop-theme"
+#define META_DEFAULT_ICON_NAME "application-x-executable"
 
 #define META_PRIORITY_PREFS_NOTIFY   (G_PRIORITY_DEFAULT_IDLE + 10)
 #define META_PRIORITY_WORK_AREA_HINT (G_PRIORITY_DEFAULT_IDLE + 15)


### PR DESCRIPTION
The preferences-desktop-theme icon is really annoying and confusing as the default icon for windows which do not have an icon. I suggest using application-x-executable as a more visually consistent alternative.